### PR TITLE
Add method to determine connector client necessity

### DIFF
--- a/src/libraries/Builder/Microsoft.Agents.Builder/ChannelServiceAdapterBase.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/ChannelServiceAdapterBase.cs
@@ -262,7 +262,7 @@ namespace Microsoft.Agents.Builder
 
             // Create the connector client to use for outbound requests.
             using IConnectorClient connectorClient =
-                activity.DeliveryMode != DeliveryModes.ExpectReplies ?  // if Delivery Mode == ExpectReplies, we don't need a connector client.
+                ResolveIfConnectorClientIsNeeded(activity) ?  // if Delivery Mode == ExpectReplies, we don't need a connector client.
                     await ChannelServiceFactory.CreateConnectorClientAsync(
                     claimsIdentity,
                     activity.ServiceUrl,
@@ -366,6 +366,33 @@ namespace Microsoft.Agents.Builder
 
             // No body to return.
             return null;
+        }
+
+
+        /// <summary>
+        /// Determines whether a connector client is needed based on the delivery mode and service URL of the given activity.
+        /// </summary>
+        /// <param name="activity">The activity to evaluate.</param>
+        /// <returns>
+        /// <c>true</c> if a connector client is needed; otherwise, <c>false</c>.
+        /// A connector client is required if the activity's delivery mode is not "ExpectReplies" or "Stream" 
+        /// and the service URL is not null or empty.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">Thrown if the <paramref name="activity"/> is null.</exception>
+        private static bool ResolveIfConnectorClientIsNeeded(IActivity activity)
+        {
+            Microsoft.Agents.Core.AssertionHelpers.ThrowIfNull(activity, nameof(activity));
+            switch (activity.DeliveryMode)
+            {
+                case DeliveryModes.ExpectReplies:
+                case DeliveryModes.Stream: 
+                    if (string.IsNullOrEmpty(activity.ServiceUrl))
+                        return false;
+                    break; 
+                default:
+                    break;
+            }
+            return true;
         }
     }
 }


### PR DESCRIPTION
Introduces a new private static method `ResolveIfConnectorClientIsNeeded` to evaluate if a connector client is required based on the activity's delivery mode and service URL. Updates existing code to utilize this method for improved clarity and maintainability.

Additional Fix #267