### PR TITLE
Fixed async CloudAdapter making IBot a singleton

### DIFF
--- a/src/libraries/Hosting/AspNetCore/BackgroundActivityService/ActivityTaskQueue.cs
+++ b/src/libraries/Hosting/AspNetCore/BackgroundActivityService/ActivityTaskQueue.cs
@@ -25,15 +25,16 @@ namespace Microsoft.Agents.Hosting.AspNetCore.BackgroundQueue
         /// It is assumed these Claims have been authenticated via JwtTokenValidation.AuthenticateRequest 
         /// before enqueueing.
         /// </remarks>
+        /// <param name="bot"></param>
         /// <param name="claimsIdentity">Authenticated <see cref="ClaimsIdentity"/> used to process the 
         /// activity.</param>
         /// <param name="activity"><see cref="Activity"/> to be processed.</param>
-        public void QueueBackgroundActivity(ClaimsIdentity claimsIdentity, Activity activity)
+        public void QueueBackgroundActivity(ClaimsIdentity claimsIdentity, Activity activity, Type bot = null)
         {
             ArgumentNullException.ThrowIfNull(claimsIdentity);
             ArgumentNullException.ThrowIfNull(activity);
 
-            _activities.Enqueue(new ActivityWithClaims { ClaimsIdentity = claimsIdentity, Activity = activity});
+            _activities.Enqueue(new ActivityWithClaims { BotType = bot, ClaimsIdentity = claimsIdentity, Activity = activity});
             _signal.Release();
         }
 

--- a/src/libraries/Hosting/AspNetCore/BackgroundActivityService/ActivityWithClaims.cs
+++ b/src/libraries/Hosting/AspNetCore/BackgroundActivityService/ActivityWithClaims.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 //
 using Microsoft.Agents.Core.Models;
+using System;
 using System.Security.Claims;
 
 namespace Microsoft.Agents.Hosting.AspNetCore.BackgroundQueue
