### PR TITLE
Adds a fallback mechanic to support falling back to standard messaging when streaming fails for a not supported reason.

### DIFF
--- a/src/libraries/Builder/Microsoft.Agents.Builder/ChannelAdapter.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/ChannelAdapter.cs
@@ -27,11 +27,11 @@ namespace Microsoft.Agents.Builder
         /// <summary>
         /// Logger for the Adapter. 
         /// </summary>
-        private readonly ILogger? _logger;
+        public ILogger? Logger { get; set; }
 
         public ChannelAdapter(ILogger logger = null)
         {
-            _logger = logger ?? NullLogger.Instance;
+            Logger = logger ?? NullLogger.Instance;
         }
 
         /// <inheritdoc/>

--- a/src/libraries/Builder/Microsoft.Agents.Builder/ChannelServiceAdapterBase.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/ChannelServiceAdapterBase.cs
@@ -12,7 +12,6 @@ using Microsoft.Agents.Connector.Types;
 using Microsoft.Agents.Core;
 using Microsoft.Agents.Core.Models;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Microsoft.Agents.Builder
 {
@@ -32,14 +31,6 @@ namespace Microsoft.Agents.Builder
         /// The <see cref="IChannelServiceClientFactory" /> instance for this adapter.
         /// </value>
         protected IChannelServiceClientFactory ChannelServiceFactory { get; private set; } = channelServiceClientFactory ?? throw new ArgumentNullException(nameof(channelServiceClientFactory));
-
-        /// <summary>
-        /// Gets a <see cref="ILogger" /> to use within this adapter and its subclasses.
-        /// </summary>
-        /// <value>
-        /// The <see cref="ILogger" /> instance for this adapter.
-        /// </value>
-        protected ILogger Logger { get; private set; } = logger ?? NullLogger.Instance;
 
         /// <inheritdoc/>
         public override async Task<ResourceResponse[]> SendActivitiesAsync(ITurnContext turnContext, IActivity[] activities, CancellationToken cancellationToken)

--- a/src/libraries/Builder/Microsoft.Agents.Builder/IChannelAdapter.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/IChannelAdapter.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Microsoft.Agents.Core.Models;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Security.Claims;
 using System.Threading;
@@ -253,5 +254,10 @@ namespace Microsoft.Agents.Builder
         /// the receiving channel assigned to the activities.</returns>
         /// <seealso cref="ITurnContext.OnSendActivities(SendActivitiesHandler)"/>
         Task<ResourceResponse[]> SendActivitiesAsync(ITurnContext turnContext, IActivity[] activities, CancellationToken cancellationToken);
+        
+        /// <summary>
+        /// Channel Adapter Logger
+        /// </summary>
+        ILogger? Logger { get; set; }
     }
 }

--- a/src/tests/Microsoft.Agents.Extensions.Teams.Tests/Connector/TeamsInfoTests.cs
+++ b/src/tests/Microsoft.Agents.Extensions.Teams.Tests/Connector/TeamsInfoTests.cs
@@ -20,6 +20,7 @@ using Microsoft.Agents.Extensions.Teams.Compat;
 using Microsoft.Agents.Extensions.Teams.Connector;
 using Microsoft.Agents.Extensions.Teams.Models;
 using Microsoft.Agents.Extensions.Teams.Tests.Model;
+using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
 
@@ -1550,6 +1551,8 @@ namespace Microsoft.Agents.Extensions.Teams.Tests.Connector
             public Func<ITurnContext, Exception, Task> OnTurnError { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
             public IMiddlewareSet MiddlewareSet => throw new NotImplementedException();
+
+            public ILogger Logger { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
             public Task ContinueConversationAsync(ClaimsIdentity claimsIdentity, IActivity continuationActivity, AgentCallbackHandler callback, CancellationToken cancellationToken)
             {


### PR DESCRIPTION
Added support to detect teams failing to accept a streaming request for a 'not enabled' reason and falling back to a nonstreaming send pattern. 