### PR TITLE
Removed OnTurn Before/After from RouteAttribute (potentially confusing)

### DIFF
--- a/src/libraries/BotBuilder/Microsoft.Agents.BotBuilder/App/RouteAttribute.cs
+++ b/src/libraries/BotBuilder/Microsoft.Agents.BotBuilder/App/RouteAttribute.cs
@@ -13,8 +13,6 @@ namespace Microsoft.Agents.BotBuilder.App
         Activity,
         Message,
         Conversation,
-        BeforeTurn,
-        AfterTurn,
         HandOff,
         ReactionAdded,
         ReactionRemoved
@@ -28,8 +26,6 @@ namespace Microsoft.Agents.BotBuilder.App
     ///    Activity,       // { ActivityType | RegEx | Selector}, Rank
     ///    Message,        // { ActivityText | RegEx | Selector}, Rank
     ///    Conversation,   // { Event | Selector}, Rank
-    ///    BeforeTurn,     // order added/defined
-    ///    AfterTurn,      // order added/defined
     ///    HandOff,        // Selector, Rank
     ///    ReactionAdded,  // Rank
     ///    ReactionRemoved // Rank
@@ -133,16 +129,6 @@ namespace Microsoft.Agents.BotBuilder.App
             {
                 CreateHandlerDelegate<HandoffHandler>(app, attributedMethod, out var delegateHandler);
                 app.OnHandoff(delegateHandler, rank: Rank);
-            }
-            else if (Type == RouteType.BeforeTurn)
-            {
-                CreateHandlerDelegate<TurnEventHandler>(app, attributedMethod, out var delegateHandler);
-                app.OnBeforeTurn(delegateHandler);
-            }
-            else if (Type == RouteType.AfterTurn)
-            {
-                CreateHandlerDelegate<TurnEventHandler>(app, attributedMethod, out var delegateHandler);
-                app.OnAfterTurn(delegateHandler);
             }
         }
 


### PR DESCRIPTION
Using RouteAttribute for OnBeforeTurn/OnAfterTurn is potentially confusing.  These are ALWAYS executed in the order they are added (no ranking).  With RouteAttribute, the order would be in the order the methods are defined.  To change the order means changing the order of method definition.  Not super clear.