### PR TITLE
Fix to allow using a Dialog conditionally in AgentApplication

### DIFF
--- a/src/Microsoft.Agents.SDK.sln
+++ b/src/Microsoft.Agents.SDK.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.14.36301.6 d17.14
+VisualStudioVersion = 17.14.36301.6
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Libraries", "Libraries", "{4269F3C3-6B42-419B-B64A-3E6DC0F1574A}"
 EndProject
@@ -132,6 +132,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TeamsAgent", "samples\Teams\TeamsAgent\TeamsAgent.csproj", "{D6410977-B795-C315-CC94-C2482E84BB4A}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MultiAgent", "samples\MultiAgent\MultiAgent.csproj", "{A895CA1A-DA20-E508-FB57-2AFA0F9457FE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DialogAgent", "samples\DialogAgent\DialogAgent.csproj", "{2C4EB57F-20B3-08D6-D2B8-1F0C37FFAA8E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -731,6 +733,18 @@ Global
 		{A895CA1A-DA20-E508-FB57-2AFA0F9457FE}.Release|x64.Build.0 = Release|Any CPU
 		{A895CA1A-DA20-E508-FB57-2AFA0F9457FE}.Release|x86.ActiveCfg = Release|Any CPU
 		{A895CA1A-DA20-E508-FB57-2AFA0F9457FE}.Release|x86.Build.0 = Release|Any CPU
+		{2C4EB57F-20B3-08D6-D2B8-1F0C37FFAA8E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2C4EB57F-20B3-08D6-D2B8-1F0C37FFAA8E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2C4EB57F-20B3-08D6-D2B8-1F0C37FFAA8E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2C4EB57F-20B3-08D6-D2B8-1F0C37FFAA8E}.Debug|x64.Build.0 = Debug|Any CPU
+		{2C4EB57F-20B3-08D6-D2B8-1F0C37FFAA8E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2C4EB57F-20B3-08D6-D2B8-1F0C37FFAA8E}.Debug|x86.Build.0 = Debug|Any CPU
+		{2C4EB57F-20B3-08D6-D2B8-1F0C37FFAA8E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2C4EB57F-20B3-08D6-D2B8-1F0C37FFAA8E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2C4EB57F-20B3-08D6-D2B8-1F0C37FFAA8E}.Release|x64.ActiveCfg = Release|Any CPU
+		{2C4EB57F-20B3-08D6-D2B8-1F0C37FFAA8E}.Release|x64.Build.0 = Release|Any CPU
+		{2C4EB57F-20B3-08D6-D2B8-1F0C37FFAA8E}.Release|x86.ActiveCfg = Release|Any CPU
+		{2C4EB57F-20B3-08D6-D2B8-1F0C37FFAA8E}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -798,6 +812,7 @@ Global
 		{112E7BB8-2368-4061-90DC-3A8D6C7A43E6} = {AD743B78-D61F-4FBF-B620-FA83CE599A50}
 		{D6410977-B795-C315-CC94-C2482E84BB4A} = {674A812C-7287-4883-97F9-697D83750648}
 		{A895CA1A-DA20-E508-FB57-2AFA0F9457FE} = {674A812C-7287-4883-97F9-697D83750648}
+		{2C4EB57F-20B3-08D6-D2B8-1F0C37FFAA8E} = {674A812C-7287-4883-97F9-697D83750648}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F1E8E538-309A-46F8-9CE7-AEC6589FAE60}

--- a/src/libraries/Builder/Microsoft.Agents.Builder.Dialogs/DialogExtensions.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder.Dialogs/DialogExtensions.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Agents.Builder.Dialogs
         /// <param name="cancellationToken">A cancellation token that can be used by other objects
         /// or threads to receive notice of cancellation.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public static async Task RunAsync(this Dialog dialog, ITurnContext turnContext, AgentState state, CancellationToken cancellationToken)
+        public static async Task<DialogTurnResult> RunAsync(this Dialog dialog, ITurnContext turnContext, AgentState state, CancellationToken cancellationToken)
         {
             var dialogState = state.GetValue<DialogState>("DialogState", () => new DialogState());
             var dialogSet = new DialogSet(dialogState);
@@ -42,7 +42,7 @@ namespace Microsoft.Agents.Builder.Dialogs
 
             var dialogContext = await dialogSet.CreateContextAsync(turnContext, cancellationToken).ConfigureAwait(false);
 
-            await InternalRunAsync(turnContext, dialog.Id, dialogContext, cancellationToken).ConfigureAwait(false);
+            return await InternalRunAsync(turnContext, dialog.Id, dialogContext, cancellationToken).ConfigureAwait(false);
         }
 
         [Obsolete("Use the non-IStatePropertyAccessor version")]

--- a/src/samples/DialogAgent/AspNetExtensions.cs
+++ b/src/samples/DialogAgent/AspNetExtensions.cs
@@ -1,0 +1,251 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Agents.Authentication;
+using Microsoft.Agents.Core;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.IdentityModel.Validators;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+public static class AspNetExtensions
+{
+    private static readonly ConcurrentDictionary<string, ConfigurationManager<OpenIdConnectConfiguration>> _openIdMetadataCache = new();
+
+    /// <summary>
+    /// Adds AspNet token validation typical for ABS/SMBA and agent-to-agent using settings in configuration.
+    /// </summary>
+    /// <param name="services"></param>
+    /// <param name="configuration"></param>
+    /// <param name="tokenValidationSectionName">Name of the config section to read.</param>
+    /// <param name="logger">Optional logger to use for authentication event logging.</param>
+    /// <remarks>
+    /// <para>This extension reads <see cref="TokenValidationOptions"/> settings from configuration.  If configuration is missing JWT token
+    /// is not enabled.</para>
+    /// The minimum, but typical, configuration is:
+    /// <code>
+    /// "TokenValidation": {
+    ///    "Audiences": [
+    ///      "{{ClientId}}" // this is the Client ID used for the Azure Bot
+    ///    ],
+    ///    "TenantId": "{{TenantId}}"
+    /// }
+    /// </code>
+    /// </remarks>
+    public static void AddAgentAspNetAuthentication(this IServiceCollection services, IConfiguration configuration, string tokenValidationSectionName = "TokenValidation")
+    {
+        IConfigurationSection tokenValidationSection = configuration.GetSection(tokenValidationSectionName);
+
+        if (!tokenValidationSection.Exists() || !tokenValidationSection.GetValue("Enabled", true))
+        {
+            // Noop if TokenValidation section missing or disabled.
+            System.Diagnostics.Trace.WriteLine("AddAgentAspNetAuthentication: Auth disabled");
+            return;
+        }
+
+        services.AddAgentAspNetAuthentication(tokenValidationSection.Get<TokenValidationOptions>()!);
+    }
+
+    /// <summary>
+    /// Adds AspNet token validation typical for ABS/SMBA and agent-to-agent.
+    /// </summary>
+    public static void AddAgentAspNetAuthentication(this IServiceCollection services, TokenValidationOptions validationOptions)
+    {
+        AssertionHelpers.ThrowIfNull(validationOptions, nameof(validationOptions));
+
+        // Must have at least one Audience.
+        if (validationOptions.Audiences == null || validationOptions.Audiences.Count == 0)
+        {
+            throw new ArgumentException($"{nameof(TokenValidationOptions)}:Audiences requires at least one ClientId");
+        }
+
+        // Audience values must be GUID's
+        foreach (var audience in validationOptions.Audiences)
+        {
+            if (!Guid.TryParse(audience, out _))
+            {
+                throw new ArgumentException($"{nameof(TokenValidationOptions)}:Audiences values must be a GUID");
+            }
+        }
+
+        // If ValidIssuers is empty, default for ABS Public Cloud
+        if (validationOptions.ValidIssuers == null || validationOptions.ValidIssuers.Count == 0)
+        {
+            validationOptions.ValidIssuers =
+            [
+                "https://api.botframework.com",
+                "https://sts.windows.net/d6d49420-f39b-4df7-a1dc-d59a935871db/",
+                "https://login.microsoftonline.com/d6d49420-f39b-4df7-a1dc-d59a935871db/v2.0",
+                "https://sts.windows.net/f8cdef31-a31e-4b4a-93e4-5f571e91255a/",
+                "https://login.microsoftonline.com/f8cdef31-a31e-4b4a-93e4-5f571e91255a/v2.0",
+                "https://sts.windows.net/69e9b82d-4842-4902-8d1e-abc5b98a55e8/",
+                "https://login.microsoftonline.com/69e9b82d-4842-4902-8d1e-abc5b98a55e8/v2.0",
+            ];
+
+            if (!string.IsNullOrEmpty(validationOptions.TenantId) && Guid.TryParse(validationOptions.TenantId, out _))
+            {
+                validationOptions.ValidIssuers.Add(string.Format(CultureInfo.InvariantCulture, AuthenticationConstants.ValidTokenIssuerUrlTemplateV1, validationOptions.TenantId));
+                validationOptions.ValidIssuers.Add(string.Format(CultureInfo.InvariantCulture, AuthenticationConstants.ValidTokenIssuerUrlTemplateV2, validationOptions.TenantId));
+            }
+        }
+
+        // If the `AzureBotServiceOpenIdMetadataUrl` setting is not specified, use the default based on `IsGov`.  This is what is used to authenticate ABS tokens.
+        if (string.IsNullOrEmpty(validationOptions.AzureBotServiceOpenIdMetadataUrl))
+        {
+            validationOptions.AzureBotServiceOpenIdMetadataUrl = validationOptions.IsGov ? AuthenticationConstants.GovAzureBotServiceOpenIdMetadataUrl : AuthenticationConstants.PublicAzureBotServiceOpenIdMetadataUrl;
+        }
+
+        // If the `OpenIdMetadataUrl` setting is not specified, use the default based on `IsGov`.  This is what is used to authenticate Entra ID tokens.
+        if (string.IsNullOrEmpty(validationOptions.OpenIdMetadataUrl))
+        {
+            validationOptions.OpenIdMetadataUrl = validationOptions.IsGov ? AuthenticationConstants.GovOpenIdMetadataUrl : AuthenticationConstants.PublicOpenIdMetadataUrl;
+        }
+
+        var openIdMetadataRefresh = validationOptions.OpenIdMetadataRefresh ?? BaseConfigurationManager.DefaultAutomaticRefreshInterval;
+
+        _ = services.AddAuthentication(options =>
+        {
+            options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+            options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+        })
+        .AddJwtBearer(options =>
+        {
+            options.SaveToken = true;
+            options.TokenValidationParameters = new TokenValidationParameters
+            {
+                ValidateIssuer = true,
+                ValidateAudience = true,
+                ValidateLifetime = true,
+                ClockSkew = TimeSpan.FromMinutes(5),
+                ValidIssuers = validationOptions.ValidIssuers,
+                ValidAudiences = validationOptions.Audiences,
+                ValidateIssuerSigningKey = true,
+                RequireSignedTokens = true,
+            };
+
+            // Using Microsoft.IdentityModel.Validators
+            options.TokenValidationParameters.EnableAadSigningKeyIssuerValidation();
+
+            options.Events = new JwtBearerEvents
+            {
+                // Create a ConfigurationManager based on the requestor.  This is to handle ABS non-Entra tokens.
+                OnMessageReceived = async context =>
+                {
+                    string authorizationHeader = context.Request.Headers.Authorization.ToString();
+
+                    if (string.IsNullOrEmpty(authorizationHeader))
+                    {
+                        // Default to AadTokenValidation handling
+                        context.Options.TokenValidationParameters.ConfigurationManager ??= options.ConfigurationManager as BaseConfigurationManager;
+                        await Task.CompletedTask.ConfigureAwait(false);
+                        return;
+                    }
+
+                    string[] parts = authorizationHeader?.Split(' ')!;
+                    if (parts.Length != 2 || parts[0] != "Bearer")
+                    {
+                        // Default to AadTokenValidation handling
+                        context.Options.TokenValidationParameters.ConfigurationManager ??= options.ConfigurationManager as BaseConfigurationManager;
+                        await Task.CompletedTask.ConfigureAwait(false);
+                        return;
+                    }
+
+                    JwtSecurityToken token = new(parts[1]);
+                    string issuer = token.Claims.FirstOrDefault(claim => claim.Type == AuthenticationConstants.IssuerClaim)?.Value!;
+
+                    if (validationOptions.AzureBotServiceTokenHandling && AuthenticationConstants.BotFrameworkTokenIssuer.Equals(issuer))
+                    {
+                        // Use the Azure Bot authority for this configuration manager
+                        context.Options.TokenValidationParameters.ConfigurationManager = _openIdMetadataCache.GetOrAdd(validationOptions.AzureBotServiceOpenIdMetadataUrl, key =>
+                        {
+                            return new ConfigurationManager<OpenIdConnectConfiguration>(validationOptions.AzureBotServiceOpenIdMetadataUrl, new OpenIdConnectConfigurationRetriever(), new HttpClient())
+                            {
+                                AutomaticRefreshInterval = openIdMetadataRefresh
+                            };
+                        });
+                    }
+                    else
+                    {
+                        context.Options.TokenValidationParameters.ConfigurationManager = _openIdMetadataCache.GetOrAdd(validationOptions.OpenIdMetadataUrl, key =>
+                        {
+                            return new ConfigurationManager<OpenIdConnectConfiguration>(validationOptions.OpenIdMetadataUrl, new OpenIdConnectConfigurationRetriever(), new HttpClient())
+                            {
+                                AutomaticRefreshInterval = openIdMetadataRefresh
+                            };
+                        });
+                    }
+
+                    await Task.CompletedTask.ConfigureAwait(false);
+                },
+
+                OnTokenValidated = context =>
+                {
+                    return Task.CompletedTask;
+                },
+                OnForbidden = context =>
+                {
+                    return Task.CompletedTask;
+                },
+                OnAuthenticationFailed = context =>
+                {
+                    return Task.CompletedTask;
+                }
+            };
+        });
+    }
+
+    public class TokenValidationOptions
+    {
+        public IList<string>? Audiences { get; set; }
+
+        /// <summary>
+        /// TenantId of the Azure Bot.  Optional but recommended. 
+        /// </summary>
+        public string? TenantId { get; set; }
+
+        /// <summary>
+        /// Additional valid issuers.  Optional, in which case the Public Azure Bot Service issuers are used.
+        /// </summary>
+        public IList<string>? ValidIssuers { get; set; }
+
+        /// <summary>
+        /// Can be omitted, in which case public Azure Bot Service and Azure Cloud metadata urls are used.
+        /// </summary>
+        public bool IsGov { get; set; } = false;
+
+        /// <summary>
+        /// Azure Bot Service OpenIdMetadataUrl.  Optional, in which case default value depends on IsGov.
+        /// </summary>
+        /// <see cref="AuthenticationConstants.PublicAzureBotServiceOpenIdMetadataUrl"/>
+        /// <see cref="AuthenticationConstants.GovAzureBotServiceOpenIdMetadataUrl"/>
+        public string? AzureBotServiceOpenIdMetadataUrl { get; set; }
+
+        /// <summary>
+        /// Entra OpenIdMetadataUrl.  Optional, in which case default value depends on IsGov.
+        /// </summary>
+        /// <see cref="AuthenticationConstants.PublicOpenIdMetadataUrl"/>
+        /// <see cref="AuthenticationConstants.GovOpenIdMetadataUrl"/>
+        public string? OpenIdMetadataUrl { get; set; }
+
+        /// <summary>
+        /// Determines if Azure Bot Service tokens are handled.  Defaults to true and should always be true until Azure Bot Service sends Entra ID token.
+        /// </summary>
+        public bool AzureBotServiceTokenHandling { get; set; } = true;
+
+        /// <summary>
+        /// OpenIdMetadata refresh interval.  Defaults to 12 hours.
+        /// </summary>
+        public TimeSpan? OpenIdMetadataRefresh { get; set; }
+    }
+}

--- a/src/samples/DialogAgent/DialogAgent.csproj
+++ b/src/samples/DialogAgent/DialogAgent.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<LangVersion>latest</LangVersion>
+		<ImplicitUsings>disable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<Compile Remove="wwwroot\**" />
+		<Content Remove="wwwroot\**" />
+		<EmbeddedResource Remove="wwwroot\**" />
+		<None Remove="wwwroot\**" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\libraries\Authentication\Authentication.Msal\Microsoft.Agents.Authentication.Msal.csproj" />
+		<ProjectReference Include="..\..\libraries\Builder\Microsoft.Agents.Builder.Dialogs\Microsoft.Agents.Builder.Dialogs.csproj" />
+		<ProjectReference Include="..\..\libraries\Hosting\AspNetCore\Microsoft.Agents.Hosting.AspNetCore.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/samples/DialogAgent/DialogAgentApplication.cs
+++ b/src/samples/DialogAgent/DialogAgentApplication.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Agents.Builder;
+using Microsoft.Agents.Builder.App;
+using Microsoft.Agents.Builder.State;
+using Microsoft.Agents.Core.Models;
+using System.Threading.Tasks;
+using System.Threading;
+using Microsoft.Agents.Builder.Dialogs;
+using Microsoft.Agents.Core.Serialization;
+
+namespace DialogAgent;
+
+public class DialogAgentApplication : AgentApplication
+{
+    public DialogAgentApplication(AgentApplicationOptions options) : base(options)
+    {
+        OnConversationUpdate(ConversationUpdateEvents.MembersAdded, WelcomeMessageAsync);
+        OnMessage("-dialog", OnStartDialogAsync);
+        OnActivity(ActivityTypes.Message, OnMessageAsync, rank: RouteRank.Last);
+    }
+
+    private async Task WelcomeMessageAsync(ITurnContext turnContext, ITurnState turnState, CancellationToken cancellationToken)
+    {
+        foreach (ChannelAccount member in turnContext.Activity.MembersAdded)
+        {
+            if (member.Id != turnContext.Activity.Recipient.Id)
+            {
+                await turnContext.SendActivityAsync(MessageFactory.Text("Hello and Welcome!"), cancellationToken);
+            }
+        }
+    }
+
+    private async Task OnStartDialogAsync(ITurnContext turnContext, ITurnState turnState, CancellationToken cancellationToken)
+    {
+        var activeDialog = turnState.User.GetValue<string>("ActiveDialog");
+        if (!string.IsNullOrEmpty(activeDialog))
+        {
+            await turnContext.SendActivityAsync($"Dialog '{activeDialog}' already active", cancellationToken: cancellationToken);
+            return;
+        }
+
+        turnState.User.SetValue("ActiveDialog", nameof(UserProfileDialog));
+        var dialog = new UserProfileDialog(turnState);
+        var dialogResult = await dialog.RunAsync(turnContext, turnState.Conversation, cancellationToken);
+    }
+
+    private async Task OnMessageAsync(ITurnContext turnContext, ITurnState turnState, CancellationToken cancellationToken)
+    {
+        var activeDialog = turnState.User.GetValue<string>("ActiveDialog");
+        if (string.IsNullOrEmpty(activeDialog))
+        {
+            await turnContext.SendActivityAsync($"You said: {turnContext.Activity.Text}", cancellationToken: cancellationToken);
+        }
+        else
+        {
+            var dialog = new UserProfileDialog(turnState);
+            var dialogResult = await dialog.RunAsync(turnContext, turnState.Conversation, cancellationToken);
+            if (   dialogResult?.Status == DialogTurnStatus.Complete
+                || dialogResult?.Status == DialogTurnStatus.CompleteAndWait
+                || dialogResult?.Status == DialogTurnStatus.Cancelled)
+            {
+                turnState.User.DeleteValue("ActiveDialog");
+                await turnContext.SendActivityAsync($"Dialog '{activeDialog}' complete.\nResult={ProtocolJsonSerializer.ToJson(dialogResult.Result)}", cancellationToken: cancellationToken);
+            }
+        }
+    }
+}

--- a/src/samples/DialogAgent/Program.cs
+++ b/src/samples/DialogAgent/Program.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using DialogAgent;
+using Microsoft.Agents.Builder;
+using Microsoft.Agents.Hosting.AspNetCore;
+using Microsoft.Agents.Storage;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using System.Threading;
+
+WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddHttpClient();
+
+// Add AgentApplicationOptions from appsettings section "AgentApplication".
+builder.AddAgentApplicationOptions();
+
+// Add the AgentApplication, which contains the logic for responding to
+// user messages.
+builder.AddAgent<DialogAgentApplication>();
+
+// Register IStorage.  For development, MemoryStorage is suitable.
+// For production Agents, persisted storage should be used so
+// that state survives Agent restarts, and operates correctly
+// in a cluster of Agent instances.
+builder.Services.AddSingleton<IStorage, MemoryStorage>();
+
+// Configure the HTTP request pipeline.
+
+// Add AspNet token validation for Azure Bot Service and Entra.  Authentication is
+// configured in the appsettings.json "TokenValidation" section.
+builder.Services.AddControllers();
+builder.Services.AddAgentAspNetAuthentication(builder.Configuration);
+
+WebApplication app = builder.Build();
+
+// Enable AspNet authentication and authorization
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapGet("/", () => "Microsoft Agents SDK Sample");
+
+// This receives incoming messages from Azure Bot Service or other SDK Agents
+var incomingRoute = app.MapPost("/api/messages", async (HttpRequest request, HttpResponse response, IAgentHttpAdapter adapter, IAgent agent, CancellationToken cancellationToken) =>
+{
+    await adapter.ProcessAsync(request, response, agent, cancellationToken);
+});
+
+if (!app.Environment.IsDevelopment())
+{
+    incomingRoute.RequireAuthorization();
+}
+else
+{
+    // Hardcoded for brevity and ease of testing. 
+    // In production, this should be set in configuration.
+    app.Urls.Add($"http://localhost:3978");
+}
+
+app.Run();

--- a/src/samples/DialogAgent/README.md
+++ b/src/samples/DialogAgent/README.md
@@ -1,0 +1,121 @@
+﻿# EmptyAgent Sample
+
+This is a sample of a simple Agent that is hosted on an Asp.net core web service.  This Agent is configured to accept a request and echo the text of the request back to the caller.
+
+This Agent Sample is intended to introduce you the basic operation of the Microsoft 365 Agents SDK messaging loop. It can also be used as a the base for a custom Agent that you choose to develop.
+
+## Prerequisites
+
+- [.Net](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) version 8.0
+- [dev tunnel](https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/get-started?tabs=windows)
+- [Microsoft 365 Agents Toolkit](https://github.com/OfficeDev/microsoft-365-agents-toolkit)
+
+## QuickestStart using Agent Toolkit
+1. If you haven't done so already, install the Agents Playground
+ 
+   ```
+   winget install agentsplayground
+   ```
+1. Start the Agent in VS or VS Code in debug
+1. Start Agents Playground.  At a command prompt: `agentsplayground`
+   - The tool will open a web browser showing the Microsoft 365 Agents Playgroun, ready to send messages to your agent. 
+1. Interact with the Agent via the browser
+
+## QuickStart using WebChat or Teams
+
+- Overview of running and testing an Agent
+  - Provision an Azure Bot in your Azure Subscription
+  - Configure your Agent settings to use to desired authentication type
+  - Running an instance of the Agent app (either locally or deployed to Azure)
+  - Test in a client
+
+1. Create an Azure Bot with one of these authentication types
+   - [SingleTenant, Client Secret](https://github.com/microsoft/Agents/blob/main/docs/HowTo/azurebot-create-single-secret.md)
+   - [SingleTenant, Federated Credentials](https://github.com/microsoft/Agents/blob/main/docs/HowTo/azurebot-create-fic.md) 
+   - [User Assigned Managed Identity](https://github.com/microsoft/Agents/blob/main/docs/HowTo/azurebot-create-msi.md)
+
+1. Configuring the authentication connection in the Agent settings
+   > These instructions are for **SingleTenant, Client Secret**. For other auth type configuration, see [DotNet MSAL Authentication](https://github.com/microsoft/Agents/blob/main/docs/HowTo/MSALAuthConfigurationOptions.md).
+   1. Open the `appsettings.json` file in the root of the sample project.
+
+   1. Find the section labeled `Connections`,  it should appear similar to this:
+
+      ```json
+      "Connections": {
+        "ServiceConnection": {
+          "Settings": {
+            "AuthType": "ClientSecret", // this is the AuthType for the connection, valid values can be found in Microsoft.Agents.Authentication.Msal.Model.AuthTypes.  The default is ClientSecret.
+            "AuthorityEndpoint": "https://login.microsoftonline.com/{{TenantId}}",
+            "ClientId": "{{ClientId}}", // this is the Client ID used for the connection.
+            "ClientSecret": "{{ClientSecret}}", // this is the Client Secret used for the connection.
+            "Scopes": [
+              "https://api.botframework.com/.default"
+            ]
+          }
+        }
+      },
+      ```
+
+      1. Replace all **{{ClientId}}** with the AppId of the Azure Bot.
+      1. Replace all **{{TenantId}}** with the Tenant Id where your application is registered.
+      1. Set the **{{ClientSecret}}** to the Secret that was created on the App Registration.
+      
+      > Storing sensitive values in appsettings is not recommend.  Follow [AspNet Configuration](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-9.0) for best practices.
+
+1. Running the Agent
+   1. Running the Agent locally
+      - Requires a tunneling tool to allow for local development and debugging should you wish to do local development whilst connected to a external client such as Microsoft Teams.
+      - **For ClientSecret or Certificate authentication types only.**  Federated Credentials and Managed Identity will not work via a tunnel to a local agent and must be deployed to an App Service or container.
+      
+      1. Run `dev tunnels`. Please follow [Create and host a dev tunnel](https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/get-started?tabs=windows) and host the tunnel with anonymous user access command as shown below:
+
+         ```bash
+         devtunnel host -p 3978 --allow-anonymous
+         ```
+
+      1. On the Azure Bot, select **Settings**, then **Configuration**, and update the **Messaging endpoint** to `{tunnel-url}/api/messages`
+
+      1. Start the Agent in Visual Studio
+
+   1. Deploy Agent code to Azure
+      1. VS Publish works well for this.  But any tools used to deploy a web application will also work.
+      1. On the Azure Bot, select **Settings**, then **Configuration**, and update the **Messaging endpoint** to `https://{{appServiceDomain}}/api/messages`
+
+## Testing this agent with WebChat
+
+   1. Select **Test in WebChat** on the Azure Bot
+
+## Testing this Agent in Teams or M365
+
+1. Update the manifest.json
+   - Edit the `manifest.json` contained in the `/appManifest` folder
+     - Replace with your AppId (that was created above) *everywhere* you see the place holder string `<<AAD_APP_CLIENT_ID>>`
+     - Replace `<<BOT_DOMAIN>>` with your Agent url.  For example, the tunnel host name.
+   - Zip up the contents of the `/appManifest` folder to create a `manifest.zip`
+     - `manifest.json`
+     - `outline.png`
+     - `color.png`
+
+1. Your Azure Bot should have the **Microsoft Teams** channel added under **Channels**.
+
+1. Navigate to the Microsoft Admin Portal (MAC). Under **Settings** and **Integrated Apps,** select **Upload Custom App**.
+
+1. Select the `manifest.zip` created in the previous step. 
+
+1. After a short period of time, the agent shows up in Microsoft Teams and Microsoft 365 Copilot.
+
+## Enabling JWT token validation
+1. By default, the AspNet token validation is disabled in order to support local debugging.
+1. Enable by updating appsettings
+   ```json
+   "TokenValidation": {
+     "Enabled": false,
+     "Audiences": [
+       "{{ClientId}}" // this is the Client ID used for the Azure Bot
+     ],
+     "TenantId": "{{TenantId}}"
+   },
+   ```
+
+## Further reading
+To learn more about building Agents, see our [Microsoft 365 Agents SDK](https://github.com/microsoft/agents) repo.

--- a/src/samples/DialogAgent/UserProfile.cs
+++ b/src/samples/DialogAgent/UserProfile.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Agents.Core.Models;
+
+namespace DialogAgent;
+
+/// <summary>
+/// This is our application state. Just a regular serializable .NET class.
+/// </summary>
+public class UserProfile
+{
+    public string? Transport { get; set; }
+
+    public string? Name { get; set; }
+
+    public int? Age { get; set; }
+
+    public Attachment? Picture { get; set; }
+}

--- a/src/samples/DialogAgent/UserProfileDialog.cs
+++ b/src/samples/DialogAgent/UserProfileDialog.cs
@@ -1,0 +1,217 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Agents.Builder.Dialogs;
+using Microsoft.Agents.Builder.Dialogs.Choices;
+using Microsoft.Agents.Builder.Dialogs.Prompts;
+using Microsoft.Agents.Builder.State;
+using Microsoft.Agents.Core.Models;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DialogAgent;
+
+public class UserProfileDialog : ComponentDialog
+{
+    private readonly UserProfile _userProfile;
+
+    public UserProfileDialog(ITurnState turnState)
+        : base(nameof(UserProfileDialog))
+    {
+        _userProfile = turnState.User.GetValue("UserProfile", () => new UserProfile());
+
+        // This array defines how the Waterfall will execute.
+        var waterfallSteps = new WaterfallStep[]
+        {
+            TransportStepAsync,
+            NameStepAsync,
+            NameConfirmStepAsync,
+            AgeStepAsync,
+            PictureStepAsync,
+            SummaryStepAsync,
+            ConfirmStepAsync,
+        };
+
+        // Add named dialogs to the DialogSet. These names are saved in the dialog state.
+        AddDialog(new WaterfallDialog(nameof(WaterfallDialog), waterfallSteps));
+        AddDialog(new TextPrompt(nameof(TextPrompt)));
+        AddDialog(new NumberPrompt<int>(nameof(NumberPrompt<int>), AgePromptValidatorAsync));
+        AddDialog(new ChoicePrompt(nameof(ChoicePrompt)));
+        AddDialog(new ConfirmPrompt(nameof(ConfirmPrompt)));
+        AddDialog(new AttachmentPrompt(nameof(AttachmentPrompt), PicturePromptValidatorAsync));
+
+        // The initial child Dialog to run.
+        InitialDialogId = nameof(WaterfallDialog);
+    }
+
+    private static async Task<DialogTurnResult> TransportStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+    {
+        // WaterfallStep always finishes with the end of the Waterfall or with another dialog; here it is a Prompt Dialog.
+        // Running a prompt here means the next WaterfallStep will be run when the user's response is received.
+        return await stepContext.PromptAsync(nameof(ChoicePrompt),
+            new PromptOptions
+            {
+                Prompt = MessageFactory.Text("Please enter your mode of transport."),
+                Choices = ChoiceFactory.ToChoices(new List<string> { "Car", "Bus", "Bicycle" }),
+            }, cancellationToken);
+    }
+
+    private static async Task<DialogTurnResult> NameStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+    {
+        stepContext.Values["transport"] = ((FoundChoice)stepContext.Result).Value;
+
+        return await stepContext.PromptAsync(nameof(TextPrompt), new PromptOptions { Prompt = MessageFactory.Text("Please enter your name.") }, cancellationToken);
+    }
+
+    private async Task<DialogTurnResult> NameConfirmStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+    {
+        stepContext.Values["name"] = (string)stepContext.Result;
+
+        // We can send messages to the user at any point in the WaterfallStep.
+        await stepContext.Context.SendActivityAsync(MessageFactory.Text($"Thanks {stepContext.Result}."), cancellationToken);
+
+        // WaterfallStep always finishes with the end of the Waterfall or with another dialog; here it is a Prompt Dialog.
+        return await stepContext.PromptAsync(nameof(ConfirmPrompt), new PromptOptions { Prompt = MessageFactory.Text("Would you like to give your age?") }, cancellationToken);
+    }
+
+    private async Task<DialogTurnResult> AgeStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+    {
+        if ((bool)stepContext.Result)
+        {
+            // User said "yes" so we will be prompting for the age.
+            // WaterfallStep always finishes with the end of the Waterfall or with another dialog; here it is a Prompt Dialog.
+            var promptOptions = new PromptOptions
+            {
+                Prompt = MessageFactory.Text("Please enter your age."),
+                RetryPrompt = MessageFactory.Text("The value entered must be greater than 0 and less than 150."),
+            };
+
+            return await stepContext.PromptAsync(nameof(NumberPrompt<int>), promptOptions, cancellationToken);
+        }
+        else
+        {
+            // User said "no" so we will skip the next step. Give -1 as the age.
+            return await stepContext.NextAsync(-1, cancellationToken);
+        }
+    }
+
+    private static async Task<DialogTurnResult> PictureStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+    {
+        stepContext.Values["age"] = (int)stepContext.Result;
+
+        var msg = (int)stepContext.Values["age"] == -1 ? "No age given." : $"I have your age as {stepContext.Values["age"]}.";
+
+        // We can send messages to the user at any point in the WaterfallStep.
+        await stepContext.Context.SendActivityAsync(MessageFactory.Text(msg), cancellationToken);
+
+        if (stepContext.Context.Activity.ChannelId == Channels.Msteams)
+        {
+            // This attachment prompt example is not designed to work for Teams attachments, so skip it in this case
+            await stepContext.Context.SendActivityAsync(MessageFactory.Text("Skipping attachment prompt in Teams channel..."), cancellationToken);
+            return await stepContext.NextAsync(null, cancellationToken);
+        }
+        else
+        {
+            // WaterfallStep always finishes with the end of the Waterfall or with another dialog; here it is a Prompt Dialog.
+            var promptOptions = new PromptOptions
+            {
+                Prompt = MessageFactory.Text("Please attach a profile picture (or type any message to skip)."),
+                RetryPrompt = MessageFactory.Text("The attachment must be a jpeg/png image file."),
+            };
+
+            return await stepContext.PromptAsync(nameof(AttachmentPrompt), promptOptions, cancellationToken);
+        }
+    }
+
+    private async Task<DialogTurnResult> SummaryStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+    {
+        stepContext.Values["picture"] = ((IList<Attachment>)stepContext.Result)?.FirstOrDefault();
+
+        _userProfile.Transport = (string)stepContext.Values["transport"];
+        _userProfile.Name = (string)stepContext.Values["name"];
+        _userProfile.Age = (int)stepContext.Values["age"];
+        _userProfile.Picture = (Attachment)stepContext.Values["picture"];
+
+        var msg = $"I have your mode of transport as {_userProfile.Transport} and your name as {_userProfile.Name}";
+
+        if (_userProfile.Age != -1)
+        {
+            msg += $" and your age as {_userProfile.Age}";
+        }
+
+        msg += ".";
+
+        await stepContext.Context.SendActivityAsync(MessageFactory.Text(msg), cancellationToken);
+
+        if (_userProfile.Picture != null)
+        {
+            try
+            {
+                await stepContext.Context.SendActivityAsync(MessageFactory.Attachment(_userProfile.Picture, "This is your profile picture."), cancellationToken);
+            }
+            catch
+            {
+                await stepContext.Context.SendActivityAsync(MessageFactory.Text("A profile picture was saved but could not be displayed here."), cancellationToken);
+            }
+        }
+
+        // WaterfallStep always finishes with the end of the Waterfall or with another dialog; here it is a Prompt Dialog.
+        return await stepContext.PromptAsync(nameof(ConfirmPrompt), new PromptOptions { Prompt = MessageFactory.Text("Is this ok?") }, cancellationToken);
+    }
+
+    private async Task<DialogTurnResult> ConfirmStepAsync(WaterfallStepContext stepContext, CancellationToken cancellationToken)
+    {
+        var msg = $"Thanks. ";
+
+        if ((bool)stepContext.Result)
+        {
+            msg += $" Your profile saved successfully.";
+        }
+        else
+        {
+            msg += $" Your profile will not be kept.";
+        }
+
+        await stepContext.Context.SendActivityAsync(MessageFactory.Text(msg), cancellationToken);
+
+        // WaterfallStep always finishes with the end of the Waterfall or with another dialog; here it is the end.
+        return await stepContext.EndDialogAsync(result: _userProfile, cancellationToken: cancellationToken);
+    }
+
+    private static Task<bool> AgePromptValidatorAsync(PromptValidatorContext<int> promptContext, CancellationToken cancellationToken)
+    {
+        // This condition is our validation rule. You can also change the value at this point.
+        return Task.FromResult(promptContext.Recognized.Succeeded && promptContext.Recognized.Value > 0 && promptContext.Recognized.Value < 150);
+    }
+
+    private static async Task<bool> PicturePromptValidatorAsync(PromptValidatorContext<IList<Attachment>> promptContext, CancellationToken cancellationToken)
+    {
+        if (promptContext.Recognized.Succeeded)
+        {
+            var attachments = promptContext.Recognized.Value;
+            var validImages = new List<Attachment>();
+
+            foreach (var attachment in attachments)
+            {
+                if (attachment.ContentType == "image/jpeg" || attachment.ContentType == "image/png")
+                {
+                    validImages.Add(attachment);
+                }
+            }
+
+            promptContext.Recognized.Value = validImages;
+
+            // If none of the attachments are valid images, the retry prompt should be sent.
+            return validImages.Any();
+        }
+        else
+        {
+            await promptContext.Context.SendActivityAsync("No attachments received. Proceeding without a profile picture...");
+
+            // We can return true from a validator function even if Recognized.Succeeded is false.
+            return true;
+        }
+    }
+}

--- a/src/samples/DialogAgent/appsettings.json
+++ b/src/samples/DialogAgent/appsettings.json
@@ -1,0 +1,42 @@
+{
+  "TokenValidation": {
+    "Enabled": false,
+    "Audiences": [
+      "{{ClientId}}" // this is the Client ID used for the Azure Bot
+    ],
+    "TenantId": "{{TenantId}}"
+  },
+
+  "AgentApplication": {
+    "StartTypingTimer": false,
+    "RemoveRecipientMention": false,
+    "NormalizeMentions": false
+  },
+
+  "Connections": {
+    "ServiceConnection": {
+      "Settings": {
+        "AuthType": "ClientSecret", // this is the AuthType for the connection, valid values can be found in Microsoft.Agents.Authentication.Msal.Model.AuthTypes.  The default is ClientSecret.
+        "AuthorityEndpoint": "https://login.microsoftonline.com/{{TenantId}}",
+        "ClientId": "{{ClientId}}", // this is the Client ID used for the Azure Bot
+        "ClientSecret": "00000000-0000-0000-0000-000000000000", // this is the Client Secret used for the connection.
+        "Scopes": [
+          "https://api.botframework.com/.default"
+        ]
+      }
+    }
+  },
+  "ConnectionsMap": [
+    {
+      "ServiceUrl": "*",
+      "Connection": "ServiceConnection"
+    }
+  ],
+
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}


### PR DESCRIPTION
- `DialogExtensions.RunAsync` will return `DialogTurnResult`
- Sample to show conditionally running a dialog to completion
  - This puts the burden of tracking state on the dev, and likely not the final solution.  It does clear a blocker though.
  - No intention on publishing this sample at the moment