@@ -11,6 +12,11 @@ namespace Microsoft.Agents.Hosting.AspNetCore.BackgroundQueue
     /// </summary>
     public class ActivityWithClaims
     {
+        /// <summary>
+        /// Optional: Defaults to IBot
+        /// </summary>
+        public Type BotType { get; set; }
+
         /// <summary>
         /// <see cref="ClaimsIdentity"/> retrieved from a call to authentication.
         /// </summary>

--- a/src/libraries/Hosting/AspNetCore/BackgroundActivityService/IActivityTaskQueue.cs
+++ b/src/libraries/Hosting/AspNetCore/BackgroundActivityService/IActivityTaskQueue.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 //
 using Microsoft.Agents.Core.Models;
+using System;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
@@ -21,7 +22,8 @@ namespace Microsoft.Agents.Hosting.AspNetCore.BackgroundQueue
         /// <param name="claimsIdentity">Authenticated <see cref="ClaimsIdentity"/> used to process the 
         /// activity.</param>
         /// <param name="activity"><see cref="Activity"/> to be processed.</param>
-        void QueueBackgroundActivity(ClaimsIdentity claimsIdentity, Activity activity);
+        /// <param name="bot"></param>
+        void QueueBackgroundActivity(ClaimsIdentity claimsIdentity, Activity activity, Type bot = null);
 
         /// <summary>
         /// Wait for a signal of an enqueued Activity with Claims to be processed.

--- a/src/samples/SemanticKernel/WeatherBot/Agents/WeatherForecastAgent.cs
+++ b/src/samples/SemanticKernel/WeatherBot/Agents/WeatherForecastAgent.cs
@@ -9,13 +9,14 @@ using System.Threading.Tasks;
 using Microsoft.SemanticKernel.ChatCompletion;
 using System.Text;
 using System.Text.Json;
+using Microsoft.Agents.State;
+using System;
 
 namespace WeatherBot.Agents
 {
     public class WeatherForecastAgent
     {
         private readonly Kernel _kernel;
-        private readonly ChatHistory _chatHistory;
         private readonly ChatCompletionAgent _agent;
         private int retryCount;
 
@@ -40,7 +41,6 @@ namespace WeatherBot.Agents
         public WeatherForecastAgent(Kernel kernel)
         {
             this._kernel = kernel;
-            this._chatHistory = [];
 
             // Define the agent
             this._agent =
@@ -67,15 +67,17 @@ namespace WeatherBot.Agents
         /// </summary>
         /// <param name="input">A message to process.</param>
         /// <returns>An instance of <see cref="WeatherForecastAgentResponse"/></returns>
-        public async Task<WeatherForecastAgentResponse> InvokeAgentAsync(string input)
+        public async Task<WeatherForecastAgentResponse> InvokeAgentAsync(string input, ChatHistory chatHistory)
         {
+            ArgumentNullException.ThrowIfNull(chatHistory);
+
             ChatMessageContent message = new(AuthorRole.User, input);
-            this._chatHistory.Add(message);
+            chatHistory.Add(message);
 
             StringBuilder sb = new();
-            await foreach (ChatMessageContent response in this._agent.InvokeAsync(this._chatHistory))
+            await foreach (ChatMessageContent response in this._agent.InvokeAsync(chatHistory))
             {
-                this._chatHistory.Add(response);
+                chatHistory.Add(response);
                 sb.Append(response.Content);
             }
 
@@ -97,7 +99,7 @@ namespace WeatherBot.Agents
 
                 // Try again, providing corrective feedback to the model so that it can correct its mistake
                 this.retryCount++;
-                return await InvokeAgentAsync($"That response did not match the expected format. Please try again. Error: {je.Message}");
+                return await InvokeAgentAsync($"That response did not match the expected format. Please try again. Error: {je.Message}", chatHistory);
             }
         }
     }

--- a/src/samples/SemanticKernel/WeatherBot/MyBot.cs
+++ b/src/samples/SemanticKernel/WeatherBot/MyBot.cs
@@ -2,9 +2,10 @@
 // Licensed under the MIT License.
 
 using Microsoft.Agents.BotBuilder;
-using Microsoft.Agents.Core;
 using Microsoft.Agents.Core.Interfaces;
 using Microsoft.Agents.Core.Models;
+using Microsoft.Agents.State;
+using Microsoft.SemanticKernel.ChatCompletion;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -16,16 +17,19 @@ namespace WeatherBot
     public class MyBot : ActivityHandler
     {
         private readonly WeatherForecastAgent _weatherAgent;
+        private readonly ConversationState _conversationState;
+        private ChatHistory _chatHistory;
 
-        public MyBot(WeatherForecastAgent weatherAgent)
+        public MyBot(WeatherForecastAgent weatherAgent, ConversationState conversationState)
         {
-            this._weatherAgent = weatherAgent;
+            _weatherAgent = weatherAgent;
+            _conversationState = conversationState;
         }
 
         protected override async Task OnMessageActivityAsync(ITurnContext<IMessageActivity> turnContext, CancellationToken cancellationToken)
         {
             // Invoke the WeatherForecastAgent to process the message
-            var forecastResponse = await _weatherAgent.InvokeAgentAsync(turnContext.Activity.Text);
+            var forecastResponse = await _weatherAgent.InvokeAgentAsync(turnContext.Activity.Text, _chatHistory);
             if (forecastResponse == null)
             {
                 await turnContext.SendActivityAsync(MessageFactory.Text("Sorry, I couldn't get the weather forecast at the moment."), cancellationToken);
@@ -56,6 +60,17 @@ namespace WeatherBot
 
             // Send the response message back to the user. 
             await turnContext.SendActivityAsync(message, cancellationToken);
+        }
+
+        protected override async Task OnTurnBeginAsync(ITurnContext turnContext, CancellationToken cancellationToken = default)
+        {
+            await _conversationState.LoadAsync(turnContext, cancellationToken: cancellationToken);
+            _chatHistory = await _conversationState.GetPropertyAsync(turnContext, "chatHistory", () => new ChatHistory(), cancellationToken: cancellationToken);
+        }
+
+        protected override async Task OnTurnEndAsync(ITurnContext turnContext, CancellationToken cancellationToken = default)
+        {
+            await _conversationState.SaveChangesAsync(turnContext, cancellationToken: cancellationToken);
         }
     }
 }

--- a/src/samples/SemanticKernel/WeatherBot/Program.cs
+++ b/src/samples/SemanticKernel/WeatherBot/Program.cs
@@ -8,10 +8,11 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.SemanticKernel;
 using Microsoft.Extensions.Configuration;
 using WeatherBot.Agents;
-using Microsoft.Identity.Client.Platforms.Features.DesktopOs.Kerberos;
 using Azure.Identity;
 using Microsoft.Agents.Hosting.AspNetCore;
 using Microsoft.Agents.Samples;
+using Microsoft.Agents.Storage;
+using Microsoft.Agents.State;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -55,6 +56,9 @@ builder.Services.AddBotAspNetAuthentication(builder.Configuration);
 
 // Add basic bot functionality
 builder.AddBot<MyBot>();
+
+builder.Services.AddSingleton<IStorage>(new MemoryStorage());
+builder.Services.AddSingleton<ConversationState>();
 
 var app = builder.Build();
 

--- a/src/tests/Microsoft.Agents.Hosting.AspNetCore/BackgroundActivityService/HostedActivityServiceTests.cs
+++ b/src/tests/Microsoft.Agents.Hosting.AspNetCore/BackgroundActivityService/HostedActivityServiceTests.cs
@@ -25,19 +25,20 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests.BackgroundActivityService
             var adapter = new TestAdapter();
             var queue = new ActivityTaskQueue();
             var logger = new Mock<ILogger<HostedActivityService>>();
+            var sp = new Mock<IServiceProvider>();
 
-            Assert.Throws<ArgumentNullException>(() => new HostedActivityService(null, bot, adapter, queue, logger.Object));
+            Assert.Throws<ArgumentNullException>(() => new HostedActivityService(sp.Object, null, adapter, queue, logger.Object));
         }
 
         [Fact]
-        public void Constructor_ShouldThrowWithNullBot()
+        public void Constructor_ShouldThrowWithNullServiceProvider()
         {
             var config = new ConfigurationBuilder().Build();
             var adapter = new TestAdapter();
             var queue = new ActivityTaskQueue();
             var logger = new Mock<ILogger<HostedActivityService>>();
 
-            Assert.Throws<ArgumentNullException>(() => new HostedActivityService(config, null, adapter, queue, logger.Object));
+            Assert.Throws<ArgumentNullException>(() => new HostedActivityService(null, config, adapter, queue, logger.Object));
         }
 
         [Fact]
@@ -47,8 +48,9 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests.BackgroundActivityService
             var bot = new ActivityHandler();
             var queue = new ActivityTaskQueue();
             var logger = new Mock<ILogger<HostedActivityService>>();
+            var sp = new Mock<IServiceProvider>();
 
-            Assert.Throws<ArgumentNullException>(() => new HostedActivityService(config, bot, null, queue, logger.Object));
+            Assert.Throws<ArgumentNullException>(() => new HostedActivityService(sp.Object, config, null, queue, logger.Object));
         }
 
         [Fact]
