### PR TITLE
Enhance serialization initialization with performance logging and ass…

### DIFF
--- a/src/libraries/Core/Microsoft.Agents.Core/Serialization/SerializationInitAttribute.cs
+++ b/src/libraries/Core/Microsoft.Agents.Core/Serialization/SerializationInitAttribute.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Agents.Core.Serialization
 
             // Call serialization init on currently loaded assemblies.
             var listOfAssembliesForScaning = AppDomain.CurrentDomain.GetAssemblies().Where(w => w.GetTypes().Where(a => Attribute.IsDefined(a, typeof(SerializationInitAttribute))).Any());
-            System.Diagnostics.Trace.WriteLine($"SerializationInitAttribute.FilterAssemblies: At {go.ElapsedMilliseconds}ms - Found: {l.Count()}");
+            System.Diagnostics.Trace.WriteLine($"SerializationInitAttribute.FilterAssemblies: At {go.ElapsedMilliseconds}ms - Found: {listOfAssembliesForScaning.Count()}");
             foreach (var assembly in listOfAssembliesForScaning)
             {
                 InitAssembly(assembly);


### PR DESCRIPTION
This pull request improves the performance monitoring and debugging of the serialization initialization process in `SerializationInitAttribute`. The main changes add detailed timing and tracing output, and optimize which assemblies are scanned and initialized for serialization.

Performance monitoring and tracing:

* Added `Stopwatch` timing and multiple `System.Diagnostics.Trace.WriteLine` statements throughout `InitSerialization` and `InitAssembly` to log elapsed times for key steps in the serialization initialization workflow.
* Added trace logs for filtering assemblies, running initialization, and invoking the `Init` method on types, making it easier to diagnose slowdowns or bottlenecks.

Initialization optimization:

* Changed the assembly scanning logic to only initialize assemblies containing types decorated with `SerializationInitAttribute`, reducing unnecessary work and improving startup performance.

Dependency updates:

* Added `System.Diagnostics` and `System.Linq` namespaces to support tracing and LINQ-based filtering.…embly filtering