### PR TITLE
MultiAgentHost POC

### DIFF
--- a/src/Microsoft.Agents.SDK.sln
+++ b/src/Microsoft.Agents.SDK.sln
@@ -122,6 +122,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DialogSkillBot", "samples\C
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Agents.Authentication.Tests", "tests\Microsoft.Agents.Authentication.Tests\Microsoft.Agents.Authentication.Tests.csproj", "{2D522479-7808-6236-5B86-F9653C2F2D0A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MultiAgentHost", "samples\test-bots\MultiAgentHost\MultiAgentHost.csproj", "{7994CBC3-7886-887B-835B-3CEB6D57987F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -296,6 +298,10 @@ Global
 		{2D522479-7808-6236-5B86-F9653C2F2D0A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2D522479-7808-6236-5B86-F9653C2F2D0A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2D522479-7808-6236-5B86-F9653C2F2D0A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7994CBC3-7886-887B-835B-3CEB6D57987F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7994CBC3-7886-887B-835B-3CEB6D57987F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7994CBC3-7886-887B-835B-3CEB6D57987F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7994CBC3-7886-887B-835B-3CEB6D57987F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -356,6 +362,7 @@ Global
 		{087CEF80-A51A-77C6-227D-7AF40A1E0770} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{AD401416-D318-1F5D-AD79-EEF717EF8155} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{2D522479-7808-6236-5B86-F9653C2F2D0A} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
+		{7994CBC3-7886-887B-835B-3CEB6D57987F} = {674A812C-7287-4883-97F9-697D83750648}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F1E8E538-309A-46F8-9CE7-AEC6589FAE60}

--- a/src/libraries/Hosting/AspNetCore/CloudAdapter.cs
+++ b/src/libraries/Hosting/AspNetCore/CloudAdapter.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Agents.Hosting.AspNetCore
                     else
                     {
                         // Queue the activity to be processed by the ActivityBackgroundService
-                        _activityTaskQueue.QueueBackgroundActivity(claimsIdentity, activity);
+                        _activityTaskQueue.QueueBackgroundActivity(claimsIdentity, activity, agent: agent.GetType());
 
                         // Activity has been queued to process, so return immediately
                         httpResponse.StatusCode = (int)HttpStatusCode.Accepted;

--- a/src/samples/test-bots/MultiAgentHost/Echo1.cs
+++ b/src/samples/test-bots/MultiAgentHost/Echo1.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Agents.Builder;
+using Microsoft.Agents.Builder.App;
+using Microsoft.Agents.Builder.State;
+using Microsoft.Agents.Core.Models;
+using System.Threading.Tasks;
+using System.Threading;
+
+namespace MultiAgentHost;
+
+public class Echo1 : AgentApplication
+{
+    public Echo1(AgentApplicationOptions options) : base(options)
+    {
+        OnConversationUpdate(ConversationUpdateEvents.MembersAdded, WelcomeMessageAsync);
+        OnActivity(ActivityTypes.Message, OnMessageAsync, rank: RouteRank.Last);
+    }
+
+    private async Task WelcomeMessageAsync(ITurnContext turnContext, ITurnState turnState, CancellationToken cancellationToken)
+    {
+        foreach (ChannelAccount member in turnContext.Activity.MembersAdded)
+        {
+            if (member.Id != turnContext.Activity.Recipient.Id)
+            {
+                await turnContext.SendActivityAsync(MessageFactory.Text("Hello and Welcome!"), cancellationToken);
+            }
+        }
+    }
+
+    private async Task OnMessageAsync(ITurnContext turnContext, ITurnState turnState, CancellationToken cancellationToken)
+    {
+        await turnContext.SendActivityAsync($"[{nameof(Echo1)}] you said: {turnContext.Activity.Text}", cancellationToken: cancellationToken);
+    }
+}

--- a/src/samples/test-bots/MultiAgentHost/Echo2.cs
+++ b/src/samples/test-bots/MultiAgentHost/Echo2.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Agents.Builder;
+using Microsoft.Agents.Builder.App;
+using Microsoft.Agents.Builder.State;
+using Microsoft.Agents.Core.Models;
+using System.Threading.Tasks;
+using System.Threading;
+
+namespace MultiAgentHost;
+
+public class Echo2 : AgentApplication
+{
+    public Echo2(AgentApplicationOptions options) : base(options)
+    {
+        OnConversationUpdate(ConversationUpdateEvents.MembersAdded, WelcomeMessageAsync);
+        OnActivity(ActivityTypes.Message, OnMessageAsync, rank: RouteRank.Last);
+    }
+
+    private async Task WelcomeMessageAsync(ITurnContext turnContext, ITurnState turnState, CancellationToken cancellationToken)
+    {
+        foreach (ChannelAccount member in turnContext.Activity.MembersAdded)
+        {
+            if (member.Id != turnContext.Activity.Recipient.Id)
+            {
+                await turnContext.SendActivityAsync(MessageFactory.Text("Hello and Welcome!"), cancellationToken);
+            }
+        }
+    }
+
+    private async Task OnMessageAsync(ITurnContext turnContext, ITurnState turnState, CancellationToken cancellationToken)
+    {
+        await turnContext.SendActivityAsync($"[{nameof(Echo2)}] you said: {turnContext.Activity.Text}", cancellationToken: cancellationToken);
+    }
+}

--- a/src/samples/test-bots/MultiAgentHost/MultiAgentHost.csproj
+++ b/src/samples/test-bots/MultiAgentHost/MultiAgentHost.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<LangVersion>latest</LangVersion>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\..\libraries\Authentication\Authentication.Msal\Microsoft.Agents.Authentication.Msal.csproj" />
+		<ProjectReference Include="..\..\..\libraries\Hosting\AspNetCore\Microsoft.Agents.Hosting.AspNetCore.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Content Update="appManifest\teams-manifest.json">
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		  <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+		  <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+		</Content>
+		<Content Update="appsettings.Development.json">
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		  <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+		  <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+		</Content>
+		<Content Update="appsettings.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+			<ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+			<CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+		</Content>
+	</ItemGroup>
+</Project>

--- a/src/samples/test-bots/MultiAgentHost/Program.cs
+++ b/src/samples/test-bots/MultiAgentHost/Program.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Agents.Builder.App;
+using Microsoft.Agents.Hosting.AspNetCore;
+using Microsoft.Agents.Samples;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System.Threading;
+using Microsoft.Agents.Storage;
+using MultiAgentHost;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+builder.Services.AddHttpClient();
+
+builder.Logging.AddConsole();
+builder.Logging.AddDebug();
+
+
+// Register IStorage.  For development, MemoryStorage is suitable.
+// For production Agents, persisted storage should be used so
+// that state survives Agent restarts, and operate correctly
+// in a cluster of Agent instances.
+builder.Services.AddSingleton<IStorage, MemoryStorage>();
+
+// This adds the "core" Agent services: ICollections, CloudAdapter, and IChannelServiceClientFactory
+builder.AddAgentCore();
+
+// For this sample, both Agents will use the same config.
+builder.AddAgentApplicationOptions();
+
+// Add the first Agent
+builder.Services.AddTransient<Echo1>();
+
+// Add the second Agent
+builder.Services.AddTransient<Echo2>();
+
+// Configure the HTTP request pipeline.
+
+// Add AspNet token validation
+builder.Services.AddAgentAspNetAuthentication(builder.Configuration);
+
+var app = builder.Build();
+
+app.UseRouting();
+app.UseAuthentication();
+app.UseAuthorization();
+
+// Route to first agent
+var route1 = app.MapPost(
+    "/agent1/api/messages",
+    async (HttpRequest request, HttpResponse response, IAgentHttpAdapter adapter, Echo1 agent, CancellationToken cancellationToken) =>
+    {
+        await adapter.ProcessAsync(request, response, agent, cancellationToken);
+    })
+    .RequireAuthorization(new AuthorizeAttribute("AllowedCallers"));
+
+// Route to second agent
+var route2 = app.MapPost(
+    "/agent2/api/messages",
+    async (HttpRequest request, HttpResponse response, IAgentHttpAdapter adapter, Echo2 agent, CancellationToken cancellationToken) =>
+    {
+        await adapter.ProcessAsync(request, response, agent, cancellationToken);
+    })
+    .RequireAuthorization(new AuthorizeAttribute("AllowedCallers"));
+
+// Setup port and listening address.
+
+if (app.Environment.IsDevelopment())
+{
+    route1.AllowAnonymous();
+    route2.AllowAnonymous();
+    var port = args.Length > 0 ? args[0] : "3978";
+    app.Urls.Add($"http://localhost:{port}");
+}
+
+// Start listening. 
+await app.RunAsync();

--- a/src/samples/test-bots/MultiAgentHost/appsettings.json
+++ b/src/samples/test-bots/MultiAgentHost/appsettings.json
@@ -1,0 +1,53 @@
+{
+  "TokenValidation": {
+    "Audiences": [
+      "{{Agent1ClientId}}",
+      "{{Agent2ClientId}}"
+    ],
+    "TenantId": "{{TenantId}}"
+  },
+
+  "Connections": {
+    "Agent1ServiceConnection": {
+      "Settings": {
+        "AuthType": "ClientSecret", // this is the AuthType for the connection, valid values can be found in Microsoft.Agents.Authentication.Msal.Model.AuthTypes.  The default is ClientSecret.
+        "AuthorityEndpoint": "https://login.microsoftonline.com/{{TenantId}}",
+        "ClientId": "{{Agent1ClientId}}", // this is the Client ID used for the Azure Bot
+        "ClientSecret": "00000000-0000-0000-0000-000000000000", // this is the Client Secret used for the connection.
+        "Scopes": [
+          "https://api.botframework.com/.default"
+        ]
+      }
+    },
+    "Agent2ServiceConnection": {
+      "Settings": {
+        "AuthType": "ClientSecret", // this is the AuthType for the connection, valid values can be found in Microsoft.Agents.Authentication.Msal.Model.AuthTypes.  The default is ClientSecret.
+        "AuthorityEndpoint": "https://login.microsoftonline.com/{{TenantId}}",
+        "ClientId": "{{Agent2ServiceConnection}}", // this is the Client ID used for the Azure Bot
+        "ClientSecret": "00000000-0000-0000-0000-000000000000", // this is the Client Secret used for the connection.
+        "Scopes": [
+          "https://api.botframework.com/.default"
+        ]
+      }
+    }
+  },
+  "ConnectionsMap": [
+    {
+      "Audience": "{{Agent1ClientId}}",
+      "Connection": "Agent1ServiceConnection"
+    },
+    {
+      "Audience": "{{Agent2ClientId}}",
+      "Connection": "Agent2ServiceConnection"
+    }
+  ],
+
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.Agents": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}


### PR DESCRIPTION
This sample demonstrates a POC for a single AspNet host with multiple Agents: Echo1 and Echo2.

See `samples/test-bots/MultiAgentHost`

- Echo1 and Echo2 each have an individual Azure Bot and App Registration.
- Echo1 Messaging Endpoint:  {{host}}/agent1/api/messages
- Echo2 Messaging Endpoint:  {{host}}/agent2/api/messages
- Both are just Echo, and nothing different/unusual going on there.

## This handles:
- JWT token authentication for each (see appsettings "TokenValidation")
- Two token provider connections (see appsettings "Connections")
  - The do not need to be the same.  In my test one was multitenant, and the other single.
- ConnectionMap routes to token provider based on audience (see appsettings "ConnectionMap")

## Issues:
1) For ease of use, exposed `Microsoft.Agents.Hosting.AspNetCore.ServiceCollectionExtensions.AddAgentCore`
2) I wanted to use keyed services instead of the way the sample uses.  This won't currently work but could.
    - This is related to the CloudAdapter using a queue, and the `IAgent` needs to be fetched from `ServiceProvider` due to DI scoping.  And with keyed services, we just don't have the information to do that.  This entire process needs more attention.
    - This also means the `AddTransient(Func)` variation could not be used, requiring a subclass of each Agent instead (the queue doesn't know which to get again).