### PR TITLE
Add unit tests for the Microsoft.Agents.Authentication project

### DIFF
--- a/src/libraries/Core/Microsoft.Agents.Authentication/AssemblyInfo.cs
+++ b/src/libraries/Core/Microsoft.Agents.Authentication/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Microsoft.Agents.Auth.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]

--- a/src/tests/Microsoft.Agents.Auth.Tests/AuthTests.cs
+++ b/src/tests/Microsoft.Agents.Auth.Tests/AuthTests.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Agents.Authentication.Msal;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Agents.Authentication.Msal;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using System;
@@ -8,7 +11,7 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace Microsoft.CopilotStudio.Connector.Tests
+namespace Microsoft.Agents.Auth.Tests
 {
     public class AuthTests
     {

--- a/src/tests/Microsoft.Agents.Auth.Tests/BotClaimsTests.cs
+++ b/src/tests/Microsoft.Agents.Auth.Tests/BotClaimsTests.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Agents.Authentication;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Agents.Authentication;
 using System;
 using System.Collections.Generic;
 using System.Security.Claims;
@@ -206,14 +209,14 @@ namespace Microsoft.Agents.Auth.Tests
         [Fact]
         public void GetOutgoingAppId_ValidV2VersionClaimWithAuthorizedParty()
         {
-            // this tests sets up a claimset with a version claim "2.0" and an AuthorizedParty Claim
-            var claims = new List<Claim>
+            static IEnumerable<Claim> GetClaims() // Use this function to cover the ToList() method.
             {
-                new(AuthenticationConstants.VersionClaim, "2.0"),
-                new(AuthenticationConstants.AuthorizedParty, "appId") 
+                // this tests sets up a claimset with a version claim "2.0" and an AuthorizedParty Claim.
+                yield return new Claim(AuthenticationConstants.VersionClaim, "2.0");
+                yield return new Claim(AuthenticationConstants.AuthorizedParty, "appId");
             };
 
-            Assert.Equal("appId", BotClaims.GetOutgoingAppId(claims));
+            Assert.Equal("appId", BotClaims.GetOutgoingAppId(GetClaims()));
         }
 
         [Fact]
@@ -264,6 +267,46 @@ namespace Microsoft.Agents.Auth.Tests
             };
 
             Assert.False(BotClaims.IsBotClaim(claims));
+        }
+
+        [Fact]
+        public void IsBotClaim_ShouldReturnFalseOnNoVersion()
+        {
+            var claims = new List<Claim>
+            {
+                new(AuthenticationConstants.AudienceClaim, "audience"),
+                new(AuthenticationConstants.AppIdClaim, "appId")
+            };
+
+            Assert.False(BotClaims.IsBotClaim(claims));
+        }
+
+        [Fact]
+        public void IsBotClaim_ShouldReturnFalseOnNoOutgoingAppId()
+        {
+            // Setup an invalid claim set
+            var claims = new List<Claim>
+            {
+                new(AuthenticationConstants.VersionClaim, "2.0"),
+                new(AuthenticationConstants.AudienceClaim, "audience"),
+                new(AuthenticationConstants.AppIdClaim, "appId") // not a valid claim on a v2 token
+            };
+
+            Assert.False(BotClaims.IsBotClaim(claims));
+        }
+
+        [Fact]
+        public void GetTokenAudience_ShouldSetAudienceInUri()
+        {
+            var claims = new List<Claim>
+            {
+                new(AuthenticationConstants.VersionClaim, "2.0"),
+                new(AuthenticationConstants.AuthorizedParty, "appId")
+            };
+
+            var audience = BotClaims.GetTokenAudience(claims);
+
+            Assert.Equal("app://appId", audience);
         }
     }
 }

