### PR TITLE
Add unit tests for the Microsoft.Agents.Client namespace

### DIFF
--- a/src/libraries/Client/Microsoft.Agents.Client/AssemblyInfo.cs
+++ b/src/libraries/Client/Microsoft.Agents.Client/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Microsoft.Agents.Client.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]

--- a/src/tests/Microsoft.Agents.Client.Tests/ConfigurationChannelHostTests.cs
+++ b/src/tests/Microsoft.Agents.Client.Tests/ConfigurationChannelHostTests.cs
@@ -15,111 +15,67 @@ namespace Microsoft.Agents.Client.Tests
     public class ConfigurationChannelHostTests
     {
         private readonly string _defaultChannel = "webchat";
+        private readonly Mock<IKeyedServiceProvider> _provider = new();
+        private readonly Mock<IConnections> _connections = new();
+        private readonly IConfigurationRoot _config = new ConfigurationBuilder().Build();
+        private readonly Mock<IChannelInfo> _channelInfo = new();
+        private readonly Mock<IChannelFactory> _channelFactory = new();
+        private readonly Mock<IAccessTokenProvider> _token = new();
+        private readonly Mock<IChannel> _channel = new();
 
         [Fact]
         public void Constructor_ShouldThrowOnNullConfigSection()
         {
-            var provider = new Mock<IServiceProvider>();
-            var connections = new Mock<IConnections>();
-            var config = new Mock<IConfiguration>();
-
-            Assert.Throws<ArgumentNullException>(() => new ConfigurationChannelHost(provider.Object, connections.Object, config.Object, _defaultChannel, null));
+            Assert.Throws<ArgumentNullException>(() => new ConfigurationChannelHost(_provider.Object, _connections.Object, _config, _defaultChannel, null));
         }
 
         [Fact]
         public void Constructor_ShouldThrowOnEmptyConfigSection()
         {
-            var provider = new Mock<IServiceProvider>();
-            var connections = new Mock<IConnections>();
-            var config = new Mock<IConfiguration>();
-
-            Assert.Throws<ArgumentException>(() => new ConfigurationChannelHost(provider.Object, connections.Object, config.Object, _defaultChannel, string.Empty));
+            Assert.Throws<ArgumentException>(() => new ConfigurationChannelHost(_provider.Object, _connections.Object, _config, _defaultChannel, string.Empty));
         }
 
         [Fact]
         public void Constructor_ShouldThrowOnNullServiceProvider()
         {
-            var provider = new Mock<IServiceProvider>();
-            var connections = new Mock<IConnections>();
-            var config = new Mock<IConfiguration>();
-
-            Assert.Throws<ArgumentNullException>(() => new ConfigurationChannelHost(null, connections.Object, config.Object, _defaultChannel));
+            Assert.Throws<ArgumentNullException>(() => new ConfigurationChannelHost(null, _connections.Object, _config, _defaultChannel));
         }
 
         [Fact]
         public void Constructor_ShouldThrowOnNullConnections()
         {
-            var provider = new Mock<IServiceProvider>();
-            var config = new Mock<IConfiguration>();
-
-            Assert.Throws<ArgumentNullException>(() => new ConfigurationChannelHost(provider.Object, null, config.Object, _defaultChannel));
+            Assert.Throws<ArgumentNullException>(() => new ConfigurationChannelHost(_provider.Object, null, _config, _defaultChannel));
         }
 
         [Fact]
-        public void Constructor_ShouldSetChannel()
+        public void Constructor_ShouldSetProperties()
         {
             var botId = "bot1";
+            var appId = "123";
             var channel = "testing";
-            var provider = new Mock<IServiceProvider>();
-            var connections = new Mock<IConnections>();
+            var endpoint = "http://localhost/";
             var sections = new Dictionary<string, string>{
                 {"ChannelHost:Channels:0:Id", botId},
-            };
-            var config = new ConfigurationBuilder()
-                .AddInMemoryCollection(sections)
-                .Build();
-
-            var host = new ConfigurationChannelHost(provider.Object, connections.Object, config, channel);
-
-            Assert.Single(host.Channels);
-            Assert.Equal(botId, host.Channels[botId].Id);
-            Assert.Equal(channel, host.Channels[botId].ChannelFactory);
-        }
-
-        [Fact]
-        public void Constructor_ShouldSetHostEndpoint()
-        {
-            var endpoint = "http://localhost/";
-            var provider = new Mock<IServiceProvider>();
-            var connections = new Mock<IConnections>();
-            var sections = new Dictionary<string, string>{
                 {"ChannelHost:HostEndpoint", endpoint},
-            };
-            var config = new ConfigurationBuilder()
-                .AddInMemoryCollection(sections)
-                .Build();
-
-            var host = new ConfigurationChannelHost(provider.Object, connections.Object, config, _defaultChannel);
-
-            Assert.Equal(endpoint, host.HostEndpoint.ToString());
-        }
-
-        [Fact]
-        public void Constructor_ShouldSetHostAppId()
-        {
-            var appId = "123";
-            var provider = new Mock<IServiceProvider>();
-            var connections = new Mock<IConnections>();
-            var sections = new Dictionary<string, string>{
                 {"ChannelHost:HostAppId", appId},
             };
             var config = new ConfigurationBuilder()
                 .AddInMemoryCollection(sections)
                 .Build();
 
-            var host = new ConfigurationChannelHost(provider.Object, connections.Object, config, _defaultChannel);
+            var host = new ConfigurationChannelHost(_provider.Object, _connections.Object, config, channel);
 
+            Assert.Single(host.Channels);
+            Assert.Equal(botId, host.Channels[botId].Id);
+            Assert.Equal(channel, host.Channels[botId].ChannelFactory);
+            Assert.Equal(endpoint, host.HostEndpoint.ToString());
             Assert.Equal(appId, host.HostAppId);
         }
 
         [Fact]
         public void GetChannel_ShouldThrowOnNullName()
         {
-            var provider = new Mock<IServiceProvider>();
-            var connections = new Mock<IConnections>();
-            var config = new ConfigurationBuilder().Build();
-
-            var host = new ConfigurationChannelHost(provider.Object, connections.Object, config, _defaultChannel);
+            var host = new ConfigurationChannelHost(_provider.Object, _connections.Object, _config, _defaultChannel);
 
             Assert.Throws<ArgumentException>(() => host.GetChannel(string.Empty ?? null));
         }
@@ -127,11 +83,7 @@ namespace Microsoft.Agents.Client.Tests
         [Fact]
         public void GetChannel_ShouldThrowOnEmptyName()
         {
-            var provider = new Mock<IServiceProvider>();
-            var connections = new Mock<IConnections>();
-            var config = new ConfigurationBuilder().Build();
-
-            var host = new ConfigurationChannelHost(provider.Object, connections.Object, config, _defaultChannel);
+            var host = new ConfigurationChannelHost(_provider.Object, _connections.Object, _config, _defaultChannel);
 
             Assert.Throws<ArgumentException>(() => host.GetChannel(string.Empty));
         }
@@ -139,11 +91,7 @@ namespace Microsoft.Agents.Client.Tests
         [Fact]
         public void GetChannel_ShouldThrowOnUnknownChannel()
         {
-            var provider = new Mock<IServiceProvider>();
-            var connections = new Mock<IConnections>();
-            var config = new ConfigurationBuilder().Build();
-
-            var host = new ConfigurationChannelHost(provider.Object, connections.Object, config, _defaultChannel);
+            var host = new ConfigurationChannelHost(_provider.Object, _connections.Object, _config, _defaultChannel);
 
             Assert.Throws<InvalidOperationException>(() => host.GetChannel("random"));
         }
@@ -151,11 +99,7 @@ namespace Microsoft.Agents.Client.Tests
         [Fact]
         public void GetChannel_ShouldThrowOnNullChannel()
         {
-            var provider = new Mock<IServiceProvider>();
-            var connections = new Mock<IConnections>();
-            var config = new ConfigurationBuilder().Build();
-
-            var host = new ConfigurationChannelHost(provider.Object, connections.Object, config, _defaultChannel);
+            var host = new ConfigurationChannelHost(_provider.Object, _connections.Object, _config, _defaultChannel);
             host.Channels.Add(_defaultChannel, null);
 
             Assert.Throws<ArgumentNullException>(() => host.GetChannel(_defaultChannel));
@@ -164,177 +108,136 @@ namespace Microsoft.Agents.Client.Tests
         [Fact]
         public void GetChannel_ShouldThrowOnNullChannelFactory()
         {
-            var provider = new Mock<IServiceProvider>();
-            var connections = new Mock<IConnections>();
-            var config = new ConfigurationBuilder().Build();
-            var channelInfo = new Mock<IChannelInfo>();
-
-            channelInfo.SetupGet(e => e.ChannelFactory)
+            _channelInfo.SetupGet(e => e.ChannelFactory)
                 .Returns(() => null)
                 .Verifiable(Times.Once);
 
-            var host = new ConfigurationChannelHost(provider.Object, connections.Object, config, _defaultChannel);
-            host.Channels.Add(_defaultChannel, channelInfo.Object);
+            var host = new ConfigurationChannelHost(_provider.Object, _connections.Object, _config, _defaultChannel);
+            host.Channels.Add(_defaultChannel, _channelInfo.Object);
 
             Assert.Throws<ArgumentNullException>(() => host.GetChannel(_defaultChannel));
-            Mock.Verify(channelInfo);
+            Mock.Verify(_channelInfo);
         }
 
         [Fact]
         public void GetChannel_ShouldThrowOnEmptyChannelFactory()
         {
-            var provider = new Mock<IServiceProvider>();
-            var connections = new Mock<IConnections>();
-            var config = new ConfigurationBuilder().Build();
-            var channelInfo = new Mock<IChannelInfo>();
-
-            channelInfo.SetupGet(e => e.ChannelFactory)
+            _channelInfo.SetupGet(e => e.ChannelFactory)
                 .Returns(string.Empty)
                 .Verifiable(Times.Once);
 
-            var host = new ConfigurationChannelHost(provider.Object, connections.Object, config, _defaultChannel);
-            host.Channels.Add(_defaultChannel, channelInfo.Object);
+            var host = new ConfigurationChannelHost(_provider.Object, _connections.Object, _config, _defaultChannel);
+            host.Channels.Add(_defaultChannel, _channelInfo.Object);
 
             Assert.Throws<ArgumentException>(() => host.GetChannel(_defaultChannel));
-            Mock.Verify(channelInfo);
+            Mock.Verify(_channelInfo);
         }
 
         [Fact]
         public void GetChannel_ShouldThrowOnNullKeyedService()
         {
-            var provider = new Mock<IKeyedServiceProvider>();
-            var connections = new Mock<IConnections>();
-            var config = new ConfigurationBuilder().Build();
-            var channelInfo = new Mock<IChannelInfo>();
-
-            channelInfo.SetupGet(e => e.ChannelFactory)
+            _channelInfo.SetupGet(e => e.ChannelFactory)
                 .Returns("factory")
                 .Verifiable(Times.Exactly(2));
-            provider.Setup(e => e.GetKeyedService(It.IsAny<Type>(), It.IsAny<string>()))
+            _provider.Setup(e => e.GetKeyedService(It.IsAny<Type>(), It.IsAny<string>()))
                 .Returns<object>(null)
                 .Verifiable(Times.Once);
 
-            var host = new ConfigurationChannelHost(provider.Object, connections.Object, config, _defaultChannel);
-            host.Channels.Add(_defaultChannel, channelInfo.Object);
+            var host = new ConfigurationChannelHost(_provider.Object, _connections.Object, _config, _defaultChannel);
+            host.Channels.Add(_defaultChannel, _channelInfo.Object);
 
             Assert.Throws<InvalidOperationException>(() => host.GetChannel(_defaultChannel));
-            Mock.Verify(provider);
+            Mock.Verify(_provider);
         }
 
         [Fact]
         public void GetChannel_ShouldThrowOnNullChannelTokenProvider()
         {
-            var provider = new Mock<IKeyedServiceProvider>();
-            var connections = new Mock<IConnections>();
-            var config = new ConfigurationBuilder().Build();
-            var channelInfo = new Mock<IChannelInfo>();
-            var channelFactory = new Mock<IChannelFactory>();
-
-            channelInfo.SetupGet(e => e.ChannelFactory)
+            _channelInfo.SetupGet(e => e.ChannelFactory)
                 .Returns("factory")
                 .Verifiable(Times.Exactly(2));
-            channelInfo.SetupGet(e => e.TokenProvider)
+            _channelInfo.SetupGet(e => e.TokenProvider)
                 .Returns(() => null)
                 .Verifiable(Times.Once);
-            provider.Setup(e => e.GetKeyedService(It.IsAny<Type>(), It.IsAny<string>()))
-                .Returns(channelFactory.Object)
+            _provider.Setup(e => e.GetKeyedService(It.IsAny<Type>(), It.IsAny<string>()))
+                .Returns(_channelFactory.Object)
                 .Verifiable(Times.Once);
 
-            var host = new ConfigurationChannelHost(provider.Object, connections.Object, config, _defaultChannel);
-            host.Channels.Add(_defaultChannel, channelInfo.Object);
+            var host = new ConfigurationChannelHost(_provider.Object, _connections.Object, _config, _defaultChannel);
+            host.Channels.Add(_defaultChannel, _channelInfo.Object);
 
             Assert.Throws<ArgumentNullException>(() => host.GetChannel(_defaultChannel));
-            Mock.Verify(channelInfo, provider);
+            Mock.Verify(_channelInfo, _provider);
         }
 
         [Fact]
         public void GetChannel_ShouldThrowOnEmptyChannelTokenProvider()
         {
-            var provider = new Mock<IKeyedServiceProvider>();
-            var connections = new Mock<IConnections>();
-            var config = new ConfigurationBuilder().Build();
-            var channelInfo = new Mock<IChannelInfo>();
-            var channelFactory = new Mock<IChannelFactory>();
-
-            channelInfo.SetupGet(e => e.ChannelFactory)
+            _channelInfo.SetupGet(e => e.ChannelFactory)
                 .Returns("factory")
                 .Verifiable(Times.Exactly(2));
-            channelInfo.SetupGet(e => e.TokenProvider)
+            _channelInfo.SetupGet(e => e.TokenProvider)
                 .Returns(string.Empty)
                 .Verifiable(Times.Once);
-            provider.Setup(e => e.GetKeyedService(It.IsAny<Type>(), It.IsAny<string>()))
-                .Returns(channelFactory.Object)
+            _provider.Setup(e => e.GetKeyedService(It.IsAny<Type>(), It.IsAny<string>()))
+                .Returns(_channelFactory.Object)
                 .Verifiable(Times.Once);
 
-            var host = new ConfigurationChannelHost(provider.Object, connections.Object, config, _defaultChannel);
-            host.Channels.Add(_defaultChannel, channelInfo.Object);
+            var host = new ConfigurationChannelHost(_provider.Object, _connections.Object, _config, _defaultChannel);
+            host.Channels.Add(_defaultChannel, _channelInfo.Object);
 
             Assert.Throws<ArgumentException>(() => host.GetChannel(_defaultChannel));
-            Mock.Verify(channelInfo, provider);
+            Mock.Verify(_channelInfo, _provider);
         }
 
         [Fact]
         public void GetChannel_ShouldThrowOnNullConnection()
         {
-            var provider = new Mock<IKeyedServiceProvider>();
-            var connections = new Mock<IConnections>();
-            var config = new ConfigurationBuilder().Build();
-            var channelInfo = new Mock<IChannelInfo>();
-            var channelFactory = new Mock<IChannelFactory>();
-
-            channelInfo.SetupGet(e => e.ChannelFactory)
+            _channelInfo.SetupGet(e => e.ChannelFactory)
                 .Returns("factory")
                 .Verifiable(Times.Exactly(2));
-            channelInfo.SetupGet(e => e.TokenProvider)
+            _channelInfo.SetupGet(e => e.TokenProvider)
                 .Returns("provider")
                 .Verifiable(Times.Exactly(2));
-            provider.Setup(e => e.GetKeyedService(It.IsAny<Type>(), It.IsAny<string>()))
-                .Returns(channelFactory.Object)
+            _provider.Setup(e => e.GetKeyedService(It.IsAny<Type>(), It.IsAny<string>()))
+                .Returns(_channelFactory.Object)
                 .Verifiable(Times.Once);
-            connections.Setup(e => e.GetConnection(It.IsAny<string>()))
+            _connections.Setup(e => e.GetConnection(It.IsAny<string>()))
                 .Returns<IAccessTokenProvider>(null)
                 .Verifiable(Times.Once);
 
-            var host = new ConfigurationChannelHost(provider.Object, connections.Object, config, _defaultChannel);
-            host.Channels.Add(_defaultChannel, channelInfo.Object);
+            var host = new ConfigurationChannelHost(_provider.Object, _connections.Object, _config, _defaultChannel);
+            host.Channels.Add(_defaultChannel, _channelInfo.Object);
 
             Assert.Throws<InvalidOperationException>(() => host.GetChannel(_defaultChannel));
-            Mock.Verify(channelInfo, provider, connections);
+            Mock.Verify(_channelInfo, _provider, _connections);
         }
 
         [Fact]
         public void GetChannel_ShouldReturnChannel()
         {
-            var provider = new Mock<IKeyedServiceProvider>();
-            var connections = new Mock<IConnections>();
-            var config = new ConfigurationBuilder().Build();
-            var channelInfo = new Mock<IChannelInfo>();
-            var channelFactory = new Mock<IChannelFactory>();
-            var token = new Mock<IAccessTokenProvider>();
-            var channel = new Mock<IChannel>();
-
-            channelInfo.SetupGet(e => e.ChannelFactory)
+            _channelInfo.SetupGet(e => e.ChannelFactory)
                 .Returns("factory")
                 .Verifiable(Times.Exactly(2));
-            channelInfo.SetupGet(e => e.TokenProvider)
+            _channelInfo.SetupGet(e => e.TokenProvider)
                 .Returns("provider")
                 .Verifiable(Times.Exactly(2));
-            provider.Setup(e => e.GetKeyedService(It.IsAny<Type>(), It.IsAny<string>()))
-                .Returns(channelFactory.Object)
+            _provider.Setup(e => e.GetKeyedService(It.IsAny<Type>(), It.IsAny<string>()))
+                .Returns(_channelFactory.Object)
                 .Verifiable(Times.Once);
-            connections.Setup(e => e.GetConnection(It.IsAny<string>()))
-                .Returns(token.Object)
+            _connections.Setup(e => e.GetConnection(It.IsAny<string>()))
+                .Returns(_token.Object)
                 .Verifiable(Times.Once);
-            channelFactory.Setup(e => e.CreateChannel(It.IsAny<IAccessTokenProvider>()))
-                .Returns(channel.Object)
+            _channelFactory.Setup(e => e.CreateChannel(It.IsAny<IAccessTokenProvider>()))
+                .Returns(_channel.Object)
                 .Verifiable(Times.Once);
 
-            var host = new ConfigurationChannelHost(provider.Object, connections.Object, config, _defaultChannel);
-            host.Channels.Add(_defaultChannel, channelInfo.Object);
+            var host = new ConfigurationChannelHost(_provider.Object, _connections.Object, _config, _defaultChannel);
+            host.Channels.Add(_defaultChannel, _channelInfo.Object);
             var result = host.GetChannel(_defaultChannel);
 
-            Assert.Equal(channel.Object, result);
-            Mock.Verify(channelInfo, provider, connections, channelFactory);
+            Assert.Equal(_channel.Object, result);
+            Mock.Verify(_channelInfo, _provider, _connections, _channelFactory);
         }
     }
 }

