### PR TITLE
Fix typo in readme for the semantic kernel weather bot sample

### DIFF
--- a/src/samples/SemanticKernel/WeatherBot/README.md
+++ b/src/samples/SemanticKernel/WeatherBot/README.md
@@ -1,6 +1,6 @@
 ﻿# WeatherBot Sample with Semantic Kernel
 
-This is a sample of a simple Weather Forecast Agent that is hosted on an Asp.net core web service.  This Agent is configured to accept a request asking for information about a wheather forecast and respond to the caller with an Adaptive Card.
+This is a sample of a simple Weather Forecast Agent that is hosted on an Asp.net core web service.  This Agent is configured to accept a request asking for information about a weather forecast and respond to the caller with an Adaptive Card.
 
 This Agent Sample is intended to introduce you the basics of integrating Semantic Kernel with the Microsoft 365 Agents SDK in order to build powerful Agents. It can also be used as a the base for a custom Agent that you choose to develop.
 


### PR DESCRIPTION
It said "wheather" instead of "weather"