--- a/src/tests/Microsoft.Agents.Auth.Tests/ConfigurationConnectionsTests.cs
+++ b/src/tests/Microsoft.Agents.Auth.Tests/ConfigurationConnectionsTests.cs
@@ -1,0 +1,325 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Agents.Authentication;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.Memory;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Runtime.Loader;
+using System.Security.Claims;
+using Xunit;
+
+namespace Microsoft.Agents.Auth.Tests
+{
+    public class ConfigurationConnectionsTests
+    {
+        private readonly Mock<IServiceProvider> _serviceProvider = new();
+        private readonly ClaimsIdentity _identity = new([]);
+
+        [Fact]
+        public void GetConnection_ShouldReturnAccessTokenProviderWithConnectionName()
+        {
+            var config = new ConfigurationRoot(
+            [
+                new MemoryConfigurationProvider(new MemoryConfigurationSource
+                {
+                    InitialData = new Dictionary<string, string>
+                    {
+                        { "ConnectionsMap:0:ServiceUrl", "*" },
+                        { "ConnectionsMap:0:Connection", "BotServiceConnection" },
+                        { "Connections:BotServiceConnection:Type", "MsalAuth" },
+                        { "Connections:BotServiceConnection:Assembly", "Microsoft.Agents.Authentication.Msal" },
+                        { "Connections:BotServiceConnection:Settings:ClientId", "ClientId" },
+                        { "Connections:BotServiceConnection:Settings:ClientSecret", "ClientSecret" },
+                        { "Connections:BotServiceConnection:Settings:AuthorityEndpoint", "AuthorityEndpoint" },
+                    }
+                })
+            ]);
+            var configurationConnections = new ConfigurationConnections(_serviceProvider.Object, config);
+
+            var response = configurationConnections.GetConnection("BotServiceConnection");
+
+            Assert.NotNull(response);
+        }
+
+        [Fact]
+        public void GetConnection_ShouldThrowOnNullConnectionName()
+        {
+            var config = new ConfigurationRoot(
+            [
+                new MemoryConfigurationProvider(new MemoryConfigurationSource
+                {
+                    InitialData = new Dictionary<string, string>
+                    {
+                        { "ConnectionsMap:0:ServiceUrl", "*" },
+                        { "ConnectionsMap:0:Connection", "BotServiceConnection" },
+                        { "Connections:BotServiceConnection:Type", "MsalAuth" },
+                        { "Connections:BotServiceConnection:Assembly", "Microsoft.Agents.Authentication.Msal" },
+                        { "Connections:BotServiceConnection:Settings:ClientId", "ClientId" },
+                        { "Connections:BotServiceConnection:Settings:ClientSecret", "ClientSecret" },
+                        { "Connections:BotServiceConnection:Settings:AuthorityEndpoint", "AuthorityEndpoint" },
+                    }
+                })
+            ]);
+            var configurationConnections = new ConfigurationConnections(_serviceProvider.Object, config);
+
+            Assert.Throws<ArgumentNullException>(() => configurationConnections.GetConnection(null));
+        }
+
+        [Fact]
+        public void GetDefaultConnection_ShouldReturnAccessTokenProviderFromMap()
+        {
+            var config = new ConfigurationRoot(
+            [
+                new MemoryConfigurationProvider(new MemoryConfigurationSource
+                {
+                    InitialData = new Dictionary<string, string>
+                    {
+                        { "ConnectionsMap:0:ServiceUrl", "*" },
+                        { "ConnectionsMap:0:Connection", "BotServiceConnection" },
+                        { "Connections:BotServiceConnection:Type", "MsalAuth" },
+                        { "Connections:BotServiceConnection:Assembly", "Microsoft.Agents.Authentication.Msal" },
+                        { "Connections:BotServiceConnection:Settings:ClientId", "ClientId" },
+                        { "Connections:BotServiceConnection:Settings:ClientSecret", "ClientSecret" },
+                        { "Connections:BotServiceConnection:Settings:AuthorityEndpoint", "AuthorityEndpoint" },
+                    }
+                })
+            ]);
+            var configurationConnections = new ConfigurationConnections(_serviceProvider.Object, config);
+
+            var response = configurationConnections.GetDefaultConnection();
+
+            Assert.NotNull(response);
+        }
+
+        [Fact]
+        public void GetDefaultConnection_ShouldReturnAccessTokenProviderFromConnections()
+        {
+            var config = new ConfigurationRoot(
+            [
+                new MemoryConfigurationProvider(new MemoryConfigurationSource
+                {
+                    InitialData = new Dictionary<string, string>
+                    {
+                        { "ConnectionsMap:0:ServiceUrl", "serviceUrl" },
+                        { "ConnectionsMap:0:Connection", "BotServiceConnection" },
+                        { "Connections:BotServiceConnection:Type", "MsalAuth" },
+                        { "Connections:BotServiceConnection:Assembly", "Microsoft.Agents.Authentication.Msal" },
+                        { "Connections:BotServiceConnection:Settings:ClientId", "ClientId" },
+                        { "Connections:BotServiceConnection:Settings:ClientSecret", "ClientSecret" },
+                        { "Connections:BotServiceConnection:Settings:AuthorityEndpoint", "AuthorityEndpoint" },
+                    }
+                })
+            ]);
+
+            var configurationConnections = new ConfigurationConnections(_serviceProvider.Object, config);
+
+            var response = configurationConnections.GetDefaultConnection();
+
+            Assert.NotNull(response);
+        }
+
+        [Fact]
+        public void GetTokenProvider_ShouldReturnAccessTokenProviderOnMatchingServiceUrl()
+        {
+            var config = new ConfigurationRoot(
+            [
+                new MemoryConfigurationProvider(new MemoryConfigurationSource
+                {
+                    InitialData = new Dictionary<string, string>
+                    {
+                        { "ConnectionsMap:0:ServiceUrl", "serviceUrl" },
+                        { "ConnectionsMap:0:Connection", "BotServiceConnection" },
+                        { "Connections:BotServiceConnection:Type", "MsalAuth" },
+                        { "Connections:BotServiceConnection:Assembly", "Microsoft.Agents.Authentication.Msal" },
+                        { "Connections:BotServiceConnection:Settings:ClientId", "ClientId" },
+                        { "Connections:BotServiceConnection:Settings:ClientSecret", "ClientSecret" },
+                        { "Connections:BotServiceConnection:Settings:AuthorityEndpoint", "AuthorityEndpoint" },
+                    }
+                })
+            ]);
+            var configurationConnections = new ConfigurationConnections(_serviceProvider.Object, config);
+
+            var response = configurationConnections.GetTokenProvider(_identity, "serviceUrl");
+
+            Assert.NotNull(response);
+        }
+
+        [Fact]
+        public void GetTokenProvider_ShouldReturnAccessTokenProviderOnEmptyServiceUrl()
+        {
+            var config = new ConfigurationRoot(
+            [
+                new MemoryConfigurationProvider(new MemoryConfigurationSource
+                {
+                    InitialData = new Dictionary<string, string>
+                    {
+                        { "Connections:BotServiceConnection:Type", "MsalAuth" },
+                        { "Connections:BotServiceConnection:Assembly", "Microsoft.Agents.Authentication.Msal" },
+                        { "Connections:BotServiceConnection:Settings:ClientId", "ClientId" },
+                        { "Connections:BotServiceConnection:Settings:ClientSecret", "ClientSecret" },
+                        { "Connections:BotServiceConnection:Settings:AuthorityEndpoint", "AuthorityEndpoint" },
+                    }
+                })
+            ]);
+
+            var configurationConnections = new ConfigurationConnections(_serviceProvider.Object, config);
+
+            var response = configurationConnections.GetTokenProvider(_identity, "serviceUrl");
+
+            Assert.NotNull(response);
+        }
+
+        [Fact]
+        public void GetTokenProvider_ShouldReturnAccessTokenProviderOnGenericServiceUrl()
+        {
+            var config = new ConfigurationRoot(
+            [
+                new MemoryConfigurationProvider(new MemoryConfigurationSource
+                {
+                    InitialData = new Dictionary<string, string>
+                    {
+                        { "ConnectionsMap:0:ServiceUrl", "*" },
+                        { "ConnectionsMap:0:Connection", "BotServiceConnection" },
+                        { "Connections:BotServiceConnection:Type", "MsalAuth" },
+                        { "Connections:BotServiceConnection:Assembly", "Microsoft.Agents.Authentication.Msal" },
+                        { "Connections:BotServiceConnection:Settings:ClientId", "ClientId" },
+                        { "Connections:BotServiceConnection:Settings:ClientSecret", "ClientSecret" },
+                        { "Connections:BotServiceConnection:Settings:AuthorityEndpoint", "AuthorityEndpoint" },
+                    }
+                })
+            ]);
+            var configurationConnections = new ConfigurationConnections(_serviceProvider.Object, config);
+
+            var response = configurationConnections.GetTokenProvider(_identity, "generic");
+
+            Assert.NotNull(response);
+        }
+
+        [Fact]
+        public void GetTokenProvider_ShouldReturnAccessTokenProviderFromConnectionInstance()
+        {
+            var config = new ConfigurationRoot(
+            [
+                new MemoryConfigurationProvider(new MemoryConfigurationSource
+                {
+                    InitialData = new Dictionary<string, string>
+                    {
+                        { "ConnectionsMap:0:ServiceUrl", "serviceUrl" },
+                        { "ConnectionsMap:0:Connection", "BotServiceConnection" },
+                        { "Connections:BotServiceConnection:Type", "MsalAuth" },
+                        { "Connections:BotServiceConnection:Assembly", "Microsoft.Agents.Authentication.Msal" },
+                        { "Connections:BotServiceConnection:Settings:ClientId", "ClientId" },
+                        { "Connections:BotServiceConnection:Settings:ClientSecret", "ClientSecret" },
+                        { "Connections:BotServiceConnection:Settings:AuthorityEndpoint", "AuthorityEndpoint" },
+                    }
+                })
+            ]);
+            var configurationConnections = new ConfigurationConnections(_serviceProvider.Object, config);
+
+            var response = configurationConnections.GetTokenProvider(_identity, "serviceUrl");
+            
+            //Call a second time to obtain AccessTokenProvider from the Connection instance
+            response = configurationConnections.GetTokenProvider(_identity, "serviceUrl");
+
+            Assert.NotNull(response);
+        }
+
+        [Fact]
+        public void GetTokenProvider_ShouldReturnNullOnNotMatchingServiceUrl()
+        {
+            var config = new ConfigurationRoot(
+            [
+                new MemoryConfigurationProvider(new MemoryConfigurationSource
+                {
+                    InitialData = new Dictionary<string, string>
+                    {
+                        { "ConnectionsMap:0:ServiceUrl", "serviceUrl" },
+                        { "ConnectionsMap:0:Connection", "BotServiceConnection" },
+                        { "Connections:BotServiceConnection:Type", "MsalAuth" },
+                        { "Connections:BotServiceConnection:Assembly", "Microsoft.Agents.Authentication.Msal" },
+                        { "Connections:BotServiceConnection:Settings:ClientId", "ClientId" },
+                        { "Connections:BotServiceConnection:Settings:ClientSecret", "ClientSecret" },
+                        { "Connections:BotServiceConnection:Settings:AuthorityEndpoint", "AuthorityEndpoint" },
+                    }
+                })
+            ]);
+            var configurationConnections = new ConfigurationConnections(_serviceProvider.Object, config);
+
+            var response = configurationConnections.GetTokenProvider(_identity, "noUrl");
+
+            Assert.Null(response);
+        }
+
+        [Fact]
+        public void GetTokenProvider_ShouldReturnNullOnEmptyConnections()
+        {
+            var config = new ConfigurationRoot(
+            [
+                new MemoryConfigurationProvider(new MemoryConfigurationSource
+                {
+                    InitialData = new Dictionary<string, string>
+                    {
+                        { "ConnectionsMap:0:ServiceUrl", "*" },
+                        { "ConnectionsMap:0:Connection", "BotServiceConnection" },
+                        { "ConnectionsMap:0:Audience", "audience" }
+                    }
+                })
+            ]);
+            var configurationConnections = new ConfigurationConnections(_serviceProvider.Object, config);
+            var claims = new List<Claim>
+            {
+                new(AuthenticationConstants.AudienceClaim, "audience"),
+            };
+            ClaimsIdentity identity = new(claims);
+            
+            var response = configurationConnections.GetTokenProvider(identity, "serviceUrl");
+
+            Assert.Null(response);
+        }
+
+        [Fact]
+        public void GetProviderConstructor_ShouldReturnConstructorInfoOnValidProviderType()
+        {
+            var assemblyLoader = new AssemblyLoader(AssemblyLoadContext.Default);
+
+            var response = assemblyLoader.GetProviderConstructor("name", "Microsoft.Agents.Authentication.Msal", "MsalAuth");
+
+            Assert.NotNull(response);
+        }
+
+        [Fact]
+        public void GetProviderConstructor_ShouldReturnConstructorInfoOnNullType()
+        {
+            var assemblyLoader = new AssemblyLoader(AssemblyLoadContext.Default);
+
+            var response = assemblyLoader.GetProviderConstructor("name", "Microsoft.Agents.Authentication.Msal", null);
+
+            Assert.NotNull(response);
+        }
+
+        [Fact]
+        public void GetProviderConstructor_ShouldThrowOnNullLoadContext()
+        {
+            Assert.Throws<ArgumentNullException>(() => new AssemblyLoader(null));
+        }
+
+        [Fact]
+        public void GetProviderConstructor_ShouldThrowOnNullAssemblyName()
+        {
+            var assemblyLoader = new AssemblyLoader(AssemblyLoadContext.Default);
+
+            Assert.Throws<ArgumentNullException>(() => assemblyLoader.GetProviderConstructor("name", null, "type-name"));
+        }
+
+        [Fact]
+        public void GetProviderConstructor_ShouldThrowOnInvalidProviderType()
+        {
+            var assemblyLoader = new AssemblyLoader(AssemblyLoadContext.Default);
+
+            Assert.Throws<InvalidOperationException>(() => assemblyLoader.GetProviderConstructor("name", "Microsoft.Agents.Authentication.Msal", "type"));
+        }
+    }
+}

