### PR TITLE
Added IAccessTokenProvider.GetTokenCredential

### DIFF
--- a/src/libraries/Authentication/Authentication.Msal/MsalTokenCredential.cs
+++ b/src/libraries/Authentication/Authentication.Msal/MsalTokenCredential.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Core;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Agents.Authentication.Msal
+{
+    internal class MsalTokenCredential(MsalAuth connection) : TokenCredential
+    {
+        public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)
+        {
+#pragma warning disable CA2012
+            return GetTokenAsync(requestContext, cancellationToken).Result;
+#pragma warning restore CA2012
+        }
+
+        public override async ValueTask<AccessToken> GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
+        {
+            var result = await connection.InternalGetAccessTokenAsync(requestContext.Scopes[0], requestContext.Scopes);
+            return new AccessToken(result.AccessToken, result.ExpiresOn);
+        }
+    }
+}

--- a/src/libraries/Core/Microsoft.Agents.Authentication/IAccessTokenProvider.cs
+++ b/src/libraries/Core/Microsoft.Agents.Authentication/IAccessTokenProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Azure.Core;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -14,6 +15,11 @@ namespace Microsoft.Agents.Authentication
         /// <param name="forceRefresh">True to force a refresh of the token; or false to get the token only if it is necessary.</param>
         /// <param name="scopes">The scopes for which to get the token.</param>
         /// <param name="resourceUrl">The resource URL for which to get the token.</param>
-        Task<string> GetAccessTokenAsync( string resourceUrl, IList<string> scopes, bool forceRefresh = false );
+        Task<string> GetAccessTokenAsync(string resourceUrl, IList<string> scopes, bool forceRefresh = false);
+
+        /// <summary>
+        /// Returns an Azure TokenCredential using this provider.
+        /// </summary>
+        TokenCredential GetTokenCredential();
     }
 }

--- a/src/libraries/Core/Microsoft.Agents.Authentication/Microsoft.Agents.Authentication.csproj
+++ b/src/libraries/Core/Microsoft.Agents.Authentication/Microsoft.Agents.Authentication.csproj
@@ -20,6 +20,7 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
 		<PackageReference Include="System.Configuration.ConfigurationManager" />
+		<PackageReference Include="Azure.Identity" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/libraries/Storage/Microsoft.Agents.Storage.Blobs/BlobsStorage.cs
+++ b/src/libraries/Storage/Microsoft.Agents.Storage.Blobs/BlobsStorage.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Agents.Storage.Blobs
         /// <param name="storageTransferOptions">Used for providing options for parallel transfers <see cref="StorageTransferOptions"/>.</param>
         /// <param name="options">Client options that define the transport pipeline policies for authentication, retries, etc., that are applied to every request.</param>
         /// <param name="jsonSerializerOptions">Custom JsonSerializerOptions.</param>
-        public BlobsStorage(Uri blobContainerUri, TokenCredential tokenCredential, StorageTransferOptions storageTransferOptions, BlobClientOptions options = default, JsonSerializerOptions jsonSerializerOptions = null)
+        public BlobsStorage(Uri blobContainerUri, TokenCredential tokenCredential, StorageTransferOptions storageTransferOptions = default, BlobClientOptions options = default, JsonSerializerOptions jsonSerializerOptions = null)
         {
             AssertionHelpers.ThrowIfNull(blobContainerUri, nameof(blobContainerUri));
             AssertionHelpers.ThrowIfNull(tokenCredential, nameof(tokenCredential));


### PR DESCRIPTION
Fixes #355

Example:
```csharp
builder.Services.AddSingleton<IStorage>(sp =>
{
    // Get a TokenCredential from your defined Connections
    var tokenCredential = sp.GetService<IConnections>().GetConnection("ServiceConnection").GetTokenCredential();

    return new BlobsStorage(
        new Uri("{{your-blobs-storage-endpoint}}/agent-state"),
        tokenCredential);
});
```