--- a/src/tests/Microsoft.Agents.Client.Tests/ConfigurationChannelHostTests.cs
+++ b/src/tests/Microsoft.Agents.Client.Tests/ConfigurationChannelHostTests.cs
@@ -1,0 +1,340 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Agents.Authentication;
+using Microsoft.Agents.Core.Models;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Microsoft.Agents.Client.Tests
+{
+    public class ConfigurationChannelHostTests
+    {
+        private readonly string _defaultChannel = "webchat";
+
+        [Fact]
+        public void Constructor_ShouldThrowOnNullConfigSection()
+        {
+            var provider = new Mock<IServiceProvider>();
+            var connections = new Mock<IConnections>();
+            var config = new Mock<IConfiguration>();
+
+            Assert.Throws<ArgumentNullException>(() => new ConfigurationChannelHost(provider.Object, connections.Object, config.Object, _defaultChannel, null));
+        }
+
+        [Fact]
+        public void Constructor_ShouldThrowOnEmptyConfigSection()
+        {
+            var provider = new Mock<IServiceProvider>();
+            var connections = new Mock<IConnections>();
+            var config = new Mock<IConfiguration>();
+
+            Assert.Throws<ArgumentException>(() => new ConfigurationChannelHost(provider.Object, connections.Object, config.Object, _defaultChannel, string.Empty));
+        }
+
+        [Fact]
+        public void Constructor_ShouldThrowOnNullServiceProvider()
+        {
+            var provider = new Mock<IServiceProvider>();
+            var connections = new Mock<IConnections>();
+            var config = new Mock<IConfiguration>();
+
+            Assert.Throws<ArgumentNullException>(() => new ConfigurationChannelHost(null, connections.Object, config.Object, _defaultChannel));
+        }
+
+        [Fact]
+        public void Constructor_ShouldThrowOnNullConnections()
+        {
+            var provider = new Mock<IServiceProvider>();
+            var config = new Mock<IConfiguration>();
+
+            Assert.Throws<ArgumentNullException>(() => new ConfigurationChannelHost(provider.Object, null, config.Object, _defaultChannel));
+        }
+
+        [Fact]
+        public void Constructor_ShouldSetChannel()
+        {
+            var botId = "bot1";
+            var channel = "testing";
+            var provider = new Mock<IServiceProvider>();
+            var connections = new Mock<IConnections>();
+            var sections = new Dictionary<string, string>{
+                {"ChannelHost:Channels:0:Id", botId},
+            };
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(sections)
+                .Build();
+
+            var host = new ConfigurationChannelHost(provider.Object, connections.Object, config, channel);
+
+            Assert.Single(host.Channels);
+            Assert.Equal(botId, host.Channels[botId].Id);
+            Assert.Equal(channel, host.Channels[botId].ChannelFactory);
+        }
+
+        [Fact]
+        public void Constructor_ShouldSetHostEndpoint()
+        {
+            var endpoint = "http://localhost/";
+            var provider = new Mock<IServiceProvider>();
+            var connections = new Mock<IConnections>();
+            var sections = new Dictionary<string, string>{
+                {"ChannelHost:HostEndpoint", endpoint},
+            };
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(sections)
+                .Build();
+
+            var host = new ConfigurationChannelHost(provider.Object, connections.Object, config, _defaultChannel);
+
+            Assert.Equal(endpoint, host.HostEndpoint.ToString());
+        }
+
+        [Fact]
+        public void Constructor_ShouldSetHostAppId()
+        {
+            var appId = "123";
+            var provider = new Mock<IServiceProvider>();
+            var connections = new Mock<IConnections>();
+            var sections = new Dictionary<string, string>{
+                {"ChannelHost:HostAppId", appId},
+            };
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(sections)
+                .Build();
+
+            var host = new ConfigurationChannelHost(provider.Object, connections.Object, config, _defaultChannel);
+
+            Assert.Equal(appId, host.HostAppId);
+        }
+
+        [Fact]
+        public void GetChannel_ShouldThrowOnNullName()
+        {
+            var provider = new Mock<IServiceProvider>();
+            var connections = new Mock<IConnections>();
+            var config = new ConfigurationBuilder().Build();
+
+            var host = new ConfigurationChannelHost(provider.Object, connections.Object, config, _defaultChannel);
+
+            Assert.Throws<ArgumentException>(() => host.GetChannel(string.Empty ?? null));
+        }
+
+        [Fact]
+        public void GetChannel_ShouldThrowOnEmptyName()
+        {
+            var provider = new Mock<IServiceProvider>();
+            var connections = new Mock<IConnections>();
+            var config = new ConfigurationBuilder().Build();
+
+            var host = new ConfigurationChannelHost(provider.Object, connections.Object, config, _defaultChannel);
+
+            Assert.Throws<ArgumentException>(() => host.GetChannel(string.Empty));
+        }
+
+        [Fact]
+        public void GetChannel_ShouldThrowOnUnknownChannel()
+        {
+            var provider = new Mock<IServiceProvider>();
+            var connections = new Mock<IConnections>();
+            var config = new ConfigurationBuilder().Build();
+
+            var host = new ConfigurationChannelHost(provider.Object, connections.Object, config, _defaultChannel);
+
+            Assert.Throws<InvalidOperationException>(() => host.GetChannel("random"));
+        }
+
+        [Fact]
+        public void GetChannel_ShouldThrowOnNullChannel()
+        {
+            var provider = new Mock<IServiceProvider>();
+            var connections = new Mock<IConnections>();
+            var config = new ConfigurationBuilder().Build();
+
+            var host = new ConfigurationChannelHost(provider.Object, connections.Object, config, _defaultChannel);
+            host.Channels.Add(_defaultChannel, null);
+
+            Assert.Throws<ArgumentNullException>(() => host.GetChannel(_defaultChannel));
+        }
+
+        [Fact]
+        public void GetChannel_ShouldThrowOnNullChannelFactory()
+        {
+            var provider = new Mock<IServiceProvider>();
+            var connections = new Mock<IConnections>();
+            var config = new ConfigurationBuilder().Build();
+            var channelInfo = new Mock<IChannelInfo>();
+
+            channelInfo.SetupGet(e => e.ChannelFactory)
+                .Returns(() => null)
+                .Verifiable(Times.Once);
+
+            var host = new ConfigurationChannelHost(provider.Object, connections.Object, config, _defaultChannel);
+            host.Channels.Add(_defaultChannel, channelInfo.Object);
+
+            Assert.Throws<ArgumentNullException>(() => host.GetChannel(_defaultChannel));
+            Mock.Verify(channelInfo);
+        }
+
+        [Fact]
+        public void GetChannel_ShouldThrowOnEmptyChannelFactory()
+        {
+            var provider = new Mock<IServiceProvider>();
+            var connections = new Mock<IConnections>();
+            var config = new ConfigurationBuilder().Build();
+            var channelInfo = new Mock<IChannelInfo>();
+
+            channelInfo.SetupGet(e => e.ChannelFactory)
+                .Returns(string.Empty)
+                .Verifiable(Times.Once);
+
+            var host = new ConfigurationChannelHost(provider.Object, connections.Object, config, _defaultChannel);
+            host.Channels.Add(_defaultChannel, channelInfo.Object);
+
+            Assert.Throws<ArgumentException>(() => host.GetChannel(_defaultChannel));
+            Mock.Verify(channelInfo);
+        }
+
+        [Fact]
+        public void GetChannel_ShouldThrowOnNullKeyedService()
+        {
+            var provider = new Mock<IKeyedServiceProvider>();
+            var connections = new Mock<IConnections>();
+            var config = new ConfigurationBuilder().Build();
+            var channelInfo = new Mock<IChannelInfo>();
+
+            channelInfo.SetupGet(e => e.ChannelFactory)
+                .Returns("factory")
+                .Verifiable(Times.Exactly(2));
+            provider.Setup(e => e.GetKeyedService(It.IsAny<Type>(), It.IsAny<string>()))
+                .Returns<object>(null)
+                .Verifiable(Times.Once);
+
+            var host = new ConfigurationChannelHost(provider.Object, connections.Object, config, _defaultChannel);
+            host.Channels.Add(_defaultChannel, channelInfo.Object);
+
+            Assert.Throws<InvalidOperationException>(() => host.GetChannel(_defaultChannel));
+            Mock.Verify(provider);
+        }
+
+        [Fact]
+        public void GetChannel_ShouldThrowOnNullChannelTokenProvider()
+        {
+            var provider = new Mock<IKeyedServiceProvider>();
+            var connections = new Mock<IConnections>();
+            var config = new ConfigurationBuilder().Build();
+            var channelInfo = new Mock<IChannelInfo>();
+            var channelFactory = new Mock<IChannelFactory>();
+
+            channelInfo.SetupGet(e => e.ChannelFactory)
+                .Returns("factory")
+                .Verifiable(Times.Exactly(2));
+            channelInfo.SetupGet(e => e.TokenProvider)
+                .Returns(() => null)
+                .Verifiable(Times.Once);
+            provider.Setup(e => e.GetKeyedService(It.IsAny<Type>(), It.IsAny<string>()))
+                .Returns(channelFactory.Object)
+                .Verifiable(Times.Once);
+
+            var host = new ConfigurationChannelHost(provider.Object, connections.Object, config, _defaultChannel);
+            host.Channels.Add(_defaultChannel, channelInfo.Object);
+
+            Assert.Throws<ArgumentNullException>(() => host.GetChannel(_defaultChannel));
+            Mock.Verify(channelInfo, provider);
+        }
+
+        [Fact]
+        public void GetChannel_ShouldThrowOnEmptyChannelTokenProvider()
+        {
+            var provider = new Mock<IKeyedServiceProvider>();
+            var connections = new Mock<IConnections>();
+            var config = new ConfigurationBuilder().Build();
+            var channelInfo = new Mock<IChannelInfo>();
+            var channelFactory = new Mock<IChannelFactory>();
+
+            channelInfo.SetupGet(e => e.ChannelFactory)
+                .Returns("factory")
+                .Verifiable(Times.Exactly(2));
+            channelInfo.SetupGet(e => e.TokenProvider)
+                .Returns(string.Empty)
+                .Verifiable(Times.Once);
+            provider.Setup(e => e.GetKeyedService(It.IsAny<Type>(), It.IsAny<string>()))
+                .Returns(channelFactory.Object)
+                .Verifiable(Times.Once);
+
+            var host = new ConfigurationChannelHost(provider.Object, connections.Object, config, _defaultChannel);
+            host.Channels.Add(_defaultChannel, channelInfo.Object);
+
+            Assert.Throws<ArgumentException>(() => host.GetChannel(_defaultChannel));
+            Mock.Verify(channelInfo, provider);
+        }
+
+        [Fact]
+        public void GetChannel_ShouldThrowOnNullConnection()
+        {
+            var provider = new Mock<IKeyedServiceProvider>();
+            var connections = new Mock<IConnections>();
+            var config = new ConfigurationBuilder().Build();
+            var channelInfo = new Mock<IChannelInfo>();
+            var channelFactory = new Mock<IChannelFactory>();
+
+            channelInfo.SetupGet(e => e.ChannelFactory)
+                .Returns("factory")
+                .Verifiable(Times.Exactly(2));
+            channelInfo.SetupGet(e => e.TokenProvider)
+                .Returns("provider")
+                .Verifiable(Times.Exactly(2));
+            provider.Setup(e => e.GetKeyedService(It.IsAny<Type>(), It.IsAny<string>()))
+                .Returns(channelFactory.Object)
+                .Verifiable(Times.Once);
+            connections.Setup(e => e.GetConnection(It.IsAny<string>()))
+                .Returns<IAccessTokenProvider>(null)
+                .Verifiable(Times.Once);
+
+            var host = new ConfigurationChannelHost(provider.Object, connections.Object, config, _defaultChannel);
+            host.Channels.Add(_defaultChannel, channelInfo.Object);
+
+            Assert.Throws<InvalidOperationException>(() => host.GetChannel(_defaultChannel));
+            Mock.Verify(channelInfo, provider, connections);
+        }
+
+        [Fact]
+        public void GetChannel_ShouldReturnChannel()
+        {
+            var provider = new Mock<IKeyedServiceProvider>();
+            var connections = new Mock<IConnections>();
+            var config = new ConfigurationBuilder().Build();
+            var channelInfo = new Mock<IChannelInfo>();
+            var channelFactory = new Mock<IChannelFactory>();
+            var token = new Mock<IAccessTokenProvider>();
+            var channel = new Mock<IChannel>();
+
+            channelInfo.SetupGet(e => e.ChannelFactory)
+                .Returns("factory")
+                .Verifiable(Times.Exactly(2));
+            channelInfo.SetupGet(e => e.TokenProvider)
+                .Returns("provider")
+                .Verifiable(Times.Exactly(2));
+            provider.Setup(e => e.GetKeyedService(It.IsAny<Type>(), It.IsAny<string>()))
+                .Returns(channelFactory.Object)
+                .Verifiable(Times.Once);
+            connections.Setup(e => e.GetConnection(It.IsAny<string>()))
+                .Returns(token.Object)
+                .Verifiable(Times.Once);
+            channelFactory.Setup(e => e.CreateChannel(It.IsAny<IAccessTokenProvider>()))
+                .Returns(channel.Object)
+                .Verifiable(Times.Once);
+
+            var host = new ConfigurationChannelHost(provider.Object, connections.Object, config, _defaultChannel);
+            host.Channels.Add(_defaultChannel, channelInfo.Object);
+            var result = host.GetChannel(_defaultChannel);
+
+            Assert.Equal(channel.Object, result);
+            Mock.Verify(channelInfo, provider, connections, channelFactory);
+        }
+    }
+}