--- a/src/tests/Microsoft.Agents.Auth.Tests/ConnectionSettingsBaseTests.cs
+++ b/src/tests/Microsoft.Agents.Auth.Tests/ConnectionSettingsBaseTests.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Agents.Authentication;
+using Microsoft.Extensions.Configuration;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Microsoft.Agents.Auth.Tests
+{
+    public class ConnectionSettingsBaseTests
+    {
+        private const string ClientId = "client-id";
+        private const string AuthorityEndpoint = "https://botframework/test.com";
+        private const string TenantId = "tenant-id";
+        private static readonly List<string> _scopes = ["scope1", "scope2"];
+
+        [Fact]
+        public void Constructor_ShouldSetPropertiesWithDefaults()
+        {
+
+            Dictionary<string, string> configSettings = new()
+            {
+                { "Connections:Settings:Other", "other" }
+            };
+
+            IConfiguration configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(configSettings)
+                .Build();
+
+            var settings = new TestConnectionSettings(configuration.GetSection("Connections:Settings"));
+
+            Assert.Null(settings.ClientId);
+            Assert.Null(settings.Authority);
+            Assert.Null(settings.TenantId);
+            Assert.Null(settings.Scopes);
+        }
+
+        [Fact]
+        public void Constructor_ShouldCorrectlySetProperties()
+        {
+            Dictionary<string, string> configSettings = new()
+            {
+                { "Connections:Settings:ClientId", ClientId },
+                { "Connections:Settings:AuthorityEndpoint", AuthorityEndpoint },
+                { "Connections:Settings:TenantId", TenantId },
+                { "Connections:Settings:Scopes:0", _scopes[0] },
+                { "Connections:Settings:Scopes:1", _scopes[1] }
+            };
+
+            IConfiguration configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(configSettings)
+                .Build();
+
+            var settings = new TestConnectionSettings(configuration.GetSection("Connections:Settings"));
+
+            Assert.Equal(ClientId, settings.ClientId);
+            Assert.Equal(AuthorityEndpoint, settings.Authority);
+            Assert.Equal(TenantId, settings.TenantId);
+            Assert.Equal(_scopes[0], settings.Scopes[0]);
+            Assert.Equal(_scopes[1], settings.Scopes[1]);
+        }
+
+        [Fact]
+        public void Constructor_ShouldThrowOnNullConfig()
+        {
+            Assert.Throws<ArgumentNullException>(() => new TestConnectionSettings(null));
+        }
+
+        [Fact]
+        public void Constructor_ShouldThrowOnNoConfigSection()
+        {
+            IConfiguration configuration = new ConfigurationBuilder()
+                .Build();
+
+           Assert.Throws<ArgumentException>(() => new TestConnectionSettings(configuration.GetSection("EmptySection")));
+        }
+
+        private class TestConnectionSettings(IConfigurationSection configurationSection) : ConnectionSettingsBase(configurationSection)
+        {
+        }
+    }
+}

