### PR TITLE
Agent-to-agent samples fixes

### DIFF
--- a/src/samples/AgentToAgent/Agent2/Program.cs
+++ b/src/samples/AgentToAgent/Agent2/Program.cs
@@ -57,7 +57,7 @@ else
 {
     // Hardcoded for brevity and ease of testing. 
     // In production, this should be set in configuration.
-    app.Urls.Add($"http://localhost:3978");
+    app.Urls.Add($"http://localhost:39783");
 }
 
 app.Run();

--- a/src/samples/AgentToAgent/StreamingAgent1/appsettings.json
+++ b/src/samples/AgentToAgent/StreamingAgent1/appsettings.json
@@ -16,7 +16,7 @@
   "Agent": {
     "ClientId": "{{ClientId}}", // this is the Client ID for StreamingAgent1
     "Host": {
-      "DefaultEndpoint": "http://localhost:3978/api/agentresponse/", // Default host serviceUrl.  This is the Url to this Agent and AgentResponseController path.
+      "DefaultResponseEndpoint": "http://localhost:3978/api/agentresponse/", // Default host serviceUrl.  This is the Url to this Agent and AgentResponseController path.
       "Agents": {
         "Echo": {
           "ConnectionSettings": {


### PR DESCRIPTION
- Agent2 port (39783)
- StreamingAgent1 `DefaultResponseEndpoint`