### PR TITLE
Update Nuget feed info for Nuget Nightly feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ We are in preview with this codebase right now.
 The best way to consume this SDK is via our Nuget packages found here: [nuget.org](https://www.nuget.org/profiles/nugetbotbuilder). They will all begin with **Microsoft.Agents**
 
 ### Nightly Nuget feed.
-We also provide nightly build packages via a public Nuget feed here: [AgentSdkNightly](https://pkgs.dev.azure.com/ConversationalAI/BotFramework/_packaging/SDK/nuget/v3/index.json).  They will all begin with **Microsoft.Agents**
+**Updated March 11 2025** :  Nightly Feed has been shifted to public [nuget.org](https://www.nuget.org/profiles/nugetbotbuilder). They will all begin with **Microsoft.Agents**  and have a version number that ends with **-alpha.**
 - This feed is updated overnight (PT) whenever commits occur in our repo. 
 - This feed's packages will be much more up to date with the current repo, however, packages provided on this feed are not necessary stable.
 


### PR DESCRIPTION
This pull request includes an update to the `README.md` file to reflect changes in the nightly Nuget feed location.

Documentation update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L28-R28): Updated the nightly Nuget feed information to indicate that it has been shifted to the public `nuget.org` and clarified that the version numbers will end with **-alpha**.