### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,3 @@ Any use of third-party trademarks or logos are subject to those third-party's po
 
 - [agents Repository](https://github.com/Microsoft/Agents)
 - agents-for-net Repository: **You are here.**
-- [agents-for-js Repository](https://github.com/Microsoft/Agents-for-js)
-- [agents-for-python Repository]( https://github.com/Microsoft/Agents-for-python)
-- [Official Agents Documentation](https://aka.ms/AgentsFramework)
-- [.NET Documentation](https://aka.ms/Agents-net-docs)
-- [JavaScript Documentation](https://aka.ms/agents-js-docs)
-- [Python Documentation](https://aka.ms/agents-python-docs)


### PR DESCRIPTION
During a review of the "## Useful Links" section of our documentation, I noticed that some links appear to be non-functional. To maintain the usefulness of the docs, could we please verify and remove any links that are not working? Here is the list of current links for easy reference:

- [agents-for-js Repository](https://github.com/Microsoft/Agents-for-js)
- [agents-for-python Repository]( https://github.com/Microsoft/Agents-for-python)
- [Official Agents Documentation](https://aka.ms/AgentsFramework)
- [.NET Documentation](https://aka.ms/Agents-net-docs)
- [JavaScript Documentation](https://aka.ms/agents-js-docs)
- [Python Documentation](https://aka.ms/agents-python-docs)

Perhaps these links are still being updated, but currently, they seem to lead to confusion and frustration