### PR TITLE
Moved TranscriptLoggerMiddleware out of Compat

### DIFF
--- a/src/libraries/Builder/Microsoft.Agents.Builder/TranscriptLoggerMiddleware.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/TranscriptLoggerMiddleware.cs
@@ -8,7 +8,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Microsoft.Agents.Builder.Compat
+namespace Microsoft.Agents.Builder
 {
     /// <summary>
     /// Middleware for logging incoming and outgoing activities to an <see cref="ITranscriptStore"/>.


### PR DESCRIPTION
Did not need to create a type forward as it was moved to `Microsoft.Agents.Builder`. 

To use, still the following in Program.cs (as before):

```
builder.Services.AddSingleton<Microsoft.Agents.Builder.IMiddleware[]>([new TranscriptLoggerMiddleware(new FileTranscriptLogger())]);
```