### PR TITLE
POC: unified OAuth flow via ActivityHandler

### DIFF
--- a/src/libraries/Hosting/AspNetCore/CloudAdapter.cs
+++ b/src/libraries/Hosting/AspNetCore/CloudAdapter.cs
@@ -13,6 +13,7 @@ using Microsoft.Agents.Core.Models;
 using Microsoft.Agents.BotBuilder;
 using Microsoft.Agents.Connector.Types;
 using System.Text;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Microsoft.Agents.Hosting.AspNetCore
 {
@@ -37,6 +38,7 @@ namespace Microsoft.Agents.Hosting.AspNetCore
     {
         private readonly IActivityTaskQueue _activityTaskQueue;
         private readonly bool _async;
+        private readonly ILogger _logger;
 
         public CloudAdapter(
             IChannelServiceClientFactory channelServiceClientFactory,
@@ -46,6 +48,7 @@ namespace Microsoft.Agents.Hosting.AspNetCore
         {
             _activityTaskQueue = activityTaskQueue ?? throw new ArgumentNullException(nameof(activityTaskQueue));
             _async = async;
+            _logger = logger ?? NullLogger.Instance;
 
             OnTurnError = async (turnContext, exception) =>
             {
@@ -58,7 +61,7 @@ namespace Microsoft.Agents.Hosting.AspNetCore
                     sbError.Append(errorResponse.Body.ToString());
                 }
                 string resolvedErrorMessage = sbError.ToString();
-                logger.LogError(exception, "Exception caught : {ExceptionMessage}", resolvedErrorMessage);
+                _logger.LogError(exception, "Exception caught : {ExceptionMessage}", resolvedErrorMessage);
 
                 await turnContext.SendActivityAsync(MessageFactory.Text(resolvedErrorMessage));
 

--- a/src/samples/AuthenticationBot/ActivityHandlerWithOAuth.cs
+++ b/src/samples/AuthenticationBot/ActivityHandlerWithOAuth.cs
@@ -1,0 +1,316 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using System.Threading;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using Microsoft.Agents.BotBuilder;
+using Microsoft.Agents.Storage;
+using Microsoft.Agents.Core.Models;
+using Microsoft.Agents.Core.Interfaces;
+using Microsoft.Agents.Core.Serialization;
+using Microsoft.Agents.Connector;
+
+namespace AuthenticationBot
+{
+    public class ActivityHandlerWithOAuth : ActivityHandler
+    {
+        private readonly OAuthFlow _flow;
+        private FlowState _flowState;
+        private readonly IStorage _storage;
+        private OAuthSettings _settings;
+
+        public class OAuthSettings
+        {
+            public string ConnectionName { get; set; }
+            public string Title { get; set; } = "Sign In";
+            public string Text { get; set; } = "Please sign in and send 6-digit code";
+            public int Timeout { get; set; } = 60000;
+            public bool? ShowSignInLink { get; set; }
+            public string TimeoutMessage { get; set; }
+            public bool AutoRetry { get; set; } = true;
+
+            public bool IsOAuthEnabled => !string.IsNullOrWhiteSpace(ConnectionName);
+        }
+
+        public ActivityHandlerWithOAuth(
+            IStorage storage,
+            OAuthSettings oAuthSettings = null)
+        {
+            _settings = oAuthSettings ?? new OAuthSettings();
+
+            if (_settings.IsOAuthEnabled)
+            {
+                _storage = storage ?? throw new ArgumentNullException(nameof(storage));
+                _flow = new OAuthFlow(_settings.Title, _settings.Text, _settings.ConnectionName, _settings.Timeout, _settings.ShowSignInLink);
+            }
+        }
+
+        protected async Task<TokenResponse> SigninUserAsync(ITurnContext turnContext, CancellationToken cancellationToken)
+        {
+            if (!_settings.IsOAuthEnabled)
+            {
+                throw new InvalidOperationException("SigninUserAsync requires a connection name");
+            }
+
+            TokenResponse tokenResponse;
+
+            if (!_flowState.FlowStarted)
+            {
+                tokenResponse = await _flow.BeginFlowAsync(turnContext, null, cancellationToken);
+
+                // If a TokenResponse is returned, there was a cached token already.  Otherwise, start the process of getting a new token.
+                if (tokenResponse == null)
+                {
+                    var expires = DateTime.UtcNow.AddMilliseconds(_flow.Timeout ?? TimeSpan.FromMinutes(15).TotalMilliseconds);
+
+                    _flowState.FlowStarted = true;
+                    _flowState.FlowExpires = expires;
+                }
+            }
+            else
+            {
+                tokenResponse = await OnContinueFlow(turnContext, cancellationToken).ConfigureAwait(false);
+            }
+
+            return tokenResponse;
+        }
+
+        protected async Task SignOutUserAsync(ITurnContext turnContext, CancellationToken cancellationToken)
+        {
+            if (!_settings.IsOAuthEnabled)
+            {
+                throw new InvalidOperationException("SignOutUserAsync requires a connection name");
+            }
+
+            await _flow.SignOutUserAsync(turnContext, cancellationToken);
+        }
+
+        public override async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default)
+        {
+            if (!_settings.IsOAuthEnabled)
+            {
+                await base.OnTurnAsync(turnContext, cancellationToken);
+                return;
+            }
+
+            if (ShouldExchange(turnContext))
+            {
+                // If the TokenExchange is NOT successful, the response will have already been sent by ExchangedTokenAsync
+                if (!await ExchangedTokenAsync(turnContext, cancellationToken).ConfigureAwait(false))
+                {
+                    // do not process this activity further.
+                    return;
+                }
+
+                // Only one token exchange should proceed from here. Deduplication is performed second because in the case
+                // of failure due to consent required, every caller needs to receive the 
+                if (!await DeduplicatedTokenExchangeIdAsync(turnContext, cancellationToken).ConfigureAwait(false))
+                {
+                    // If the token is not exchangeable, do not process this activity further.
+                    return;
+                }
+            }
+
+            // Load OAuth flow state
+            var stateKey = GetOAuthStorageKey(turnContext);
+            var items = await _storage.ReadAsync([stateKey], cancellationToken);
+            _flowState = items.TryGetValue(stateKey, out object value) ? (FlowState)value : new FlowState();
+
+            await base.OnTurnAsync(turnContext, cancellationToken);
+
+            // Store any changes to the OAuthFlow state after the turn is complete.
+            items[stateKey] = _flowState;
+            await _storage.WriteAsync(items, cancellationToken);
+        }
+
+        protected override Task OnTokenResponseEventAsync(ITurnContext<IEventActivity> turnContext, CancellationToken cancellationToken)
+        {
+            // TODO: what is this supposed to do?
+            return Task.CompletedTask;
+        }
+
+        protected override async Task OnSignInInvokeAsync(ITurnContext<IInvokeActivity> turnContext, CancellationToken cancellationToken)
+        {
+            if (!_settings.IsOAuthEnabled)
+            {
+                await base.OnSignInInvokeAsync(turnContext, cancellationToken);
+                return;
+            }
+
+            // Teams will send the bot an "Invoke" Activity that contains a value that will be exchanged for a token.
+            await OnContinueFlow(turnContext, cancellationToken);
+        }
+
+        private async Task<TokenResponse> OnContinueFlow(ITurnContext turnContext, CancellationToken cancellationToken)
+        {
+            TokenResponse tokenResponse = null;
+
+            try
+            {
+                tokenResponse = await _flow.ContinueFlowAsync(turnContext, _flowState.FlowExpires, cancellationToken);
+            }
+            catch (TimeoutException)
+            {
+                await turnContext.SendActivityAsync(MessageFactory.Text(_settings.TimeoutMessage), cancellationToken);
+                if (_settings.AutoRetry)
+                {
+                    return await _flow.BeginFlowAsync(turnContext, null, cancellationToken);
+                }
+            }
+
+            _flowState.FlowStarted = false;
+
+            return tokenResponse;
+        }
+
+        private static bool ShouldExchange(ITurnContext turnContext)
+        {
+            // Teams
+            if (string.Equals(Channels.Msteams, turnContext.Activity.ChannelId, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(SignInConstants.TokenExchangeOperationName, turnContext.Activity.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            // SharePoint
+            if (string.Equals(Channels.M365, turnContext.Activity.ChannelId, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(SignInConstants.SharePointTokenExchange, turnContext.Activity.Name, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private async Task<bool> DeduplicatedTokenExchangeIdAsync(ITurnContext turnContext, CancellationToken cancellationToken)
+        {
+            // Create a StoreItem with Etag of the unique 'signin/tokenExchange' request
+            var storeItem = new TokenStoreItem
+            {
+                ETag = ProtocolJsonSerializer.ToJsonElements(turnContext.Activity.Value)["id"].ToString(),
+            };
+
+            var storeItems = new Dictionary<string, object> { { TokenStoreItem.GetStorageKey(turnContext), storeItem } };
+            try
+            {
+                // Writing the IStoreItem with ETag of unique id will succeed only once
+                await _storage.WriteAsync(storeItems, cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+
+                // Memory storage throws a generic exception with a Message of 'Etag conflict. [other error info]'
+                // CosmosDbPartitionedStorage throws: ex.Message.Contains("pre-condition is not met")
+                when (ex.Message.StartsWith("Etag conflict", StringComparison.OrdinalIgnoreCase) || ex.Message.Contains("pre-condition is not met"))
+            {
+                // Do NOT proceed processing this message, some other thread or machine already has processed it.
+
+                // Send 200 invoke response.
+                await SendInvokeResponseAsync(turnContext, cancellationToken: cancellationToken).ConfigureAwait(false);
+                return false;
+            }
+
+            return true;
+        }
+
+        private async Task SendInvokeResponseAsync(ITurnContext turnContext, object body = null, HttpStatusCode httpStatusCode = HttpStatusCode.OK, CancellationToken cancellationToken = default)
+        {
+            await turnContext.SendActivityAsync(
+                new Activity
+                {
+                    Type = ActivityTypes.InvokeResponse,
+                    Value = new InvokeResponse
+                    {
+                        Status = (int)httpStatusCode,
+                        Body = body,
+                    },
+                }, cancellationToken).ConfigureAwait(false);
+        }
+
+        private async Task<bool> ExchangedTokenAsync(ITurnContext turnContext, CancellationToken cancellationToken)
+        {
+            TokenResponse tokenExchangeResponse = null;
+            var tokenExchangeRequest = ProtocolJsonSerializer.ToObject<TokenExchangeInvokeRequest>(turnContext.Activity.Value);
+
+            try
+            {
+                var userTokenClient = turnContext.TurnState.Get<IUserTokenClient>();
+                if (userTokenClient != null)
+                {
+                    tokenExchangeResponse = await userTokenClient.ExchangeTokenAsync(
+                        turnContext.Activity.From.Id,
+                        _settings.ConnectionName,
+                        turnContext.Activity.ChannelId,
+                        new TokenExchangeRequest { Token = tokenExchangeRequest.Token },
+                        cancellationToken).ConfigureAwait(false);
+                }
+                else
+                {
+                    throw new NotSupportedException("Token Exchange is not supported by the current adapter.");
+                }
+            }
+#pragma warning disable CA1031 // Do not catch general exception types (ignoring, see comment below)
+            catch
+#pragma warning restore CA1031 // Do not catch general exception types
+            {
+                // Ignore Exceptions
+                // If token exchange failed for any reason, tokenExchangeResponse above stays null,
+                // and hence we send back a failure invoke response to the caller.
+            }
+
+            if (string.IsNullOrEmpty(tokenExchangeResponse?.Token))
+            {
+                // The token could not be exchanged (which could be due to a consent requirement)
+                // Notify the sender that PreconditionFailed so they can respond accordingly.
+
+                var invokeResponse = new TokenExchangeInvokeResponse
+                {
+                    Id = tokenExchangeRequest.Id,
+                    ConnectionName = _settings.ConnectionName,
+                    FailureDetail = "The bot is unable to exchange token. Proceed with regular login.",
+                };
+
+                await SendInvokeResponseAsync(turnContext, invokeResponse, HttpStatusCode.PreconditionFailed, cancellationToken).ConfigureAwait(false);
+
+                return false;
+            }
+
+            return true;
+        }
+
+        private static string GetOAuthStorageKey(ITurnContext turnContext)
+        {
+            var channelId = turnContext.Activity.ChannelId ?? throw new InvalidOperationException("invalid activity-missing channelId");
+            var conversationId = turnContext.Activity.Conversation?.Id ?? throw new InvalidOperationException("invalid activity-missing Conversation.Id");
+            return $"{channelId}/conversations/{conversationId}/flowState";
+        }
+
+        private class TokenStoreItem : IStoreItem
+        {
+            public string ETag { get; set; }
+
+            public static string GetStorageKey(ITurnContext turnContext)
+            {
+                var activity = turnContext.Activity;
+                var channelId = activity.ChannelId ?? throw new InvalidOperationException("invalid activity-missing channelId");
+                var conversationId = activity.Conversation?.Id ?? throw new InvalidOperationException("invalid activity-missing Conversation.Id");
+
+                var value = activity.Value.ToJsonElements();
+                if (value == null || !value.ContainsKey("id"))
+                {
+                    throw new InvalidOperationException("Invalid signin/tokenExchange. Missing activity.Value.Id.");
+                }
+
+                return $"{channelId}/{conversationId}/{value["id"]}";
+            }
+        }
+    }
+
+    class FlowState
+    {
+        public bool FlowStarted = false;
+        public DateTime FlowExpires = DateTime.MinValue;
+    }
+}

--- a/src/samples/AuthenticationBot/AuthBot.cs
+++ b/src/samples/AuthenticationBot/AuthBot.cs
@@ -5,46 +5,15 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Agents.BotBuilder;
 using Microsoft.Agents.Core.Interfaces;
 using Microsoft.Agents.Core.Models;
 using Microsoft.Agents.Storage;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 
 namespace AuthenticationBot
 {
-    public class AuthBot : ActivityHandler
+    public class AuthBot(IConfiguration configuration, IStorage storage) : ActivityHandlerWithOAuth(storage, new OAuthSettings() { ConnectionName = configuration["ConnectionName"] })
     {
-        private readonly ILogger _logger;
-        private readonly IConfiguration _configuration;
-        private readonly OAuthFlow _flow;
-        private readonly IStorage _storage;
-        private FlowState _state;
-
-        public AuthBot(IConfiguration configuration, IStorage storage, ILogger<AuthBot> logger)
-        {
-            _logger = logger ?? NullLogger<AuthBot>.Instance;
-            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
-            _storage = storage ?? throw new ArgumentNullException(nameof(storage));
-            _flow = new OAuthFlow("Sign In", "Please sign in", _configuration["ConnectionName"], 30000, null);
-        }
-
-        public override async Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            // Read OAuthFlow state for this conversation
-            var stateKey = GetStorageKey(turnContext);
-            var items = await _storage.ReadAsync([stateKey], cancellationToken);
-            _state = items.TryGetValue(stateKey, out object value) ? (FlowState)value : new FlowState();
-
-            await base.OnTurnAsync(turnContext, cancellationToken);
-
-            // Store any changes to the OAuthFlow state after the turn is complete.
-            items[stateKey] = _state;
-            await _storage.WriteAsync(items, cancellationToken);
-        }
-
         protected override async Task OnMembersAddedAsync(IList<ChannelAccount> membersAdded, ITurnContext<IConversationUpdateActivity> turnContext, CancellationToken cancellationToken)
         {
             foreach (var member in turnContext.Activity.MembersAdded)
@@ -60,98 +29,20 @@ namespace AuthenticationBot
         {
             if (string.Equals("logout", turnContext.Activity.Text, StringComparison.OrdinalIgnoreCase))
             {
-                _logger.LogInformation("User signing out");
-
-                await _flow.SignOutUserAsync(turnContext, cancellationToken);
+                await SignOutUserAsync(turnContext, cancellationToken);
                 await turnContext.SendActivityAsync(MessageFactory.Text("You have been signed out."), cancellationToken);
             }
             else
             {
-                TokenResponse tokenResponse;
-
-                if (!_state.FlowStarted)
+                // This will return a token when the user is signed in, otherwise start the sign in flow.
+                var tokenResponse = await SigninUserAsync(turnContext, cancellationToken);
+                if (tokenResponse == null)
                 {
-                    tokenResponse = await _flow.BeginFlowAsync(turnContext, null, cancellationToken);
-
-                    // If a TokenResponse is returned, there was a cached token already.  Otherwise, start the process of getting a new token.
-                    if (tokenResponse == null)
-                    {
-                        var expires = DateTime.UtcNow.AddMilliseconds(_flow.Timeout ?? TimeSpan.FromMinutes(15).TotalMilliseconds);
-
-                        _state.FlowStarted = true;
-                        _state.FlowExpires = expires;
-                    }
-                    else
-                    {
-                        _logger.LogInformation("User is already signed in");
-                        await turnContext.SendActivityAsync(MessageFactory.Text("You are still logged in."), cancellationToken);
-                    }
-                }
-                else
-                {
-                    _logger.LogInformation("Exchange user magic code for a token");
-
-                    // For non-Teams bots, the user sends the "magic code" that will be used to exchange for a token.
-                    tokenResponse = await OnContinueFlow(turnContext, cancellationToken);
+                    return;
                 }
 
-                if (tokenResponse != null)
-                {
-                    await turnContext.SendActivityAsync(MessageFactory.Text($"Here is your token {tokenResponse.Token}"), cancellationToken);
-                }
+                await turnContext.SendActivityAsync(MessageFactory.Text($"Here is your token {tokenResponse.Token}"), cancellationToken);
             }
         }
-
-        protected override Task OnTokenResponseEventAsync(ITurnContext<IEventActivity> turnContext, CancellationToken cancellationToken)
-        {
-            _logger.LogInformation("Response Event Activity (Not handled).");
-            return Task.CompletedTask;
-        }
-
-        protected override async Task OnSignInInvokeAsync(ITurnContext<IInvokeActivity> turnContext, CancellationToken cancellationToken)
-        {
-            _logger.LogInformation("Exchange Teams code for a token");
-
-            // Teams will send the bot an "Invoke" Activity that contains a value that will be exchanged for a token.
-            await OnContinueFlow(turnContext, cancellationToken);
-        }
-
-        private async Task<TokenResponse> OnContinueFlow(ITurnContext turnContext, CancellationToken cancellationToken)
-        {
-            TokenResponse tokenResponse = null;
-
-            try
-            {
-                tokenResponse = await _flow.ContinueFlowAsync(turnContext, _state.FlowExpires, cancellationToken);
-                if (tokenResponse != null)
-                {
-                    await turnContext.SendActivityAsync(MessageFactory.Text("You are now logged in."), cancellationToken);
-                }
-                else
-                {
-                    await turnContext.SendActivityAsync(MessageFactory.Text("Login was not successful please try again."), cancellationToken);
-                }
-            }
-            catch (TimeoutException)
-            {
-                await turnContext.SendActivityAsync(MessageFactory.Text("You did not respond in time.  Please try again."), cancellationToken);
-            }
-
-            _state.FlowStarted = false;
-            return tokenResponse;
-        }
-
-        private static string GetStorageKey(ITurnContext turnContext)
-        {
-            var channelId = turnContext.Activity.ChannelId ?? throw new InvalidOperationException("invalid activity-missing channelId");
-            var conversationId = turnContext.Activity.Conversation?.Id ?? throw new InvalidOperationException("invalid activity-missing Conversation.Id");
-            return $"{channelId}/conversations/{conversationId}/flowState";
-        }
-    }
-
-    class FlowState
-    {
-        public bool FlowStarted = false;
-        public DateTime FlowExpires = DateTime.MinValue;
     }
 }


### PR DESCRIPTION
POC for consolidating OAuth flow on the bot side... ActivityHandler.  This POC subclasses ActivityHandler, and handles the state management and Activities until the user is signed in.

Compare the AuthBot to the original.  This also includes the Teams and SharePoint SSO Middleware functionality so that the bot dev does not have to add that middleware to the Adapter.

Possible next steps if we want to go this direction:
- Likely put this code in ActivityHandler
- Use ConversationState

We could go further...  Make State load/save automatic too.  This avoids the bot writer from having to override OnTurnAsync and saving state.  It would just happen.