### PR TITLE
Users/mbarbour/update teams extension for missingparts

### DIFF
--- a/src/libraries/Extensions/Microsoft.Agents.Extensions.Teams/App/TeamsAgentExtension.cs
+++ b/src/libraries/Extensions/Microsoft.Agents.Extensions.Teams/App/TeamsAgentExtension.cs
@@ -368,7 +368,7 @@ namespace Microsoft.Agents.Extensions.Teams.App
             RouteSelector routeSelector = (context, _) =>
             {
                 var jsonObject = ProtocolJsonSerializer.ToObject<JsonObject>(context.Activity.Value);
-                string? actionName = jsonObject.ContainsKey("actionName") ? jsonObject["actionName"].ToString() : string.Empty;
+                string? actionName = jsonObject != null && jsonObject.ContainsKey("actionName") ? jsonObject["actionName"].ToString() : string.Empty;
                 return Task.FromResult
                 (
                     context.Activity.Type == ActivityTypes.Invoke

--- a/src/libraries/Extensions/Microsoft.Agents.Extensions.Teams/Constants/TeamsProactiveGlobalServiceUrls.cs
+++ b/src/libraries/Extensions/Microsoft.Agents.Extensions.Teams/Constants/TeamsProactiveGlobalServiceUrls.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Agents.Extensions.Teams
+{
+    /// <summary>
+    /// These URLs are for proactive messages only. Use these only if the incoming request serviceURL is unavailable.
+    /// Once a serviceUrl has been returned from a prior conversation, you should cache and use that instead of thease. 
+    /// </summary>
+    public static class TeamsProactiveServiceEndpoints
+    {
+        public static readonly string publicGlobal = "https://smba.trafficmanager.net/teams/";
+        public static readonly string gcc = "https://smba.infra.gcc.teams.microsoft.com/teams";
+        public static readonly string gccHigh = "https://smba.infra.gov.teams.microsoft.us/teams";
+        public static readonly string dod = "https://smba.infra.dod.teams.microsoft.us/teams";
+    }
+}

--- a/src/libraries/Extensions/Microsoft.Agents.Extensions.Teams/TeamsActivityExtensions.cs
+++ b/src/libraries/Extensions/Microsoft.Agents.Extensions.Teams/TeamsActivityExtensions.cs
@@ -100,5 +100,26 @@ namespace Microsoft.Agents.Extensions.Teams
             var channelData = activity.GetChannelData<TeamsChannelData>();
             return channelData?.OnBehalfOf;
         }
+
+        /// <summary>
+        /// Adds the teams Feedback loop flag to the current ChannelData object.
+        /// Channel Data object cannot be populated when this flag is used. 
+        /// </summary>
+        /// <param name="activity"></param>
+        /// <param name="feedbackLoopType"></param>
+        /// <returns>true if it was able to add to Channel Data, other wise false.</returns>
+        public static bool TeamsEnableFeedbackLoop(this IActivity activity, string feedbackLoopType = "default")
+        {
+            if (activity.ChannelData != null)
+                return false;
+            else
+                activity.ChannelData = new 
+                    {
+                    feedbackLoop = new { 
+                            type = feedbackLoopType
+                        }
+                    };
+            return true; 
+        }
     }
 }


### PR DESCRIPTION
This pull request introduces improvements to error handling, adds new constants for Teams proactive messaging, and extends functionality for managing feedback loops. The most important changes include enhancing null checks, defining global service URLs for proactive messages, and adding a method to enable feedback loops in Teams activities.

### Error Handling Improvements:
* Enhanced null checks in `TeamsAgentExtension` to prevent potential `NullReferenceException` when accessing `jsonObject`. (`src/libraries/Extensions/Microsoft.Agents.Extensions.Teams/App/TeamsAgentExtension.cs`, [src/libraries/Extensions/Microsoft.Agents.Extensions.Teams/App/TeamsAgentExtension.csL371-R371](diffhunk://#diff-c9a7f298a185d6de09fe2ebe866dab852f347d91b9c4aa2c169461a83c7778f4L371-R371))

### New Constants for Proactive Messaging:
* Added `TeamsProactiveServiceEndpoints` class with predefined URLs for proactive messages in different environments (e.g., public, GCC, GCC High, and DoD). This ensures consistent service URL usage when the incoming request service URL is unavailable. (`src/libraries/Extensions/Microsoft.Agents.Extensions.Teams/Constants/TeamsProactiveGlobalServiceUrls.cs`, [src/libraries/Extensions/Microsoft.Agents.Extensions.Teams/Constants/TeamsProactiveGlobalServiceUrls.csR1-R20](diffhunk://#diff-4e61db1fbe838e63a0f3c0cc12a17d5cdd9851995bf681e9f45e63cb648836adR1-R20))

### Feedback Loop Enhancements:
* Introduced `TeamsEnableFeedbackLoop` extension method to add a feedback loop flag to the `ChannelData` object in Teams activities. This method ensures the flag is only added if `ChannelData` is null, improving flexibility in managing feedback loops. (`src/libraries/Extensions/Microsoft.Agents.Extensions.Teams/TeamsActivityExtensions.cs`, [src/libraries/Extensions/Microsoft.Agents.Extensions.Teams/TeamsActivityExtensions.csR103-R123](diffhunk://#diff-56bfba82d6de0e1fe5a684e71922d06eb8432ac56058555f19d21e6917d8e432R103-R123))