### PR TITLE
Fix: Ensure EntityConverter delegates to AIEntityConverter

### DIFF
--- a/src/libraries/Core/Microsoft.Agents.Core/Serialization/Converters/EntityConverter.cs
+++ b/src/libraries/Core/Microsoft.Agents.Core/Serialization/Converters/EntityConverter.cs
@@ -45,6 +45,16 @@ namespace Microsoft.Agents.Core.Serialization.Converters
             return entity;
         }
 
+        public override void Write(Utf8JsonWriter writer, Entity value, JsonSerializerOptions options)
+        {
+            if (value is AIEntity aiEntity)
+            {
+                JsonSerializer.Serialize(writer, aiEntity, options); // delegates to AIEntityConverter
+                return;
+            }
+            base.Write(writer, value, options);
+        }
+
         protected override void ReadExtensionData(ref Utf8JsonReader reader, Entity value, string propertyName, JsonSerializerOptions options)
         {
             var extensionData = JsonSerializer.Deserialize<JsonElement>(ref reader, options);

--- a/src/tests/Microsoft.Agents.Model.Tests/ObjectSerializationTests.cs
+++ b/src/tests/Microsoft.Agents.Model.Tests/ObjectSerializationTests.cs
@@ -362,6 +362,17 @@ namespace Microsoft.Agents.Model.Tests
             Assert.Equal(resultingText, outboundJson);
         }
 
+        [Fact]
+        public void ActivityWithDerivedEntitySerializationTest()
+        {
+            var jsonIn = "{\"membersAdded\":[],\"membersRemoved\":[],\"reactionsAdded\":[],\"reactionsRemoved\":[],\"attachments\":[],\"entities\":[{\"@type\":\"Message\",\"@context\":\"https://schema.org\",\"@id\":\"\",\"additionalType\":[\"AIGeneratedContent\"],\"citation\":[],\"type\":\"https://schema.org/Message\"}],\"listenFor\":[],\"textHighlights\":[]}";
+
+            var activity = ProtocolJsonSerializer.ToObject<Activity>(jsonIn);
+            var jsonOut = ProtocolJsonSerializer.ToJson(activity);
+
+            Assert.Equal(jsonIn, jsonOut);
+        }
+
 #if SKIP_EMPTY_LISTS
         [Fact]
         public void EmptyListDoesntSerialzie()


### PR DESCRIPTION
Fixes #298 
Ensure EntityConverter checks if the value is an AIEntity and delegates serialization, so @type, @context, and @id are included.