@@ -58,8 +60,9 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests.BackgroundActivityService
             var bot = new ActivityHandler();
             var adapter = new TestAdapter();
             var logger = new Mock<ILogger<HostedActivityService>>();
+            var sp = new Mock<IServiceProvider>();
 
-            Assert.Throws<ArgumentNullException>(() => new HostedActivityService(config, bot, adapter, null, logger.Object));
+            Assert.Throws<ArgumentNullException>(() => new HostedActivityService(sp.Object, config, adapter, null, logger.Object));
         }
 
         [Fact]
@@ -69,10 +72,11 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests.BackgroundActivityService
             var bot = new ActivityHandler();
             var adapter = new TestAdapter();
             var queue = new ActivityTaskQueue();
+            var sp = new Mock<IServiceProvider>();
 
             try
             {
-                var service = new HostedActivityService(config, bot, adapter, queue, null);
+                var service = new HostedActivityService(sp.Object, config, adapter, queue, null);
                 await service.StopAsync(CancellationToken.None);
             }
             catch (Exception)
@@ -154,8 +158,9 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests.BackgroundActivityService
             var bot = new Mock<ActivityHandler>();
             var adapter = new Mock<IChannelAdapter>();
             var logger = new Mock<ILogger<HostedActivityService>>();
+            var sp = new Mock<IServiceProvider>();
 
-            var service = new HostedActivityService(config, bot.Object, adapter.Object, queue, logger.Object);
+            var service = new HostedActivityService(sp.Object, config, adapter.Object, queue, logger.Object);
             return new(service, queue, bot, adapter, logger);
         }
 

--- a/src/tests/Microsoft.Agents.Hosting.AspNetCore/CloudAdapterTests.cs
+++ b/src/tests/Microsoft.Agents.Hosting.AspNetCore/CloudAdapterTests.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
             var context = CreateHttpContext(new(ActivityTypes.Message, conversation: new(id: "test")));
             var bot = new ActivityHandler();
 
-            record.Queue.Setup(e => e.QueueBackgroundActivity(It.IsAny<ClaimsIdentity>(), It.IsAny<Activity>()))
+            record.Queue.Setup(e => e.QueueBackgroundActivity(It.IsAny<ClaimsIdentity>(), It.IsAny<Activity>(), It.IsAny<Type>()))
                 .Throws(new UnauthorizedAccessException())
                 .Verifiable(Times.Once);
 
@@ -154,7 +154,7 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
             var context = CreateHttpContext(new(ActivityTypes.Message, conversation: new(id: "test")));
             var bot = new ActivityHandler();
 
-            record.Queue.Setup(e => e.QueueBackgroundActivity(It.IsAny<ClaimsIdentity>(), It.IsAny<Activity>()))
+            record.Queue.Setup(e => e.QueueBackgroundActivity(It.IsAny<ClaimsIdentity>(), It.IsAny<Activity>(), It.IsAny<Type>()))
                 .Verifiable(Times.Once);
 
             await record.Adapter.ProcessAsync(context.Request, context.Response, bot, CancellationToken.None);


### PR DESCRIPTION
Fixed #108 

Two issues that may require revisiting this:
- This means `IBot` is getting created twice per turn.  Once by the controller, then again by the queue.
- The `IBot` instantiated by the queue will get garbage collected.  Eventually.  But perhaps `IDisposable` is a better route.