### PR TITLE
Rename OnBotMessage to OnAgentsMessage

### DIFF
--- a/src/libraries/Extensions/Microsoft.Agents.Extensions.Teams/App/MessageExtensions/MessageExtension.cs
+++ b/src/libraries/Extensions/Microsoft.Agents.Extensions.Teams/App/MessageExtensions/MessageExtension.cs
@@ -162,12 +162,12 @@ namespace Microsoft.Agents.Extensions.Teams.App.MessageExtensions
         /// <param name="commandId">ID of the command to register the handler for.</param>
         /// <param name="handler">Function to call when the command is received.</param>
         /// <returns>The application instance for chaining purposes.</returns>
-        public AgentApplication OnBotMessagePreviewEdit(string commandId, BotMessagePreviewEditHandlerAsync handler)
+        public AgentApplication OnAgentMessagePreviewEdit(string commandId, BotMessagePreviewEditHandlerAsync handler)
         {
             ArgumentNullException.ThrowIfNull(commandId);
             ArgumentNullException.ThrowIfNull(handler);
             RouteSelector routeSelector = CreateTaskSelector((string input) => string.Equals(commandId, input), SUBMIT_ACTION_INVOKE_NAME, "edit");
-            return OnBotMessagePreviewEdit(routeSelector, handler);
+            return OnAgentMessagePreviewEdit(routeSelector, handler);
         }
 
         /// <summary>
@@ -177,12 +177,12 @@ namespace Microsoft.Agents.Extensions.Teams.App.MessageExtensions
         /// <param name="commandIdPattern">Regular expression to match against the ID of the command to register the handler for.</param>
         /// <param name="handler">Function to call when the command is received.</param>
         /// <returns>The application instance for chaining purposes.</returns>
-        public AgentApplication OnBotMessagePreviewEdit(Regex commandIdPattern, BotMessagePreviewEditHandlerAsync handler)
+        public AgentApplication OnAgentMessagePreviewEdit(Regex commandIdPattern, BotMessagePreviewEditHandlerAsync handler)
         {
             ArgumentNullException.ThrowIfNull(commandIdPattern);
             ArgumentNullException.ThrowIfNull(handler);
             RouteSelector routeSelector = CreateTaskSelector((string input) => commandIdPattern.IsMatch(input), SUBMIT_ACTION_INVOKE_NAME, "edit");
-            return OnBotMessagePreviewEdit(routeSelector, handler);
+            return OnAgentMessagePreviewEdit(routeSelector, handler);
         }
 
         /// <summary>
@@ -192,7 +192,7 @@ namespace Microsoft.Agents.Extensions.Teams.App.MessageExtensions
         /// <param name="routeSelector">Function that's used to select a route. The function returning true triggers the route.</param>
         /// <param name="handler">Function to call when the route is triggered.</param>
         /// <returns>The application instance for chaining purposes.</returns>
