### PR TITLE
Add conditional check for FinalMessage in activity.Text

### DIFF
--- a/src/libraries/Builder/Microsoft.Agents.Builder/StreamingResponse.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/StreamingResponse.cs
@@ -316,7 +316,10 @@ namespace Microsoft.Agents.Builder
             var activity = FinalMessage ?? new Activity();
 
             activity.Type = ActivityTypes.Message;
-            activity.Text = !string.IsNullOrEmpty(Message) ? Message : "No text was streamed";   // Teams won't allow Activity.Text changes or empty text
+            if (FinalMessage == null)
+            {
+                activity.Text = !string.IsNullOrEmpty(Message) ? Message : "No text was streamed";   // Teams won't allow Activity.Text changes or empty text
+            }
             activity.Entities ??= [];
 
             // make sure the supplied Activity doesn't have a streamInfo already.


### PR DESCRIPTION
Updated the logic to set `activity.Text` only when `FinalMessage` is null. This prevents overwriting the text if `FinalMessage` is already provided, ensuring the correct message is displayed.