### PR TITLE
Update projects for multi-targeting and framework compatibility

### DIFF
--- a/src/libraries/Client/Microsoft.Agents.Connector/Microsoft.Agents.Connector.csproj
+++ b/src/libraries/Client/Microsoft.Agents.Connector/Microsoft.Agents.Connector.csproj
@@ -5,6 +5,7 @@
 		<ComponentAreaName>CplConnector</ComponentAreaName>
 		<SignAssembly>true</SignAssembly>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
 	</PropertyGroup>
 	<Import Project="..\..\..\Build.Common.core.props" />
 

--- a/src/libraries/Client/Microsoft.Agents.Connector/RestClients/AgentSignInRestClient.cs
+++ b/src/libraries/Client/Microsoft.Agents.Connector/RestClients/AgentSignInRestClient.cs
@@ -38,7 +38,14 @@ namespace Microsoft.Agents.Connector.RestClients
         /// <inheritdoc/>
         public async Task<string> GetSignInUrlAsync(string state, string codeChallenge = null, string emulatorUrl = null, string finalRedirect = null, CancellationToken cancellationToken = default)
         {
+#if !NETSTANDARD
             ArgumentException.ThrowIfNullOrEmpty(state);
+#else
+            if (string.IsNullOrEmpty(state))
+            {
+                throw new ArgumentException("State cannot be null or empty.", nameof(state));
+            }
+#endif
 
             using var message = CreateGetSignInUrlRequest(state, codeChallenge, emulatorUrl, finalRedirect);
             using var httpClient = await _transport.GetHttpClientAsync().ConfigureAwait(false);
@@ -47,7 +54,11 @@ namespace Microsoft.Agents.Connector.RestClients
             {
                 case 200:
                     {
+#if !NETSTANDARD
                         return await httpResponse.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#else
+                        return await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+#endif
                     }
                 default:
                     throw new HttpRequestException($"GetSignInUrlAsync {httpResponse.StatusCode}");
@@ -74,7 +85,14 @@ namespace Microsoft.Agents.Connector.RestClients
         /// <inheritdoc/>
         public async Task<SignInResource> GetSignInResourceAsync(string state, string codeChallenge = null, string emulatorUrl = null, string finalRedirect = null, CancellationToken cancellationToken = default)
         {
+#if !NETSTANDARD
             ArgumentException.ThrowIfNullOrEmpty(state);
+#else
+            if (string.IsNullOrEmpty(state))
+            {
+                throw new ArgumentException("State cannot be null or empty.", nameof(state));
+            }
+#endif
 
             using var message = CreateGetSignInResourceRequest(state, codeChallenge, emulatorUrl, finalRedirect);
             using var httpClient = await _transport.GetHttpClientAsync().ConfigureAwait(false);
@@ -83,7 +101,11 @@ namespace Microsoft.Agents.Connector.RestClients
             {
                 case 200:
                     {
+#if !NETSTANDARD
                         return ProtocolJsonSerializer.ToObject<SignInResource>(httpResponse.Content.ReadAsStream(cancellationToken));
+#else
+                        return ProtocolJsonSerializer.ToObject<SignInResource>(httpResponse.Content.ReadAsStringAsync().Result);
+#endif
                     }
                 case 400:
                     {

--- a/src/libraries/Client/Microsoft.Agents.Connector/RestClients/ConversationsRestClient.cs
+++ b/src/libraries/Client/Microsoft.Agents.Connector/RestClients/ConversationsRestClient.cs
@@ -44,7 +44,11 @@ namespace Microsoft.Agents.Connector.RestClients
             {
                 case 200:
                     {
+#if !NETSTANDARD
                         return ProtocolJsonSerializer.ToObject<ConversationsResult>(httpResponse.Content.ReadAsStream(cancellationToken));
+#else
+                        return ProtocolJsonSerializer.ToObject<ConversationsResult>(httpResponse.Content.ReadAsStringAsync().Result);
+#endif
                     }
                 default:
                     {
@@ -80,7 +84,11 @@ namespace Microsoft.Agents.Connector.RestClients
                 case 201:
                 case 202:
                     {
+#if !NETSTANDARD
                         return ProtocolJsonSerializer.ToObject<ConversationResourceResponse>(httpResponse.Content.ReadAsStream(cancellationToken));
+#else
+                        return ProtocolJsonSerializer.ToObject<ConversationResourceResponse>(httpResponse.Content.ReadAsStringAsync().Result);
+#endif
                     }
                 default:
                     {
@@ -112,7 +120,14 @@ namespace Microsoft.Agents.Connector.RestClients
         /// <inheritdoc/>
         public async Task<ResourceResponse> SendToConversationAsync(string conversationId, IActivity body = null, CancellationToken cancellationToken = default)
         {
+#if !NETSTANDARD
             ArgumentNullException.ThrowIfNullOrEmpty(conversationId);
+#else
+            if (string.IsNullOrEmpty(conversationId))
+            {
+                throw new ArgumentException("ConversationId cannot be null or empty.", nameof(conversationId));
+            }
+#endif
 
             using var message = CreateSendToConversationRequest(conversationId, body);
             using var httpClient = await _transport.GetHttpClientAsync().ConfigureAwait(false);
@@ -123,7 +138,11 @@ namespace Microsoft.Agents.Connector.RestClients
                 case 201:
                 case 202:
                     {
+#if !NETSTANDARD
                         return ProtocolJsonSerializer.ToObject<ResourceResponse>(httpResponse.Content.ReadAsStream(cancellationToken));
+#else
+                        return ProtocolJsonSerializer.ToObject<ResourceResponse>(httpResponse.Content.ReadAsStringAsync().Result);
+#endif
                     }
                 default:
                     {
@@ -150,7 +169,14 @@ namespace Microsoft.Agents.Connector.RestClients
         /// <inheritdoc/>
         public async Task<ResourceResponse> SendConversationHistoryAsync(string conversationId, Transcript body = null, CancellationToken cancellationToken = default)
         {
+#if !NETSTANDARD
             ArgumentException.ThrowIfNullOrEmpty(conversationId);
+#else
+            if (string.IsNullOrEmpty(conversationId))
+            {
+                throw new ArgumentException("ConversationId cannot be null or empty.", nameof(conversationId));
+            }
+#endif
 
             using var message = CreateSendConversationHistoryRequest(conversationId, body);
             using var httpClient = await _transport.GetHttpClientAsync().ConfigureAwait(false);
@@ -161,7 +187,11 @@ namespace Microsoft.Agents.Connector.RestClients
                 case 201:
                 case 202:
                     {
+#if !NETSTANDARD
                         return ProtocolJsonSerializer.ToObject<ResourceResponse>(httpResponse.Content.ReadAsStream(cancellationToken));
+#else
+                        return ProtocolJsonSerializer.ToObject<ResourceResponse>(httpResponse.Content.ReadAsStringAsync().Result);
+#endif
                     }
                 default:
                     {
@@ -193,8 +223,19 @@ namespace Microsoft.Agents.Connector.RestClients
         /// <inheritdoc/>
         public async Task<ResourceResponse> UpdateActivityAsync(string conversationId, string activityId, IActivity body = null, CancellationToken cancellationToken = default)
         {
+#if !NETSTANDARD
             ArgumentException.ThrowIfNullOrEmpty(conversationId);
             ArgumentException.ThrowIfNullOrEmpty(activityId);
+#else
+            if (string.IsNullOrEmpty(conversationId))
+            {
+                throw new ArgumentException("ConversationId cannot be null or empty.", nameof(conversationId));
+            }
+            if (string.IsNullOrEmpty(activityId))
+            {
+                throw new ArgumentException("ActivityId cannot be null or empty.", nameof(activityId));
+            }
+#endif
 
             using var message = CreateUpdateActivityRequest(conversationId, activityId, body);
             using var httpClient = await _transport.GetHttpClientAsync().ConfigureAwait(false);
@@ -205,7 +246,11 @@ namespace Microsoft.Agents.Connector.RestClients
                 case 201:
                 case 202:
                     {
+#if !NETSTANDARD
                         return ProtocolJsonSerializer.ToObject<ResourceResponse>(httpResponse.Content.ReadAsStream(cancellationToken));
+#else
+                        return ProtocolJsonSerializer.ToObject<ResourceResponse>(httpResponse.Content.ReadAsStringAsync().Result);
+#endif
                     }
                 default:
                     {
@@ -239,8 +284,19 @@ namespace Microsoft.Agents.Connector.RestClients
         /// <inheritdoc/>
         public async Task<ResourceResponse> ReplyToActivityAsync(string conversationId, string activityId, IActivity body = null, CancellationToken cancellationToken = default)
         {
+#if !NETSTANDARD
             ArgumentException.ThrowIfNullOrEmpty(conversationId);
             ArgumentException.ThrowIfNullOrEmpty(activityId);
+#else
+            if (string.IsNullOrEmpty(conversationId))
+            {
+                throw new ArgumentException("ConversationId cannot be null or empty.", nameof(conversationId));
+            }
+            if (string.IsNullOrEmpty(activityId))
+            {
+                throw new ArgumentException("ActivityId cannot be null or empty.", nameof(activityId));
+            }
+#endif
 
             using var message = CreateReplyToActivityRequest(conversationId, activityId, body);
             using var httpClient = await _transport.GetHttpClientAsync().ConfigureAwait(false);
@@ -251,12 +307,21 @@ namespace Microsoft.Agents.Connector.RestClients
                 case 201:
                 case 202:
                     {
+#if !NETSTANDARD
                         // Teams is famous for not returning a response body for these.
                         if (httpResponse.Content.ReadAsStream(cancellationToken).Length == 0)
                         {
                             return new ResourceResponse() { Id = string.Empty };
                         }
                         return ProtocolJsonSerializer.ToObject<ResourceResponse>(httpResponse.Content.ReadAsStream(cancellationToken));
+#else
+                        // Teams is famous for not returning a response body for these.
+                        if (httpResponse.Content.ReadAsStringAsync().Result.Length == 0)
+                        {
+                            return new ResourceResponse() { Id = string.Empty };
+                        }
+                        return ProtocolJsonSerializer.ToObject<ResourceResponse>(httpResponse.Content.ReadAsStringAsync().Result);
+#endif
                     }
                 default:
                     {
@@ -279,8 +344,19 @@ namespace Microsoft.Agents.Connector.RestClients
         /// <inheritdoc/>
         public async Task DeleteActivityAsync(string conversationId, string activityId, CancellationToken cancellationToken = default)
         {
+#if !NETSTANDARD
             ArgumentException.ThrowIfNullOrEmpty(conversationId);
             ArgumentException.ThrowIfNullOrEmpty(activityId);
+#else
+            if (string.IsNullOrEmpty(conversationId))
+            {
+                throw new ArgumentException("ConversationId cannot be null or empty.", nameof(conversationId));
+            }
+            if (string.IsNullOrEmpty(activityId))
+            {
+                throw new ArgumentException("ActivityId cannot be null or empty.", nameof(activityId));
+            }
+#endif
 
             using var message = CreateDeleteActivityRequest(conversationId, activityId);
             using var httpClient = await _transport.GetHttpClientAsync().ConfigureAwait(false);
@@ -311,7 +387,15 @@ namespace Microsoft.Agents.Connector.RestClients
         /// <inheritdoc/>
         public async Task<IReadOnlyList<ChannelAccount>> GetConversationMembersAsync(string conversationId, CancellationToken cancellationToken = default)
         {
+
+#if !NETSTANDARD
             ArgumentException.ThrowIfNullOrEmpty(conversationId);
+#else
+            if (string.IsNullOrEmpty(conversationId))
+            {
+                throw new ArgumentException("ConversationId cannot be null or empty.", nameof(conversationId));
+            }
+#endif
 
             using var message = CreateGetConversationMembersRequest(conversationId);
             using var httpClient = await _transport.GetHttpClientAsync().ConfigureAwait(false);
@@ -320,7 +404,11 @@ namespace Microsoft.Agents.Connector.RestClients
             {
                 case 200:
                     {
+#if !NETSTANDARD
                         return ProtocolJsonSerializer.ToObject<IReadOnlyList<ChannelAccount>>(httpResponse.Content.ReadAsStream(cancellationToken));
+#else
+                        return ProtocolJsonSerializer.ToObject<IReadOnlyList<ChannelAccount>>(httpResponse.Content.ReadAsStringAsync().Result);
+#endif
                     }
                 default:
                     {
@@ -343,8 +431,19 @@ namespace Microsoft.Agents.Connector.RestClients
         /// <inheritdoc/>
         public async Task<ChannelAccount> GetConversationMemberAsync(string userId, string conversationId, CancellationToken cancellationToken = default)
         {
+#if !NETSTANDARD
             ArgumentException.ThrowIfNullOrEmpty(conversationId);
             ArgumentException.ThrowIfNullOrEmpty(userId);
+#else
+            if (string.IsNullOrEmpty(conversationId))
+            {
+                throw new ArgumentException("ConversationId cannot be null or empty.", nameof(conversationId));
+            }
+            if (string.IsNullOrEmpty(userId))
+            {
+                throw new ArgumentException("UserId cannot be null or empty.", nameof(userId));
+            }
+#endif
 
             using var message = CreateGetConversationMemberRequest(conversationId, userId);
             using var httpClient = await _transport.GetHttpClientAsync().ConfigureAwait(false);
@@ -353,7 +452,11 @@ namespace Microsoft.Agents.Connector.RestClients
             {
                 case 200:
                     {
+#if !NETSTANDARD
                         return ProtocolJsonSerializer.ToObject<ChannelAccount>(httpResponse.Content.ReadAsStream(cancellationToken));
+#else
+                        return ProtocolJsonSerializer.ToObject<ChannelAccount>(httpResponse.Content.ReadAsStringAsync().Result);
+#endif
                     }
                 default:
                     {
@@ -376,8 +479,19 @@ namespace Microsoft.Agents.Connector.RestClients
         /// <inheritdoc/>
         public async Task DeleteConversationMemberAsync(string conversationId, string memberId, CancellationToken cancellationToken = default)
         {
+#if !NETSTANDARD
             ArgumentException.ThrowIfNullOrEmpty(conversationId);
             ArgumentException.ThrowIfNullOrEmpty(memberId);
+#else
+            if (string.IsNullOrEmpty(conversationId))
+            {
+                throw new ArgumentException("ConversationId cannot be null or empty.", nameof(conversationId));
+            }
+            if (string.IsNullOrEmpty(memberId))
+            {
+                throw new ArgumentException("MemberId cannot be null or empty.", nameof(memberId));
+            }
+#endif
 
             using var message = CreateDeleteConversationMemberRequest(conversationId, memberId);
             using var httpClient = await _transport.GetHttpClientAsync().ConfigureAwait(false);
@@ -409,7 +523,14 @@ namespace Microsoft.Agents.Connector.RestClients
         /// <inheritdoc/>
         public async Task<PagedMembersResult> GetConversationPagedMembersAsync(string conversationId, int? pageSize = default(int?), string continuationToken = null, CancellationToken cancellationToken = default)
         {
+#if !NETSTANDARD
             ArgumentException.ThrowIfNullOrEmpty(conversationId);
+#else
+            if (string.IsNullOrEmpty(conversationId))
+            {
+                throw new ArgumentException("ConversationId cannot be null or empty.", nameof(conversationId));
+            }
+#endif
 
             using var message = CreateGetConversationPagedMembersRequest(conversationId, pageSize, continuationToken);
             using var httpClient = await _transport.GetHttpClientAsync().ConfigureAwait(false);
@@ -418,7 +539,11 @@ namespace Microsoft.Agents.Connector.RestClients
             {
                 case 200:
                     {
+#if !NETSTANDARD
                         return ProtocolJsonSerializer.ToObject<PagedMembersResult>(httpResponse.Content.ReadAsStream(cancellationToken));
+#else
+                        return ProtocolJsonSerializer.ToObject<PagedMembersResult>(httpResponse.Content.ReadAsStringAsync().Result);
+#endif
                     }
                 default:
                     {
@@ -441,8 +566,19 @@ namespace Microsoft.Agents.Connector.RestClients
         /// <inheritdoc/>
         public async Task<IReadOnlyList<ChannelAccount>> GetActivityMembersAsync(string conversationId, string activityId, CancellationToken cancellationToken = default)
         {
+#if !NETSTANDARD
             ArgumentException.ThrowIfNullOrEmpty(conversationId);
             ArgumentException.ThrowIfNullOrEmpty(activityId);
+#else
+            if (string.IsNullOrEmpty(conversationId))
+            {
+                throw new ArgumentException("ConversationId cannot be null or empty.", nameof(conversationId));
+            }
+            if (string.IsNullOrEmpty(activityId))
+            {
+                throw new ArgumentException("ActivityId cannot be null or empty.", nameof(activityId));
+            }
+#endif
 
             using var message = CreateGetActivityMembersRequest(conversationId, activityId);
             using var httpClient = await _transport.GetHttpClientAsync().ConfigureAwait(false);
@@ -451,7 +587,11 @@ namespace Microsoft.Agents.Connector.RestClients
             {
                 case 200:
                     {
+#if !NETSTANDARD
                         return ProtocolJsonSerializer.ToObject<IReadOnlyList<ChannelAccount>>(httpResponse.Content.ReadAsStream(cancellationToken));
+#else
+                        return ProtocolJsonSerializer.ToObject<IReadOnlyList<ChannelAccount>>(httpResponse.Content.ReadAsStringAsync().Result);
+#endif
                     }
                 default:
                     {
@@ -478,7 +618,14 @@ namespace Microsoft.Agents.Connector.RestClients
         /// <inheritdoc/>
         public async Task<ResourceResponse> UploadAttachmentAsync(string conversationId, AttachmentData body = null, CancellationToken cancellationToken = default)
         {
+#if !NETSTANDARD
             ArgumentException.ThrowIfNullOrEmpty(conversationId);
+#else
+            if (string.IsNullOrEmpty(conversationId))
+            {
+                throw new ArgumentException("ConversationId cannot be null or empty.", nameof(conversationId));
+            }
+#endif
 
             using var message = CreateUploadAttachmentRequest(conversationId, body);
             using var httpClient = await _transport.GetHttpClientAsync().ConfigureAwait(false);
@@ -489,7 +636,11 @@ namespace Microsoft.Agents.Connector.RestClients
                 case 201:
                 case 202:
                     {
+#if !NETSTANDARD
                         return ProtocolJsonSerializer.ToObject<ResourceResponse>(httpResponse.Content.ReadAsStream(cancellationToken));
+#else
+                        return ProtocolJsonSerializer.ToObject<ResourceResponse>(httpResponse.Content.ReadAsStringAsync().Result);
+#endif
                     }
                 default:
                     {
@@ -507,7 +658,14 @@ namespace Microsoft.Agents.Connector.RestClients
         /// <param name="errors"></param>
         private static Exception HandleExceptionResponse(HttpResponseMessage httpResponse, AgentErrorDefinition errorMessage, CancellationToken cancellationToken, params string[] errors)
         {
+#if !NETSTANDARD
             ArgumentNullException.ThrowIfNull(httpResponse);
+#else
+            if (httpResponse == null)
+            {
+                throw new ArgumentNullException(nameof(httpResponse));
+            }
+#endif
 
             var ex = ErrorResponseException.CreateErrorResponseException(httpResponse, errorMessage, cancellationToken: cancellationToken, errors: errors);
 

--- a/src/libraries/Client/Microsoft.Agents.Connector/RestClients/UriExtensions.cs
+++ b/src/libraries/Client/Microsoft.Agents.Connector/RestClients/UriExtensions.cs
@@ -16,7 +16,11 @@ namespace Microsoft.Agents.Connector.RestClients
 
             var argValue = escape ? Uri.EscapeDataString(value) : value;
             var url = uri.AbsoluteUri;
+#if !NETSTANDARD
             if (!url.Contains('?'))
+#else
+            if (!url.Contains("?"))
+#endif
             {
                 return new Uri($"{url}?{name}={argValue}");
             }

--- a/src/libraries/Client/Microsoft.Agents.Connector/RestConnectorClient.cs
+++ b/src/libraries/Client/Microsoft.Agents.Connector/RestConnectorClient.cs
@@ -23,8 +23,19 @@ namespace Microsoft.Agents.Connector
         public RestConnectorClient(Uri endpoint, IHttpClientFactory httpClientFactory, Func<Task<string>> tokenProviderFunction, string namedClient = nameof(RestConnectorClient))
             : base(endpoint, httpClientFactory, namedClient, tokenProviderFunction)
         {
+#if !NETSTANDARD
             ArgumentNullException.ThrowIfNull(endpoint);
             ArgumentNullException.ThrowIfNull(httpClientFactory);
+#else
+            if (endpoint == null)
+            {
+                throw new ArgumentNullException(nameof(endpoint));
+            }
+            if (httpClientFactory == null)
+            {
+                throw new ArgumentNullException(nameof(httpClientFactory));
+            }
+#endif
 
             Conversations = new ConversationsRestClient(this);
             Attachments = new AttachmentsRestClient(this);

--- a/src/libraries/Client/Microsoft.Agents.Connector/RestUserTokenClient.cs
+++ b/src/libraries/Client/Microsoft.Agents.Connector/RestUserTokenClient.cs
@@ -34,7 +34,14 @@ namespace Microsoft.Agents.Connector
         public RestUserTokenClient(string appId, Uri endpoint, IHttpClientFactory httpClientFactory, Func<Task<string>> tokenProviderFunction, string namedClient = nameof(RestUserTokenClient), ILogger logger = null)
             : base(endpoint, httpClientFactory, namedClient, tokenProviderFunction)
         {
+#if !NETSTANDARD
             ArgumentException.ThrowIfNullOrEmpty(appId);
+#else
+            if (string.IsNullOrEmpty(appId))
+            {
+                throw new ArgumentException("AppId cannot be null or empty.", nameof(appId));
+            }
+#endif
 
             _appId = appId;
 
@@ -65,9 +72,24 @@ namespace Microsoft.Agents.Connector
         /// <inheritdoc />
         public async Task<TokenResponse> GetUserTokenAsync(string userId, string connectionName, string channelId, string magicCode, CancellationToken cancellationToken)
         {
+#if !NETSTANDARD
             ObjectDisposedException.ThrowIf(_disposed, nameof(GetUserTokenAsync));
             ArgumentException.ThrowIfNullOrEmpty(userId);
             ArgumentException.ThrowIfNullOrEmpty(connectionName);
+#else
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(GetUserTokenAsync));
+            }
+            if (string.IsNullOrEmpty(userId))
+            {
+                throw new ArgumentException("UserId cannot be null or empty.", nameof(userId));
+            }
+            if (string.IsNullOrEmpty(connectionName))
+            {
+                throw new ArgumentException("ConnectionName cannot be null or empty.", nameof(connectionName));
+            }
+#endif
 
             _logger.LogInformation($"GetTokenAsync ConnectionName: {connectionName}");
             return await _userTokenClient.GetTokenAsync(userId, connectionName, channelId, magicCode, cancellationToken).ConfigureAwait(false);
@@ -76,9 +98,24 @@ namespace Microsoft.Agents.Connector
         /// <inheritdoc />
         public async Task<SignInResource> GetSignInResourceAsync(string connectionName, IActivity activity, string finalRedirect, CancellationToken cancellationToken)
         {
+#if !NETSTANDARD
             ObjectDisposedException.ThrowIf(_disposed, nameof(GetSignInResourceAsync));
             ArgumentException.ThrowIfNullOrEmpty(connectionName);
             ArgumentNullException.ThrowIfNull(activity);
+#else
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(GetSignInResourceAsync));
+            }
+            if (string.IsNullOrEmpty(connectionName))
+            {
+                throw new ArgumentException("ConnectionName cannot be null or empty.", nameof(connectionName));
+            }
+            if (activity == null)
+            {
+                throw new ArgumentNullException(nameof(activity));
+            }
+#endif
 
             _logger.LogInformation($"GetSignInResourceAsync ConnectionName: {connectionName}");
             var state = CreateTokenExchangeState(_appId, connectionName, activity);
@@ -88,9 +125,24 @@ namespace Microsoft.Agents.Connector
         /// <inheritdoc />
         public async Task SignOutUserAsync(string userId, string connectionName, string channelId, CancellationToken cancellationToken)
         {
+#if !NETSTANDARD
             ObjectDisposedException.ThrowIf(_disposed, nameof(SignOutUserAsync));
             ArgumentException.ThrowIfNullOrEmpty(userId);
             ArgumentException.ThrowIfNullOrEmpty(connectionName);
+#else
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(SignOutUserAsync));
+            }
+            if (string.IsNullOrEmpty(userId))
+            {
+                throw new ArgumentException("UserId cannot be null or empty.", nameof(userId));
+            }
+            if (string.IsNullOrEmpty(connectionName))
+            {
+                throw new ArgumentException("ConnectionName cannot be null or empty.", nameof(connectionName));
+            }
+#endif
 
             _logger.LogInformation($"SignOutAsync ConnectionName: {connectionName}");
             await _userTokenClient.SignOutAsync(userId, connectionName, channelId, cancellationToken).ConfigureAwait(false);
@@ -99,9 +151,24 @@ namespace Microsoft.Agents.Connector
         /// <inheritdoc />
         public async Task<TokenStatus[]> GetTokenStatusAsync(string userId, string channelId, string includeFilter, CancellationToken cancellationToken)
         {
+#if !NETSTANDARD
             ObjectDisposedException.ThrowIf(_disposed, nameof(GetTokenStatusAsync));
             ArgumentException.ThrowIfNullOrEmpty(userId);
             ArgumentException.ThrowIfNullOrEmpty(channelId);
+#else
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(GetTokenStatusAsync));
+            }
+            if (string.IsNullOrEmpty(userId))
+            {
+                throw new ArgumentException("UserId cannot be null or empty.", nameof(userId));
+            }
+            if (string.IsNullOrEmpty(channelId))
+            {
+                throw new ArgumentException("ChannelId cannot be null or empty.", nameof(channelId));
+            }
+#endif
 
             _logger.LogInformation("GetTokenStatusAsync");
             var result = await _userTokenClient.GetTokenStatusAsync(userId, channelId, includeFilter, cancellationToken).ConfigureAwait(false);
@@ -111,9 +178,24 @@ namespace Microsoft.Agents.Connector
         /// <inheritdoc />
         public async Task<Dictionary<string, TokenResponse>> GetAadTokensAsync(string userId, string connectionName, string[] resourceUrls, string channelId, CancellationToken cancellationToken)
         {
+#if !NETSTANDARD
             ObjectDisposedException.ThrowIf(_disposed, nameof(GetAadTokensAsync));
             ArgumentException.ThrowIfNullOrEmpty(userId);
             ArgumentException.ThrowIfNullOrEmpty(connectionName);
+#else
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(GetAadTokensAsync));
+            }
+            if (string.IsNullOrEmpty(userId))
+            {
+                throw new ArgumentException("UserId cannot be null or empty.", nameof(userId));
+            }
+            if (string.IsNullOrEmpty(connectionName))
+            {
+                throw new ArgumentException("ConnectionName cannot be null or empty.", nameof(connectionName));
+            }
+#endif
 
             _logger.LogInformation($"GetAadTokensAsync ConnectionName: {connectionName}");
             return (Dictionary<string, TokenResponse>)await _userTokenClient.GetAadTokensAsync(userId, connectionName, new AadResourceUrls() { ResourceUrls = resourceUrls?.ToList() }, channelId, cancellationToken).ConfigureAwait(false);
@@ -122,9 +204,24 @@ namespace Microsoft.Agents.Connector
         /// <inheritdoc />
         public async Task<TokenResponse> ExchangeTokenAsync(string userId, string connectionName, string channelId, TokenExchangeRequest exchangeRequest, CancellationToken cancellationToken)
         {
+#if !NETSTANDARD
             ObjectDisposedException.ThrowIf(_disposed, nameof(ExchangeTokenAsync));
             ArgumentException.ThrowIfNullOrEmpty(userId);
             ArgumentException.ThrowIfNullOrEmpty(connectionName);
+#else
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(ExchangeTokenAsync));
+            }
+            if (string.IsNullOrEmpty(userId))
+            {
+                throw new ArgumentException("UserId cannot be null or empty.", nameof(userId));
+            }
+            if (string.IsNullOrEmpty(connectionName))
+            {
+                throw new ArgumentException("ConnectionName cannot be null or empty.", nameof(connectionName));
+            }
+#endif
 
             _logger.LogInformation($"ExchangeAsyncAsync ConnectionName: {connectionName}");
             var result = await _userTokenClient.ExchangeAsyncAsync(userId, connectionName, channelId, exchangeRequest, cancellationToken).ConfigureAwait(false);
@@ -150,9 +247,24 @@ namespace Microsoft.Agents.Connector
         /// <inheritdoc />
         public async Task<TokenOrSignInResourceResponse> GetTokenOrSignInResourceAsync(string connectionName, IActivity activity, string code, string finalRedirect = null, string fwdUrl = null, CancellationToken cancellationToken = default)
         {
+#if !NETSTANDARD
             ObjectDisposedException.ThrowIf(_disposed, nameof(GetTokenOrSignInResourceAsync));
             ArgumentNullException.ThrowIfNull(activity);
             ArgumentException.ThrowIfNullOrEmpty(connectionName);
+#else
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(GetTokenOrSignInResourceAsync));
+            }
+            if (activity == null)
+            {
+                throw new ArgumentNullException(nameof(activity));
+            }
+            if (string.IsNullOrEmpty(connectionName))
+            {
+                throw new ArgumentException("ConnectionName cannot be null or empty.", nameof(connectionName));
+            }
+#endif
             _logger.LogInformation($"GetTokenOrSignInResourceAsync ConnectionName: {connectionName}");
             var state = CreateTokenExchangeState(_appId, connectionName, activity);
             return await _userTokenClient.GetTokenOrSignInResourceAsync(activity.From.Id, connectionName, activity.ChannelId, state, code, finalRedirect, fwdUrl, cancellationToken).ConfigureAwait(false);

--- a/src/libraries/Client/Microsoft.Agents.Connector/UriExtensions.cs
+++ b/src/libraries/Client/Microsoft.Agents.Connector/UriExtensions.cs
@@ -14,7 +14,11 @@ namespace Microsoft.Agents.Connector
         {
             if (uri == null) throw new ArgumentNullException(nameof(uri));
             string uriString = uri.ToString();
-            if (!uriString.EndsWith('/'))
+#if !NETSTANDARD
+            if (!uriString.Contains('/'))
+#else
+            if (!uriString.Contains("/"))
+#endif
             {
                 uriString += "/";
             }

--- a/src/libraries/Core/Microsoft.Agents.Core/Errors/AgentErrorDefinition.cs
+++ b/src/libraries/Core/Microsoft.Agents.Core/Errors/AgentErrorDefinition.cs
@@ -30,7 +30,25 @@ namespace Microsoft.Agents.Core.Errors
     /// <param name="code">Error code for the exception</param>
     /// <param name="description">Displayed Error message</param>
     /// <param name="helplink">Help URL Link for the Error.</param>
+#if !NETSTANDARD
     public record AgentErrorDefinition(int code, string description, string helplink);
+#else
+    public class AgentErrorDefinition(int code, string description, string helplink)
+    {
+        /// <summary>
+        /// Error code for the exception
+        /// </summary>
+        public int code { get; } = code;
+        /// <summary>
+        /// Displayed Error message
+        /// </summary>
+        public string description { get; } = description;
+        /// <summary>
+        /// Help URL Link for the Error.
+        /// </summary>
+        public string helplink { get; } = helplink;
+    }
+#endif
 
     public static class ExceptionHelper
     {
@@ -40,7 +58,13 @@ namespace Microsoft.Agents.Core.Errors
                 ? (T)Activator.CreateInstance(typeof(T), new object[] { string.Format(errorDefinition.description, messageFormat), innerException })
                 : (T)Activator.CreateInstance(typeof(T), new object[] { string.Format(errorDefinition.description, messageFormat) });
 
+#if !NETSTANDARD
             excp.HResult = errorDefinition.code;
+#else
+            // HResult is not available in .NET Standard
+            // excp.HResult = errorDefinition.code;
+            excp.Data["HResult"] = errorDefinition.code;
+#endif
             excp.HelpLink = errorDefinition.helplink;
             return excp;
         }

--- a/src/libraries/Core/Microsoft.Agents.Core/Errors/ErrorResponseException.cs
+++ b/src/libraries/Core/Microsoft.Agents.Core/Errors/ErrorResponseException.cs
@@ -51,7 +51,11 @@ namespace Microsoft.Agents.Core.Errors
             var ex = CreateErrorResponseException(message, innerException, errors);
             try
             {
+#if !NETSTANDARD
                 ErrorResponse errorBody = ProtocolJsonSerializer.ToObject<ErrorResponse>(httpResponse.Content.ReadAsStream(cancellationToken));
+#else
+                ErrorResponse errorBody = ProtocolJsonSerializer.ToObject<ErrorResponse>(httpResponse.Content.ReadAsStringAsync().Result);
+#endif
                 if (errorBody != null && errorBody.Error != null)
                 {
                     ex.Body = errorBody;

--- a/src/libraries/Core/Microsoft.Agents.Core/Microsoft.Agents.Core.csproj
+++ b/src/libraries/Core/Microsoft.Agents.Core/Microsoft.Agents.Core.csproj
@@ -5,6 +5,7 @@
 		<ComponentAreaName>CplCore</ComponentAreaName>
 		<SignAssembly>true</SignAssembly>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
 	</PropertyGroup>
 	<Import Project="..\..\..\Build.Common.core.props" />
 

--- a/src/libraries/Core/Microsoft.Agents.Core/Models/EntityExtension.cs
+++ b/src/libraries/Core/Microsoft.Agents.Core/Models/EntityExtension.cs
@@ -94,10 +94,16 @@ namespace Microsoft.Agents.Core.Models
                                 followingText = $" {followingText}";
                             }
 
+#if !NETSTANDARD
                             text = string.Concat(text.AsSpan(0, iAtClose), followingText);
 
                             // replace <at ...>
                             text = string.Concat(text.AsSpan(0, iAtStart), text.AsSpan(iAtEnd + 1));
+#else
+                            text = string.Concat(text.Substring(0, iAtClose), followingText);
+                            // replace <at ...>
+                            text = string.Concat(text.Substring(0, iAtStart), text.Substring(iAtEnd + 1));
+#endif
 
                             // we found one, try again, there may be more.
                             foundTag = true;

--- a/src/libraries/Core/Microsoft.Agents.Core/Models/HandoffEventFactory.cs
+++ b/src/libraries/Core/Microsoft.Agents.Core/Models/HandoffEventFactory.cs
@@ -20,8 +20,14 @@ namespace Microsoft.Agents.Core.Models
         /// <returns>handoff event.</returns>
         public static IActivity CreateHandoffInitiation(IActivity activity, object handoffContext, Transcript transcript = null)
         {
+#if !NETSTANDARD
             ArgumentNullException.ThrowIfNull(activity);
-
+#else
+            if (activity == null)
+            {
+                throw new ArgumentNullException(nameof(activity));
+            }
+#endif
             var handoffEvent = CreateHandoffEvent(HandoffEventNames.InitiateHandoff, handoffContext, activity.Conversation);
 
             handoffEvent.From = activity.From;
@@ -53,8 +59,19 @@ namespace Microsoft.Agents.Core.Models
         /// <returns>handoff event.</returns>
         public static Activity CreateHandoffStatus(ConversationAccount conversation, string state, string message = null)
         {
+#if !NETSTANDARD2_0
             ArgumentNullException.ThrowIfNull(conversation);
             ArgumentException.ThrowIfNullOrWhiteSpace(state);
+#else
+            if (conversation == null)
+            {
+                throw new ArgumentNullException(nameof(conversation));
+            }
+            if (string.IsNullOrWhiteSpace(state))
+            {
+                throw new ArgumentException("State cannot be null or empty.", nameof(state));
+            }
+#endif
 
             object value = new { state, message };
 


### PR DESCRIPTION
- Target both .NET 8 and .NET Standard 2.0 in project files.
- Add conditional compilation for argument checks in RestClients.
- Change `AgentErrorDefinition` to a record type for .NET 8.
- Update `ErrorResponseException` for framework-specific content reading.
- Ensure proper URI formatting in `UriExtensions` for both frameworks.
- Enhance argument validation across various classes for robustness.
- Overall improvements for compatibility and error handling best practices.