### PR TITLE
Add workload identity as a MSAL option

### DIFF
--- a/src/libraries/Authentication/Authentication.Msal/Model/AuthTypes.cs
+++ b/src/libraries/Authentication/Authentication.Msal/Model/AuthTypes.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Agents.Authentication.Msal.Model
         ClientSecret,
         UserManagedIdentity,
         SystemManagedIdentity,
-        FederatedCredentials
+        FederatedCredentials,
+        WorkloadIdentity
     }
 }

--- a/src/libraries/Authentication/Authentication.Msal/Model/ConnectionSettings.cs
+++ b/src/libraries/Authentication/Authentication.Msal/Model/ConnectionSettings.cs
@@ -146,6 +146,16 @@ namespace Microsoft.Agents.Authentication.Msal.Model
                         throw new ArgumentNullException(nameof(Authority), "TenantId or Authority is required");
                     }
                     break;
+                case AuthTypes.WorkloadIdentity:
+                    if (string.IsNullOrEmpty(ClientId))
+                    {
+                        throw new ArgumentNullException(nameof(ClientId), "ClientId is required");
+                    }
+                    if (string.IsNullOrEmpty(Authority) && string.IsNullOrEmpty(TenantId))
+                    {
+                        throw new ArgumentNullException(nameof(Authority), "TenantId or Authority is required");
+                    }
+                    break;
                 default:
                     break;
             }

--- a/src/libraries/Authentication/Authentication.Msal/MsalAuth.cs
+++ b/src/libraries/Authentication/Authentication.Msal/MsalAuth.cs
@@ -225,6 +225,10 @@ namespace Microsoft.Agents.Authentication.Msal
                     }
                     cAppBuilder.WithClientAssertion((AssertionRequestOptions options) => FetchExternalTokenAsync());
                 }
+                else if (_connectionSettings.AuthType == AuthTypes.WorkloadIdentity)
+                {
+                    // No need to do anything
+                }
                 else
                 {
                     throw new System.NotImplementedException();

--- a/src/libraries/Authentication/Authentication.Msal/MsalAuth.cs
+++ b/src/libraries/Authentication/Authentication.Msal/MsalAuth.cs
@@ -227,7 +227,7 @@ namespace Microsoft.Agents.Authentication.Msal
                 }
                 else if (_connectionSettings.AuthType == AuthTypes.WorkloadIdentity)
                 {
-                    // No need to do anything
+                    // No need to do anything more, MSAL will resolve everything for WorkloadIdentity
                 }
                 else
                 {


### PR DESCRIPTION
Hi, 

I can see that there is no option for a workload identity for agents, we are running on AKS so we would like to add a workload identity instead, this will make it more secure then federation/clientsecrets


