### PR TITLE
Enhance ADO token retrieval by adding JWT parsing functionality

### DIFF
--- a/.github/actions/get-ado-token/action.yml
+++ b/.github/actions/get-ado-token/action.yml
@@ -31,5 +31,32 @@ runs:
       with:
         azPSVersion: "latest"
         inlineScript: |
-          $accessToken = (Get-AzAccessToken -ResourceUrl "https://${{inputs.organization}}.visualstudio.com").Token
+          function Parse-JWTtoken {
+          
+              [cmdletbinding()]
+              param([Parameter(Mandatory=$true)][string]$token)
+          
+              #Payload
+              $tokenPayload = $token.Split(".")[1].Replace('-', '+').Replace('_', '/')
+              #Fix padding as needed, keep adding "=" until string length modulus 4 reaches 0
+              while ($tokenPayload.Length % 4) { Write-Verbose "Invalid length for a Base-64 char array or string, adding ="; $tokenPayload += "=" }
+              Write-Verbose "Base64 encoded (padded) payoad:"
+              Write-Verbose $tokenPayload
+              #Convert to Byte array
+              $tokenByteArray = [System.Convert]::FromBase64String($tokenPayload)
+              #Convert to string array
+              $tokenArray = [System.Text.Encoding]::ASCII.GetString($tokenByteArray)
+              Write-Verbose "Decoded array in JSON format:"
+              Write-Verbose $tokenArray
+              #Convert from JSON to PSObject
+              $tokobj = $tokenArray | ConvertFrom-Json
+              Write-Verbose "Decoded Payload:"
+              
+              return $tokobj
+          }
+          $accessToken = az account get-access-token --resource="https://${{inputs.organization}}.visualstudio.com" --query accessToken
+          Parse-JWTtoken($accessToken)
           "token=$accessToken" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+        #  $accessToken = (Get-AzAccessToken -ResourceUrl "https://${{inputs.organization}}.visualstudio.com").Token
+        #  "token=$accessToken" | Out-File -FilePath $env:GITHUB_OUTPUT -Append


### PR DESCRIPTION
This pull request modifies the `.github/actions/get-ado-token/action.yml` file to enhance token handling and introduce a new function for parsing JWT tokens. The most significant change is the addition of the `Parse-JWTtoken` function, which decodes and parses the payload of a JWT token for better usability and debugging.

Enhancements to token handling:

* Added the `Parse-JWTtoken` function to decode and parse JWT token payloads, including converting the payload from Base64 to JSON format and returning it as a PowerShell object. This improves token processing and debugging capabilities.
* Replaced the `Get-AzAccessToken` command with `az account get-access-token` for obtaining the access token, aligning with updated Azure CLI practices.