--- a/src/tests/Microsoft.Agents.Client.Tests/HttpBotChannelFactoryTests.cs
+++ b/src/tests/Microsoft.Agents.Client.Tests/HttpBotChannelFactoryTests.cs
@@ -13,32 +13,30 @@ namespace Microsoft.Agents.Client.Tests
 {
     public class HttpBotChannelFactoryTests
     {
+        private readonly Mock<IHttpClientFactory> _clientFactory = new();
+        private readonly Mock<ILogger<HttpBotChannelFactory>> _logger = new();
+        private readonly Mock<IAccessTokenProvider> _provider = new();
+        private readonly Mock<HttpClient> _httpClient = new();
+
         [Fact]
         public void Constructor_ShouldThrowOnNullHttpFactory()
         {
-            var logger = new Mock<ILogger<HttpBotChannelFactory>>();
-
-            Assert.Throws<ArgumentNullException>(() => new HttpBotChannelFactory(null, logger.Object));
+            Assert.Throws<ArgumentNullException>(() => new HttpBotChannelFactory(null, _logger.Object));
         }
 
         [Fact]
         public void CreateChannel_ShouldReturnBotChannel()
         {
-            var clientFactory = new Mock<IHttpClientFactory>();
-            var logger = new Mock<ILogger<HttpBotChannelFactory>>();
-            var provider = new Mock<IAccessTokenProvider>();
-            var httpClient = new Mock<HttpClient>();
-
-            clientFactory.Setup(e => e.CreateClient(It.IsAny<string>()))
-                .Returns(httpClient.Object)
+            _clientFactory.Setup(e => e.CreateClient(It.IsAny<string>()))
+                .Returns(_httpClient.Object)
                 .Verifiable(Times.Once);
 
-            var channelFactory = new HttpBotChannelFactory(clientFactory.Object, logger.Object);
+            var channelFactory = new HttpBotChannelFactory(_clientFactory.Object, _logger.Object);
 
-            var channel = channelFactory.CreateChannel(provider.Object);
+            var channel = channelFactory.CreateChannel(_provider.Object);
 
             Assert.NotNull(channel);
-            Mock.Verify(clientFactory);
+            Mock.Verify(_clientFactory);
         }
     }
 }

