### PR TITLE
Use WriteStringValue and GetString when UnpackObjectStrings is false to handle simple string values correctly

### DIFF
--- a/src/libraries/Core/Microsoft.Agents.Core/Serialization/Converters/ConnectorConverter.cs
+++ b/src/libraries/Core/Microsoft.Agents.Core/Serialization/Converters/ConnectorConverter.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Agents.Core.Serialization.Converters
                         {
                             if (!ProtocolJsonSerializer.UnpackObjectStrings)
                             {
-                                writer.WriteRawValue(s);
+                                writer.WriteStringValue(s);
                             }
                             else
                             {
@@ -207,7 +207,7 @@ namespace Microsoft.Agents.Core.Serialization.Converters
                 {
                     if (!ProtocolJsonSerializer.UnpackObjectStrings)
                     {
-                        var json = element.GetRawText();
+                        var json = element.GetString();
                         setter(json);
                     }
                     else


### PR DESCRIPTION
Fixes #351 
This PR fixes an issue where ConnectorConverter<T>.Write incorrectly calls WriteRawValue on Activity.Value when UnpackObjectStrings is false and Activity.Value contains a simple string.

Since WriteRawValue expects valid JSON, passing a plain string (e.g., "just a string") causes System.Text.Json.JsonReaderException.