### PR TITLE
Add DEBUG block for stack trace output control

### DIFF
--- a/src/libraries/Core/Microsoft.Agents.Core/Errors/ExceptionParser.cs
+++ b/src/libraries/Core/Microsoft.Agents.Core/Errors/ExceptionParser.cs
@@ -68,8 +68,12 @@ namespace Microsoft.Agents.Core.Errors
             sw.AppendLine("TimeStamp: " + DateTime.UtcNow.ToString("o", CultureInfo.InvariantCulture));
             sw.AppendLine("Error: " + message);
             sw.AppendLine($"HelpLink Url: {helpLink}");
+#if DEBUG
+            //TODO:
+            // Update this code to use a setting or environment variable to control the output of the stack trace.
             if (!string.IsNullOrEmpty(stackTrace))
                 sw.AppendLine("Stack Trace: " + stackTrace);
+#endif
             sw.AppendLine("=====================================");
         }
     }


### PR DESCRIPTION
Introduced a conditional compilation block in `ExceptionParser.cs` for DEBUG mode. 
Added a TODO to implement a setting or environment variable for controlling stack trace output. The stack trace will be appended if it is not null or empty.