### PR TITLE
Fixed HostedActivityService for Agent registered with a factory

### DIFF
--- a/src/libraries/Hosting/AspNetCore/BackgroundQueue/HostedActivityService.cs
+++ b/src/libraries/Hosting/AspNetCore/BackgroundQueue/HostedActivityService.cs
@@ -137,6 +137,11 @@ namespace Microsoft.Agents.Hosting.AspNetCore.BackgroundQueue
                     // else that is transient as part of the Agent, that uses IServiceProvider will encounter error since that is scoped
                     // and disposed before this gets called.
                     var agent = _serviceProvider.GetService(activityWithClaims.AgentType ?? typeof(IAgent));
+                    if (agent == null)
+                    {
+                        agent = _serviceProvider.GetService(typeof(IAgent));
+                    }
+
                     HeaderPropagationContext.HeadersFromRequest = activityWithClaims.Headers;
 
                     if (activityWithClaims.IsProactive)


### PR DESCRIPTION
Agents creating an `AgentApplication` using a factory would fail when receiving a request.  Due to change in #362.

For example, in Program.cs:

```
builder.AddAgent(sp =>
{
    var app = new AgentApplication(sp.GetRequiredService<AgentApplicationOptions>());

   // add routes

   return app;
}