### PR TITLE
TeamsSSOTokenExchangeMiddleware.DeduplicatedTokenExchangeIdAsync fails on BlobStorage ETag validation

### DIFF
--- a/src/libraries/Storage/Microsoft.Agents.Storage.Blobs/BlobsStorage.cs
+++ b/src/libraries/Storage/Microsoft.Agents.Storage.Blobs/BlobsStorage.cs
@@ -233,6 +233,11 @@ namespace Microsoft.Agents.Storage.Blobs
                         $"An error occurred while trying to write an object. The underlying '{BlobErrorCode.InvalidBlockList}' error is commonly caused due to concurrently uploading an object larger than 128MB in size.",
                         ex);
                 }
+                catch (RequestFailedException ex)
+                when (ex.Status == (int)HttpStatusCode.PreconditionFailed)
+                {
+                    throw new InvalidOperationException($"Etag conflict: {ex.Message}");
+                }
             }
         }
 


### PR DESCRIPTION
https://github.com/microsoft/botbuilder-dotnet/pull/6867