### PR TITLE
ProtocolJsonSerializer.ApplyExtensionOptions(lamda) 

### DIFF
--- a/src/libraries/Core/Microsoft.Agents.Core/Serialization/ProtocolJsonSerializer.cs
+++ b/src/libraries/Core/Microsoft.Agents.Core/Serialization/ProtocolJsonSerializer.cs
@@ -53,6 +53,20 @@ namespace Microsoft.Agents.Core.Serialization
             }
         }
 
+        public static void ApplyExtensionOptions(Func<JsonSerializerOptions, JsonSerializerOptions> applyFunc)
+        {
+            lock (_optionsLock)
+            {
+                var newOptions = SerializationOptions;
+                if (newOptions.IsReadOnly)
+                {
+                    newOptions = new JsonSerializerOptions(SerializationOptions);
+                }
+
+                SerializationOptions = applyFunc(newOptions);
+            }
+        }
+
         private static JsonSerializerOptions ApplyCoreOptions(this JsonSerializerOptions options)
         {
             options.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;

--- a/src/libraries/Core/Microsoft.Agents.Core/Serialization/ProtocolJsonSerializer.cs
+++ b/src/libraries/Core/Microsoft.Agents.Core/Serialization/ProtocolJsonSerializer.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Agents.Core.Serialization
             SerializationInitAttribute.InitSerialization();
         }
 
-        public static JsonSerializerOptions CreateConnectorOptions()
+        private static JsonSerializerOptions CreateConnectorOptions()
         {
             var options = new JsonSerializerOptions()
                 .ApplyCoreOptions();

--- a/src/libraries/Storage/Microsoft.Agents.Storage.CosmosDb/CosmosDbPartitionedStorage.cs
+++ b/src/libraries/Storage/Microsoft.Agents.Storage.CosmosDb/CosmosDbPartitionedStorage.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Agents.Storage.CosmosDb
     /// </summary>
     public class CosmosDbPartitionedStorage : IStorage, IDisposable
     {
-        private static readonly JsonSerializerOptions DefaultJsonSerializerOptions = ProtocolJsonSerializer.CreateConnectorOptions();
+        private static readonly JsonSerializerOptions DefaultJsonSerializerOptions = ProtocolJsonSerializer.SerializationOptions;
         private readonly JsonSerializerOptions _serializerOptions;
 
         private Container _container;


### PR DESCRIPTION
- Allow for more control over JsonSerializerOptions
- Mostly needed by MCS, but extensions could need this as well
- Handles creating new options if they had already been used and marked as readonly