--- a/src/tests/Microsoft.Agents.Client.Tests/HttpBotChannelFactoryTests.cs
+++ b/src/tests/Microsoft.Agents.Client.Tests/HttpBotChannelFactoryTests.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Agents.Authentication;
+using Microsoft.Agents.Core.Models;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System;
+using System.Net.Http;
+using Xunit;
+
+namespace Microsoft.Agents.Client.Tests
+{
+    public class HttpBotChannelFactoryTests
+    {
+        [Fact]
+        public void Constructor_ShouldThrowOnNullHttpFactory()
+        {
+            var logger = new Mock<ILogger<HttpBotChannelFactory>>();
+
+            Assert.Throws<ArgumentNullException>(() => new HttpBotChannelFactory(null, logger.Object));
+        }
+
+        [Fact]
+        public void CreateChannel_ShouldReturnBotChannel()
+        {
+            var clientFactory = new Mock<IHttpClientFactory>();
+            var logger = new Mock<ILogger<HttpBotChannelFactory>>();
+            var provider = new Mock<IAccessTokenProvider>();
+            var httpClient = new Mock<HttpClient>();
+
+            clientFactory.Setup(e => e.CreateClient(It.IsAny<string>()))
+                .Returns(httpClient.Object)
+                .Verifiable(Times.Once);
+
+            var channelFactory = new HttpBotChannelFactory(clientFactory.Object, logger.Object);
+
+            var channel = channelFactory.CreateChannel(provider.Object);
+
+            Assert.NotNull(channel);
+            Mock.Verify(clientFactory);
+        }
+    }
+}

