### PR TITLE
Add A365 .NET SDK as dependency in Agents .NET SDK

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -101,5 +101,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.1" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
     <PackageVersion Include="Google.Protobuf" Version="3.27.3" />
+    <!-- Agent 365 -->
+    <PackageVersion Include="Microsoft.Agent365.Sdk" Version="1.0.2-alfehr-preview" />
   </ItemGroup>
 </Project>

--- a/nuget.config
+++ b/nuget.config
@@ -13,6 +13,7 @@
     <clear/>
     <!--<add key="DPX-Tools-Upstream" value="https://pkgs.dev.azure.com/dynamicscrm/OneCRM/_packaging/DPX-Tools-Upstream/nuget/v3/index.json" /> -->
     <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+    <add key="maven-scoped" value="https://msazure.pkgs.visualstudio.com/_packaging/maven-scoped/nuget/v3/index.json" />
   </packageSources>
   
   <disabledPackageSources>
@@ -22,4 +23,13 @@
     <add key="format" value="0" />
     <add key="disabled" value="False" />
   </packageManagement>
+
+  <packageSourceMapping>
+    <packageSource key="nuget">
+      <package pattern="*" />
+    </packageSource>
+    <packageSource key="maven-scoped">
+      <package pattern="Microsoft.Agent365.Sdk" />
+    </packageSource>
+  </packageSourceMapping>
 </configuration>

--- a/src/libraries/Hosting/AspNetCore/Microsoft.Agents.Hosting.AspNetCore.csproj
+++ b/src/libraries/Hosting/AspNetCore/Microsoft.Agents.Hosting.AspNetCore.csproj
@@ -41,6 +41,7 @@
 		<PackageReference Include="Microsoft.AspNetCore.Authorization" />
 		<PackageReference Include="Microsoft.IdentityModel.Validators" />
 		<PackageReference Include="System.IdentityModel.Tokens.Jwt" />
+		<PackageReference Include="Microsoft.Agent365.Sdk" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
**Why?**
The [Agents365 SDK](https://github.com/[microsoft/Agent365](https://github.com/microsoft/Agent365)) can be used to trace agent execution. To use this SDK to trace an agent built with .NET Agents SDK, the Agents 365 package needs to be built by checking out the linked repo OR is available on an internal feed. This makes it harder to use with the .NET Agents SDK.

**What?**
Add the Agents 365 SDK as a dependency.

**Validation**
```dotnet pack --no-build --no-restore -c debug Microsoft.Agents.SDK.sln``` generates a Microsoft.Agents.Hosting.AspNetCore package that has Agent365 package as dependency. 

Create a local nuget feed with above. 
<img width="1500" height="507" alt="image" src="https://github.com/user-attachments/assets/ba52eb4c-e312-4163-878c-606ba8c57a37" />

In the solution creating agent using Agents .NET SDK, update to use Microsoft.Agents.* packages from local feed. 
<img width="3010" height="603" alt="image" src="https://github.com/user-attachments/assets/ecb0bdc2-8857-4a87-99d7-45e588539115" />

Rebuilding solution shows Agents365 is added as a dependency
<img width="503" height="577" alt="image" src="https://github.com/user-attachments/assets/fe0ba3a0-7328-4610-83ca-7df7b7ef4a28" />