-        public AgentApplication OnBotMessagePreviewEdit(RouteSelector routeSelector, BotMessagePreviewEditHandlerAsync handler)
+        public AgentApplication OnAgentMessagePreviewEdit(RouteSelector routeSelector, BotMessagePreviewEditHandlerAsync handler)
         {
             RouteHandler routeHandler = async (ITurnContext turnContext, ITurnState turnState, CancellationToken cancellationToken) =>
             {
@@ -202,7 +202,7 @@ namespace Microsoft.Agents.Extensions.Teams.App.MessageExtensions
                     || (messagingExtensionAction = ProtocolJsonSerializer.ToObject<MessagingExtensionAction>(turnContext.Activity.Value)) == null
                     || !string.Equals(messagingExtensionAction.BotMessagePreviewAction, "edit"))
                 {
-                    throw new InvalidOperationException($"Unexpected MessageExtensions.OnBotMessagePreviewEdit() triggered for activity type: {turnContext.Activity.Type}");
+                    throw new InvalidOperationException($"Unexpected MessageExtensions.OnAgentMessagePreviewEdit() triggered for activity type: {turnContext.Activity.Type}");
                 }
 
                 MessagingExtensionActionResponse result = await handler(turnContext, turnState, messagingExtensionAction.BotActivityPreview[0], cancellationToken);
@@ -225,7 +225,7 @@ namespace Microsoft.Agents.Extensions.Teams.App.MessageExtensions
         /// <param name="routeSelectors">Combination of String, Regex, and RouteSelectorAsync selectors.</param>
         /// <param name="handler">Function to call when the route is triggered.</param>
         /// <returns>The application instance for chaining purposes.</returns>
-        public AgentApplication OnBotMessagePreviewEdit(MultipleRouteSelector routeSelectors, BotMessagePreviewEditHandlerAsync handler)
+        public AgentApplication OnAgentMessagePreviewEdit(MultipleRouteSelector routeSelectors, BotMessagePreviewEditHandlerAsync handler)
         {
             ArgumentNullException.ThrowIfNull(routeSelectors);
             ArgumentNullException.ThrowIfNull(handler);
@@ -233,21 +233,21 @@ namespace Microsoft.Agents.Extensions.Teams.App.MessageExtensions
             {
                 foreach (string commandId in routeSelectors.Strings)
                 {
-                    OnBotMessagePreviewEdit(commandId, handler);
+                    OnAgentMessagePreviewEdit(commandId, handler);
                 }
             }
             if (routeSelectors.Regexes != null)
             {
                 foreach (Regex commandIdPattern in routeSelectors.Regexes)
                 {
-                    OnBotMessagePreviewEdit(commandIdPattern, handler);
+                    OnAgentMessagePreviewEdit(commandIdPattern, handler);
                 }
             }
             if (routeSelectors.RouteSelectors != null)
             {
                 foreach (RouteSelector routeSelector in routeSelectors.RouteSelectors)
                 {
-                    OnBotMessagePreviewEdit(routeSelector, handler);
+                    OnAgentMessagePreviewEdit(routeSelector, handler);
                 }
             }
             return _app;
@@ -260,12 +260,12 @@ namespace Microsoft.Agents.Extensions.Teams.App.MessageExtensions
         /// <param name="commandId">ID of the command to register the handler for.</param>
         /// <param name="handler">Function to call when the command is received.</param>
         /// <returns>The application instance for chaining purposes.</returns>
-        public AgentApplication OnBotMessagePreviewSend(string commandId, BotMessagePreviewSendHandler handler)
+        public AgentApplication OnAgentMessagePreviewSend(string commandId, BotMessagePreviewSendHandler handler)
         {
             ArgumentNullException.ThrowIfNull(commandId);
             ArgumentNullException.ThrowIfNull(handler);
             RouteSelector routeSelector = CreateTaskSelector((string input) => string.Equals(commandId, input), SUBMIT_ACTION_INVOKE_NAME, "send");
-            return OnBotMessagePreviewSend(routeSelector, handler);
+            return OnAgentMessagePreviewSend(routeSelector, handler);
         }
 
         /// <summary>
@@ -275,12 +275,12 @@ namespace Microsoft.Agents.Extensions.Teams.App.MessageExtensions
         /// <param name="commandIdPattern">Regular expression to match against the ID of the command to register the handler for.</param>
         /// <param name="handler">Function to call when the command is received.</param>
         /// <returns>The application instance for chaining purposes.</returns>
-        public AgentApplication OnBotMessagePreviewSend(Regex commandIdPattern, BotMessagePreviewSendHandler handler)
+        public AgentApplication OnAgentMessagePreviewSend(Regex commandIdPattern, BotMessagePreviewSendHandler handler)
         {
             ArgumentNullException.ThrowIfNull(commandIdPattern);
             ArgumentNullException.ThrowIfNull(handler);
             RouteSelector routeSelector = CreateTaskSelector((string input) => commandIdPattern.IsMatch(input), SUBMIT_ACTION_INVOKE_NAME, "send");
-            return OnBotMessagePreviewSend(routeSelector, handler);
+            return OnAgentMessagePreviewSend(routeSelector, handler);
         }
 
         /// <summary>
@@ -290,7 +290,7 @@ namespace Microsoft.Agents.Extensions.Teams.App.MessageExtensions
         /// <param name="routeSelector">Function that's used to select a route. The function returning true triggers the route.</param>
         /// <param name="handler">Function to call when the route is triggered.</param>
         /// <returns>The application instance for chaining purposes.</returns>
-        public AgentApplication OnBotMessagePreviewSend(RouteSelector routeSelector, BotMessagePreviewSendHandler handler)
+        public AgentApplication OnAgentMessagePreviewSend(RouteSelector routeSelector, BotMessagePreviewSendHandler handler)
         {
             ArgumentNullException.ThrowIfNull(routeSelector);
             ArgumentNullException.ThrowIfNull(handler);
@@ -302,7 +302,7 @@ namespace Microsoft.Agents.Extensions.Teams.App.MessageExtensions
                     || (messagingExtensionAction = ProtocolJsonSerializer.ToObject<MessagingExtensionAction>(turnContext.Activity.Value)) == null
                     || !string.Equals(messagingExtensionAction.BotMessagePreviewAction, "send"))
                 {
-                    throw new InvalidOperationException($"Unexpected MessageExtensions.OnBotMessagePreviewSend() triggered for activity type: {turnContext.Activity.Type}");
+                    throw new InvalidOperationException($"Unexpected MessageExtensions.OnAgentMessagePreviewSend() triggered for activity type: {turnContext.Activity.Type}");
                 }
 
                 Activity activityPreview = messagingExtensionAction.BotActivityPreview.Count > 0 ? messagingExtensionAction.BotActivityPreview[0] : new Activity();
@@ -327,7 +327,7 @@ namespace Microsoft.Agents.Extensions.Teams.App.MessageExtensions
         /// <param name="routeSelectors">Combination of String, Regex, and RouteSelectorAsync selectors.</param>
         /// <param name="handler">Function to call when the route is triggered.</param>
         /// <returns>The application instance for chaining purposes.</returns>
-        public AgentApplication OnBotMessagePreviewSend(MultipleRouteSelector routeSelectors, BotMessagePreviewSendHandler handler)
+        public AgentApplication OnAgentMessagePreviewSend(MultipleRouteSelector routeSelectors, BotMessagePreviewSendHandler handler)
         {
             ArgumentNullException.ThrowIfNull(routeSelectors);
             ArgumentNullException.ThrowIfNull(handler);
@@ -335,21 +335,21 @@ namespace Microsoft.Agents.Extensions.Teams.App.MessageExtensions
             {
                 foreach (string commandId in routeSelectors.Strings)
                 {
-                    OnBotMessagePreviewSend(commandId, handler);
+                    OnAgentMessagePreviewSend(commandId, handler);
                 }
             }
             if (routeSelectors.Regexes != null)
             {
                 foreach (Regex commandIdPattern in routeSelectors.Regexes)
                 {
-                    OnBotMessagePreviewSend(commandIdPattern, handler);
+                    OnAgentMessagePreviewSend(commandIdPattern, handler);
                 }
             }
             if (routeSelectors.RouteSelectors != null)
             {
                 foreach (RouteSelector routeSelector in routeSelectors.RouteSelectors)
                 {
-                    OnBotMessagePreviewSend(routeSelector, handler);
+                    OnAgentMessagePreviewSend(routeSelector, handler);
                 }
             }
             return _app;

--- a/src/libraries/Extensions/Microsoft.Agents.Extensions.Teams/Compat/TeamsActivityHandler.cs
+++ b/src/libraries/Extensions/Microsoft.Agents.Extensions.Teams/Compat/TeamsActivityHandler.cs
@@ -297,10 +297,10 @@ namespace Microsoft.Agents.Extensions.Teams.Compat
                 switch (action.BotMessagePreviewAction)
                 {
                     case "edit":
-                        return await OnTeamsMessagingExtensionBotMessagePreviewEditAsync(turnContext, action, cancellationToken).ConfigureAwait(false);
+                        return await OnTeamsMessagingExtensiOnAgentMessagePreviewEditAsync(turnContext, action, cancellationToken).ConfigureAwait(false);
 
                     case "send":
-                        return await OnTeamsMessagingExtensionBotMessagePreviewSendAsync(turnContext, action, cancellationToken).ConfigureAwait(false);
+                        return await OnTeamsMessagingExtensiOnAgentMessagePreviewSendAsync(turnContext, action, cancellationToken).ConfigureAwait(false);
 
                     default:
                         throw new InvokeResponseException(HttpStatusCode.BadRequest, $"{action.BotMessagePreviewAction} is not a supported BotMessagePreviewAction.");
@@ -333,7 +333,7 @@ namespace Microsoft.Agents.Extensions.Teams.Compat
         /// <param name="cancellationToken">A cancellation token that can be used by other objects
         /// or threads to receive notice of cancellation.</param>
         /// <returns>The Messaging Extension Action Response for the action.</returns>
-        protected virtual Task<MessagingExtensionActionResponse> OnTeamsMessagingExtensionBotMessagePreviewEditAsync(ITurnContext<IInvokeActivity> turnContext, MessagingExtensionAction action, CancellationToken cancellationToken)
+        protected virtual Task<MessagingExtensionActionResponse> OnTeamsMessagingExtensiOnAgentMessagePreviewEditAsync(ITurnContext<IInvokeActivity> turnContext, MessagingExtensionAction action, CancellationToken cancellationToken)
         {
             throw new InvokeResponseException(HttpStatusCode.NotImplemented);
         }
@@ -346,7 +346,7 @@ namespace Microsoft.Agents.Extensions.Teams.Compat
         /// <param name="cancellationToken">A cancellation token that can be used by other objects
         /// or threads to receive notice of cancellation.</param>
         /// <returns>The Messaging Extension Action Response for the action.</returns>
-        protected virtual Task<MessagingExtensionActionResponse> OnTeamsMessagingExtensionBotMessagePreviewSendAsync(ITurnContext<IInvokeActivity> turnContext, MessagingExtensionAction action, CancellationToken cancellationToken)
+        protected virtual Task<MessagingExtensionActionResponse> OnTeamsMessagingExtensiOnAgentMessagePreviewSendAsync(ITurnContext<IInvokeActivity> turnContext, MessagingExtensionAction action, CancellationToken cancellationToken)
         {
             throw new InvokeResponseException(HttpStatusCode.NotImplemented);
         }

--- a/src/libraries/Extensions/Microsoft.Agents.Extensions.Teams/Compat/TeamsActivityHandler.cs
+++ b/src/libraries/Extensions/Microsoft.Agents.Extensions.Teams/Compat/TeamsActivityHandler.cs
@@ -297,10 +297,10 @@ namespace Microsoft.Agents.Extensions.Teams.Compat
                 switch (action.BotMessagePreviewAction)
                 {
                     case "edit":
-                        return await OnTeamsMessagingExtensiOnAgentMessagePreviewEditAsync(turnContext, action, cancellationToken).ConfigureAwait(false);
+                        return await OnTeamsMessagingExtensionAgentMessagePreviewEditAsync(turnContext, action, cancellationToken).ConfigureAwait(false);
 
                     case "send":
-                        return await OnTeamsMessagingExtensiOnAgentMessagePreviewSendAsync(turnContext, action, cancellationToken).ConfigureAwait(false);
+                        return await OnTeamsMessagingExtensionAgentMessagePreviewSendAsync(turnContext, action, cancellationToken).ConfigureAwait(false);
 
                     default:
                         throw new InvokeResponseException(HttpStatusCode.BadRequest, $"{action.BotMessagePreviewAction} is not a supported BotMessagePreviewAction.");
@@ -333,7 +333,7 @@ namespace Microsoft.Agents.Extensions.Teams.Compat
         /// <param name="cancellationToken">A cancellation token that can be used by other objects
         /// or threads to receive notice of cancellation.</param>
         /// <returns>The Messaging Extension Action Response for the action.</returns>
-        protected virtual Task<MessagingExtensionActionResponse> OnTeamsMessagingExtensiOnAgentMessagePreviewEditAsync(ITurnContext<IInvokeActivity> turnContext, MessagingExtensionAction action, CancellationToken cancellationToken)
+        protected virtual Task<MessagingExtensionActionResponse> OnTeamsMessagingExtensionAgentMessagePreviewEditAsync(ITurnContext<IInvokeActivity> turnContext, MessagingExtensionAction action, CancellationToken cancellationToken)
         {
             throw new InvokeResponseException(HttpStatusCode.NotImplemented);
         }
@@ -346,7 +346,7 @@ namespace Microsoft.Agents.Extensions.Teams.Compat
         /// <param name="cancellationToken">A cancellation token that can be used by other objects
         /// or threads to receive notice of cancellation.</param>
         /// <returns>The Messaging Extension Action Response for the action.</returns>
-        protected virtual Task<MessagingExtensionActionResponse> OnTeamsMessagingExtensiOnAgentMessagePreviewSendAsync(ITurnContext<IInvokeActivity> turnContext, MessagingExtensionAction action, CancellationToken cancellationToken)
+        protected virtual Task<MessagingExtensionActionResponse> OnTeamsMessagingExtensionAgentMessagePreviewSendAsync(ITurnContext<IInvokeActivity> turnContext, MessagingExtensionAction action, CancellationToken cancellationToken)
         {
             throw new InvokeResponseException(HttpStatusCode.NotImplemented);
         }

--- a/src/tests/Microsoft.Agents.Extensions.Teams.Tests/App/MessageExtensionsTests.cs
+++ b/src/tests/Microsoft.Agents.Extensions.Teams.Tests/App/MessageExtensionsTests.cs
@@ -180,7 +180,7 @@ namespace Microsoft.Agents.Extensions.Teams.Tests.App
         }
 
         [Fact]
-        public async Task Test_OnBotMessagePreviewEdit_CommandId()
+        public async Task Test_OnAgentMessagePreviewEdit_CommandId()
         {
             // Arrange
             IActivity[] activitiesToSend = null;
@@ -235,7 +235,7 @@ namespace Microsoft.Agents.Extensions.Teams.Tests.App
 
             app.RegisterExtension(extension, (ext) =>
             {
-                ext.MessageExtensions.OnBotMessagePreviewEdit("test-command", handler);
+                ext.MessageExtensions.OnAgentMessagePreviewEdit("test-command", handler);
             });
 
             // Act
@@ -249,7 +249,7 @@ namespace Microsoft.Agents.Extensions.Teams.Tests.App
         }
 
         [Fact]
-        public async Task Test_OnBotMessagePreviewEdit_CommandId_NotHit()
+        public async Task Test_OnAgentMessagePreviewEdit_CommandId_NotHit()
         {
             // Arrange
             IActivity[] activitiesToSend = null;
@@ -297,7 +297,7 @@ namespace Microsoft.Agents.Extensions.Teams.Tests.App
 
             app.RegisterExtension(extension, (ext) =>
             {
-                ext.MessageExtensions.OnBotMessagePreviewEdit("not-test-command", handler);
+                ext.MessageExtensions.OnAgentMessagePreviewEdit("not-test-command", handler);
             });
 
             // Act
@@ -308,7 +308,7 @@ namespace Microsoft.Agents.Extensions.Teams.Tests.App
         }
 
         [Fact]
-        public async Task Test_OnBotMessagePreviewEdit_RouteSelector_ActivityNotMatched()
+        public async Task Test_OnAgentMessagePreviewEdit_RouteSelector_ActivityNotMatched()
         {
             var adapter = new SimpleAdapter();
             var turnContext = new TurnContext(adapter, new Activity()
@@ -338,17 +338,17 @@ namespace Microsoft.Agents.Extensions.Teams.Tests.App
 
             app.RegisterExtension(extension, (ext) =>
             {
-                ext.MessageExtensions.OnBotMessagePreviewEdit(routeSelector, handler);
+                ext.MessageExtensions.OnAgentMessagePreviewEdit(routeSelector, handler);
             });
             // Act
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () => await app.OnTurnAsync(turnContext, CancellationToken.None));
 
             // Assert
-            Assert.Equal("Unexpected MessageExtensions.OnBotMessagePreviewEdit() triggered for activity type: invoke", exception.Message);
+            Assert.Equal("Unexpected MessageExtensions.OnAgentMessagePreviewEdit() triggered for activity type: invoke", exception.Message);
         }
 
         [Fact]
-        public async Task Test_OnBotMessagePreviewSend_CommandId()
+        public async Task Test_OnAgentMessagePreviewSend_CommandId()
         {
             // Arrange
             IActivity[] activitiesToSend = null;
@@ -400,7 +400,7 @@ namespace Microsoft.Agents.Extensions.Teams.Tests.App
 
             app.RegisterExtension(extension, (ext) =>
             {
-                ext.MessageExtensions.OnBotMessagePreviewSend("test-command", handler);
+                ext.MessageExtensions.OnAgentMessagePreviewSend("test-command", handler);
             });
 
             // Act
@@ -414,7 +414,7 @@ namespace Microsoft.Agents.Extensions.Teams.Tests.App
         }
 
         [Fact]
-        public async Task Test_OnBotMessagePreviewSend_CommandId_NotHit()
+        public async Task Test_OnAgentMessagePreviewSend_CommandId_NotHit()
         {
             // Arrange
             IActivity[] activitiesToSend = null;
@@ -462,7 +462,7 @@ namespace Microsoft.Agents.Extensions.Teams.Tests.App
 
             app.RegisterExtension(extension, (ext) =>
             {
-                ext.MessageExtensions.OnBotMessagePreviewSend("not-test-command", handler);
+                ext.MessageExtensions.OnAgentMessagePreviewSend("not-test-command", handler);
             });
 
             // Act
@@ -473,7 +473,7 @@ namespace Microsoft.Agents.Extensions.Teams.Tests.App
         }
 
         [Fact]
-        public async Task Test_OnBotMessagePreviewSend_RouteSelector_ActivityNotMatched()
+        public async Task Test_OnAgentMessagePreviewSend_RouteSelector_ActivityNotMatched()
         {
             var adapter = new SimpleAdapter();
             var turnContext = new TurnContext(adapter, new Activity()
@@ -502,13 +502,13 @@ namespace Microsoft.Agents.Extensions.Teams.Tests.App
             
             app.RegisterExtension(extension, (ext) =>
             {
-                ext.MessageExtensions.OnBotMessagePreviewSend(routeSelector, handler);
+                ext.MessageExtensions.OnAgentMessagePreviewSend(routeSelector, handler);
             });
             // Act
             var exception = await Assert.ThrowsAsync<InvalidOperationException>(async () => await app.OnTurnAsync(turnContext, CancellationToken.None));
 
             // Assert
-            Assert.Equal("Unexpected MessageExtensions.OnBotMessagePreviewSend() triggered for activity type: invoke", exception.Message);
+            Assert.Equal("Unexpected MessageExtensions.OnAgentMessagePreviewSend() triggered for activity type: invoke", exception.Message);
         }
 
         [Fact]

--- a/src/tests/Microsoft.Agents.Extensions.Teams.Tests/Handler/TeamsActivityHandlerTests.cs
+++ b/src/tests/Microsoft.Agents.Extensions.Teams.Tests/Handler/TeamsActivityHandlerTests.cs
@@ -662,7 +662,7 @@ namespace Microsoft.Agents.Extensions.Teams.Tests.Handler
             Assert.Equal(3, bot.Record.Count);
             Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
             Assert.Equal("OnTeamsMessagingExtensionSubmitActionDispatchAsync", bot.Record[1]);
-            Assert.Equal("OnTeamsMessagingExtensionBotMessagePreviewEditAsync", bot.Record[2]);
+            Assert.Equal("OnTeamsMessagingExtensiOnAgentMessagePreviewEditAsync", bot.Record[2]);
             Assert.NotNull(_activitiesToSend);
             Assert.Single(_activitiesToSend);
             Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);
@@ -693,7 +693,7 @@ namespace Microsoft.Agents.Extensions.Teams.Tests.Handler
             Assert.Equal(3, bot.Record.Count);
             Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
             Assert.Equal("OnTeamsMessagingExtensionSubmitActionDispatchAsync", bot.Record[1]);
-            Assert.Equal("OnTeamsMessagingExtensionBotMessagePreviewSendAsync", bot.Record[2]);
+            Assert.Equal("OnTeamsMessagingExtensiOnAgentMessagePreviewSendAsync", bot.Record[2]);
             Assert.NotNull(_activitiesToSend);
             Assert.Single(_activitiesToSend);
             Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);

--- a/src/tests/Microsoft.Agents.Extensions.Teams.Tests/Handler/TeamsActivityHandlerTests.cs
+++ b/src/tests/Microsoft.Agents.Extensions.Teams.Tests/Handler/TeamsActivityHandlerTests.cs
@@ -662,7 +662,7 @@ namespace Microsoft.Agents.Extensions.Teams.Tests.Handler
             Assert.Equal(3, bot.Record.Count);
             Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
             Assert.Equal("OnTeamsMessagingExtensionSubmitActionDispatchAsync", bot.Record[1]);
-            Assert.Equal("OnTeamsMessagingExtensiOnAgentMessagePreviewEditAsync", bot.Record[2]);
+            Assert.Equal("OnTeamsMessagingExtensionAgentMessagePreviewEditAsync", bot.Record[2]);
             Assert.NotNull(_activitiesToSend);
             Assert.Single(_activitiesToSend);
             Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);
@@ -693,7 +693,7 @@ namespace Microsoft.Agents.Extensions.Teams.Tests.Handler
             Assert.Equal(3, bot.Record.Count);
             Assert.Equal("OnInvokeActivityAsync", bot.Record[0]);
             Assert.Equal("OnTeamsMessagingExtensionSubmitActionDispatchAsync", bot.Record[1]);
-            Assert.Equal("OnTeamsMessagingExtensiOnAgentMessagePreviewSendAsync", bot.Record[2]);
+            Assert.Equal("OnTeamsMessagingExtensionAgentMessagePreviewSendAsync", bot.Record[2]);
             Assert.NotNull(_activitiesToSend);
             Assert.Single(_activitiesToSend);
             Assert.IsType<InvokeResponse>(_activitiesToSend[0].Value);

--- a/src/tests/Microsoft.Agents.Extensions.Teams.Tests/Handler/TestActivityHandler.cs
+++ b/src/tests/Microsoft.Agents.Extensions.Teams.Tests/Handler/TestActivityHandler.cs
@@ -161,13 +161,13 @@ namespace Microsoft.Agents.Extensions.Teams.Tests
             return Task.CompletedTask;
         }
 
-        protected override Task<MessagingExtensionActionResponse> OnTeamsMessagingExtensiOnAgentMessagePreviewEditAsync(ITurnContext<IInvokeActivity> turnContext, MessagingExtensionAction action, CancellationToken cancellationToken)
+        protected override Task<MessagingExtensionActionResponse> OnTeamsMessagingExtensionAgentMessagePreviewEditAsync(ITurnContext<IInvokeActivity> turnContext, MessagingExtensionAction action, CancellationToken cancellationToken)
         {
             Record.Add(MethodBase.GetCurrentMethod().Name);
             return Task.FromResult(new MessagingExtensionActionResponse());
         }
 
-        protected override Task<MessagingExtensionActionResponse> OnTeamsMessagingExtensiOnAgentMessagePreviewSendAsync(ITurnContext<IInvokeActivity> turnContext, MessagingExtensionAction action, CancellationToken cancellationToken)
+        protected override Task<MessagingExtensionActionResponse> OnTeamsMessagingExtensionAgentMessagePreviewSendAsync(ITurnContext<IInvokeActivity> turnContext, MessagingExtensionAction action, CancellationToken cancellationToken)
         {
             Record.Add(MethodBase.GetCurrentMethod().Name);
             return Task.FromResult(new MessagingExtensionActionResponse());

--- a/src/tests/Microsoft.Agents.Extensions.Teams.Tests/Handler/TestActivityHandler.cs
+++ b/src/tests/Microsoft.Agents.Extensions.Teams.Tests/Handler/TestActivityHandler.cs
@@ -161,13 +161,13 @@ namespace Microsoft.Agents.Extensions.Teams.Tests
             return Task.CompletedTask;
         }
 
-        protected override Task<MessagingExtensionActionResponse> OnTeamsMessagingExtensionBotMessagePreviewEditAsync(ITurnContext<IInvokeActivity> turnContext, MessagingExtensionAction action, CancellationToken cancellationToken)
+        protected override Task<MessagingExtensionActionResponse> OnTeamsMessagingExtensiOnAgentMessagePreviewEditAsync(ITurnContext<IInvokeActivity> turnContext, MessagingExtensionAction action, CancellationToken cancellationToken)
         {
             Record.Add(MethodBase.GetCurrentMethod().Name);
             return Task.FromResult(new MessagingExtensionActionResponse());
         }
 
-        protected override Task<MessagingExtensionActionResponse> OnTeamsMessagingExtensionBotMessagePreviewSendAsync(ITurnContext<IInvokeActivity> turnContext, MessagingExtensionAction action, CancellationToken cancellationToken)
+        protected override Task<MessagingExtensionActionResponse> OnTeamsMessagingExtensiOnAgentMessagePreviewSendAsync(ITurnContext<IInvokeActivity> turnContext, MessagingExtensionAction action, CancellationToken cancellationToken)
         {
             Record.Add(MethodBase.GetCurrentMethod().Name);
             return Task.FromResult(new MessagingExtensionActionResponse());


### PR DESCRIPTION
This commit renames methods and their handlers from `OnBotMessagePreviewEdit` and `OnBotMessagePreviewSend` to `OnAgentMessagePreviewEdit` and `OnAgentMessagePreviewSend`. The changes are applied consistently across multiple overloads and usages in `MessageExtension.cs`,
`TeamsActivityHandler.cs`, and related test files. Exception messages and assertions in tests have also been updated to reflect the new method names,
ensuring functionality remains intact.