--- a/src/tests/Microsoft.Agents.Client.Tests/HttpBotChannelTests.cs
+++ b/src/tests/Microsoft.Agents.Client.Tests/HttpBotChannelTests.cs
@@ -1,0 +1,130 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Agents.Authentication;
+using Microsoft.Agents.Core.Models;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Agents.Client.Tests
+{
+    public class HttpBotChannelTests
+    {
+        private readonly string _toBotId = "botid";
+        private readonly string _toBotResource = "botresource";
+        private readonly Uri _endpoint = new("http://endpoint");
+        private readonly Uri _serviceUrl = new("http://serviceUrl");
+        private readonly string _conversationId = "conversationid";
+        private readonly Activity _activity = new(conversation: new());
+
+        [Fact]
+        public async Task PostActivityAsync_ShouldThrowOnNullEndpoint()
+        {
+            var provider = new Mock<IAccessTokenProvider>();
+            var factory = new Mock<IHttpClientFactory>();
+            var logger = new Mock<ILogger>();
+            var channel = new HttpBotChannel(provider.Object, factory.Object, logger.Object);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() =>
+                channel.PostActivityAsync(_toBotId, _toBotResource, null, _serviceUrl, _conversationId, _activity, CancellationToken.None));
+        }
+
+        [Fact]
+        public async Task PostActivityAsync_ShouldThrowOnNullServiceUrl()
+        {
+            var provider = new Mock<IAccessTokenProvider>();
+            var factory = new Mock<IHttpClientFactory>();
+            var logger = new Mock<ILogger>();
+            var channel = new HttpBotChannel(provider.Object, factory.Object, logger.Object);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() =>
+                channel.PostActivityAsync(_toBotId, _toBotResource, _endpoint, null, _conversationId, _activity, CancellationToken.None));
+        }
+
+        [Fact]
+        public async Task PostActivityAsync_ShouldThrowOnNullConversationId()
+        {
+            var provider = new Mock<IAccessTokenProvider>();
+            var factory = new Mock<IHttpClientFactory>();
+            var logger = new Mock<ILogger>();
+            var channel = new HttpBotChannel(provider.Object, factory.Object, logger.Object);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() =>
+                channel.PostActivityAsync(_toBotId, _toBotResource, _endpoint, _serviceUrl, null, _activity, CancellationToken.None));
+        }
+
+        [Fact]
+        public async Task PostActivityAsync_ShouldThrowOnNullActivity()
+        {
+            var provider = new Mock<IAccessTokenProvider>();
+            var factory = new Mock<IHttpClientFactory>();
+            var logger = new Mock<ILogger>();
+            var channel = new HttpBotChannel(provider.Object, factory.Object, logger.Object);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() =>
+                channel.PostActivityAsync(_toBotId, _toBotResource, _endpoint, _serviceUrl, _conversationId, null, CancellationToken.None));
+        }
+
+        [Fact]
+        public async Task PostActivityAsync_ShouldReturnSuccessfulInvokeResponse()
+        {
+            var provider = new Mock<IAccessTokenProvider>();
+            var factory = new Mock<IHttpClientFactory>();
+            var logger = new Mock<ILogger>();
+            var httpClient = new Mock<HttpClient>();
+            var content = "{\"text\": \"testing\"}";
+            var message = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(content) };
+
+            provider.Setup(e => e.GetAccessTokenAsync(It.IsAny<string>(), It.Is<IList<string>>(e => e[0].StartsWith(_toBotId)), It.IsAny<bool>()))
+                .ReturnsAsync("token")
+                .Verifiable(Times.Once);
+            factory.Setup(e => e.CreateClient(It.IsAny<string>()))
+                .Returns(httpClient.Object)
+                .Verifiable(Times.Once);
+            httpClient.Setup(e => e.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(message)
+                .Verifiable(Times.Once);
+
+            var channel = new HttpBotChannel(provider.Object, factory.Object, logger.Object);
+            var response = await channel.PostActivityAsync(_toBotId, _toBotResource, _endpoint, _serviceUrl, _conversationId, _activity, CancellationToken.None);
+
+            Assert.Equal((int)message.StatusCode, response.Status);
+            Assert.Equal(content, response.Body.ToString());
+            Mock.Verify(provider, factory, httpClient);
+        }
+
+        [Fact]
+        public async Task PostActivityAsync_ShouldReturnFailedInvokeResponse()
+        {
+            var provider = new Mock<IAccessTokenProvider>();
+            var factory = new Mock<IHttpClientFactory>();
+            var httpClient = new Mock<HttpClient>();
+            var content = "{\"text\": \"testing\"}";
+            var message = new HttpResponseMessage(HttpStatusCode.BadRequest) { Content = new StringContent(content) };
+
+            provider.Setup(e => e.GetAccessTokenAsync(It.IsAny<string>(), It.Is<IList<string>>(e => e[0].StartsWith(_toBotId)), It.IsAny<bool>()))
+                .ReturnsAsync("token")
+                .Verifiable(Times.Once);
+            factory.Setup(e => e.CreateClient(It.IsAny<string>()))
+                .Returns(httpClient.Object)
+                .Verifiable(Times.Once);
+            httpClient.Setup(e => e.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(message)
+                .Verifiable(Times.Once);
+
+            var channel = new HttpBotChannel(provider.Object, factory.Object, null);
+            var response = await channel.PostActivityAsync(_toBotId, _toBotResource, _endpoint, _serviceUrl, _conversationId, _activity, CancellationToken.None);
+
+            Assert.Equal((int)message.StatusCode, response.Status);
+            Assert.Equal(content, response.Body.ToString());
+            Mock.Verify(provider, factory, httpClient);
+        }
+    }
+}


### PR DESCRIPTION
## Description

This PR creates unit tests to cover the classes in **_Microsoft.Agents.Client_**, increasing the code coverage up to **94%**.

## Detailed Changes
- Added 3 test files (_ConfigurationChannelHostTests_, _HttpBotChannelFactoryTests_, _HttpBotChannelTests_).

## Testing
The following image shows the code coverage of this namespace.
![image](https://github.com/user-attachments/assets/b474ac49-1598-4856-adcd-f118756e4dd3)
