### PR TITLE
Allow nullable prompt in BeginFlowAsync method

### DIFF
--- a/src/libraries/BotBuilder/Microsoft.Agents.BotBuilder/OAuthFlow.cs
+++ b/src/libraries/BotBuilder/Microsoft.Agents.BotBuilder/OAuthFlow.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Agents.BotBuilder
         public int? Timeout { get; init; } = timeout;
         public bool? ShowSignInLink { get; init; } = showSignInLink;
 
-        public virtual async Task<TokenResponse> BeginFlowAsync(ITurnContext turnContext, IActivity prompt, CancellationToken cancellationToken = default)
+        public virtual async Task<TokenResponse> BeginFlowAsync(ITurnContext turnContext, IActivity? prompt, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(turnContext);
 


### PR DESCRIPTION
Updated the method signature for `BeginFlowAsync` in `OAuthFlow.cs` to accept a nullable `IActivity` parameter. This change enables the `prompt` argument to be null, enhancing flexibility in the method's usage.

Null activity is caught at a lower level in some conditions, but not all,  thus allow for a null activity or not passing activity when not needed. 