--- a/src/tests/Microsoft.Agents.Auth.Tests/Microsoft.Agents.Auth.Tests.csproj
+++ b/src/tests/Microsoft.Agents.Auth.Tests/Microsoft.Agents.Auth.Tests.csproj
@@ -9,6 +9,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="Moq" />
 		<PackageReference Include="xunit" />
 		<PackageReference Include="xunit.runner.visualstudio" />
 		<PackageReference Include="coverlet.collector" />

--- a/src/tests/Microsoft.Agents.Auth.Tests/SetupServiceCollection.cs
+++ b/src/tests/Microsoft.Agents.Auth.Tests/SetupServiceCollection.cs
@@ -1,13 +1,13 @@
-﻿using Microsoft.Agents.Authentication.Msal;
-using Microsoft.Agents.Authentication.Msal.Model;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Agents.Authentication.Msal;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-using System.Net.Http;
 using Xunit.Abstractions;
 
-namespace Microsoft.CopilotStudio.Connector.Tests
+namespace Microsoft.Agents.Auth.Tests
 {
     internal class SetupServiceCollection
     {

--- a/src/tests/Microsoft.Agents.Auth.Tests/SkippableConnectionTestAttribute.cs
+++ b/src/tests/Microsoft.Agents.Auth.Tests/SkippableConnectionTestAttribute.cs
@@ -1,11 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using Xunit;
 
-namespace Microsoft.CopilotStudio.Connector.Tests
+namespace Microsoft.Agents.Auth.Tests
 {
     public class SkippableConnectionTestAttribute : FactAttribute
     {

--- a/src/tests/Microsoft.Agents.Auth.Tests/TraceConsoleLoggingProvider.cs
+++ b/src/tests/Microsoft.Agents.Auth.Tests/TraceConsoleLoggingProvider.cs
@@ -1,9 +1,12 @@
-﻿using Microsoft.Extensions.Logging;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Concurrent;
 using Xunit.Abstractions;
 
-namespace Microsoft.CopilotStudio.Connector.Tests
+namespace Microsoft.Agents.Auth.Tests
 {
     public class TraceConsoleLoggingProvider : ILoggerProvider
     {


### PR DESCRIPTION
## Description

This PR creates unit tests to increase the code coverage in the classes of **_Microsoft.Agents.Authentication_**.

## Detailed Changes
- Added _ConfigurationConnections_ and _ConnectionSettingsBaseTests.cs_ files.
- Added AssemblyInfo file granting access for internal classes to **_Microsoft.Agents.Auth.Tests_**.
- Added new unit tests to cover the missing methods and cases of the **_Microsoft.Agents.Authentication_** classes.
- Added missing headers and fixed namespaces in the test classes.

## Testing
The following image shows the current coverage of this namespace.
![image](https://github.com/user-attachments/assets/54b2c5cc-c7c6-41f1-81c9-7c3b0205f57c)