### PR TITLE
Adding updating Version info for main branch to 1.0

### DIFF
--- a/src/libraries/version.json
+++ b/src/libraries/version.json
@@ -1,16 +1,20 @@
 {
-    "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "0.2-alpha",
-    "assemblyVersion": {
-      "precision": "revision"
-    },
-    "publicReleaseRefSpec": [
-      "^refs/heads/main$",
-      "^refs/heads/rel/v\\d+(?:\\.\\d+)?$"
-    ],
-    "cloudBuild": {
-      "buildNumber": {
-        "enabled": true
-      }
+  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "1.0-beta",
+  "assemblyVersion": {
+    "precision": "revision"
+  },
+  "publicReleaseRefSpec": [
+    "^refs/heads/main$",
+    "^refs/heads/rel/v\\d+(?:\\.\\d+)?$"
+  ],
+  "cloudBuild": {
+    "buildNumber": {
+      "enabled": true
     }
+  },
+  "release": {
+    "branchName": "rel/v{version}",
+    "firstUnstableTag": "beta"
   }
+}

--- a/src/libraries/version.json
+++ b/src/libraries/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.0-beta",
+  "version": "1.1-beta",
   "assemblyVersion": {
     "precision": "revision"
   },


### PR DESCRIPTION
This pull request updates the versioning configuration in the `src/libraries/version.json` file to prepare for a beta release. The most important changes include updating the version number and adding a new release configuration.

### Versioning updates:

* Updated the `version` field from `"0.2-alpha"` to `"1.0-beta"`, reflecting the transition to a beta release phase. (`[src/libraries/version.jsonL3-R3](diffhunk://#diff-d350b28c3db3830a4429067c8ab3e952c3ce2b3e9ae15392b2c8d90baaee0586L3-R3)`)

### Release configuration:

* Added a new `release` section specifying the `branchName` format (`rel/v{version}`) and the `firstUnstableTag` (`beta`) to streamline release management. (`[src/libraries/version.jsonR15-R18](diffhunk://#diff-d350b28c3db3830a4429067c8ab3e952c3ce2b3e9ae15392b2c8d90baaee0586R15-R18)`)