### PR TITLE
Refactor transcript logging and enforce filename length

### DIFF
--- a/src/libraries/Builder/Microsoft.Agents.Builder/TranscriptLoggerMiddleware.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/TranscriptLoggerMiddleware.cs
@@ -35,74 +35,81 @@ namespace Microsoft.Agents.Builder
         {
             var transcript = new Queue<IActivity>();
 
-            // log incoming activity at beginning of turn
-            if (turnContext.Activity != null)
+            try
             {
-                turnContext.Activity.From ??= new ChannelAccount();
-
-                if (string.IsNullOrEmpty(turnContext.Activity.From.Role))
+                // log incoming activity at beginning of turn
+                if (turnContext.Activity != null)
                 {
-                    turnContext.Activity.From.Role = RoleTypes.User;
+                    turnContext.Activity.From ??= new ChannelAccount();
+
+                    if (string.IsNullOrEmpty(turnContext.Activity.From.Role))
+                    {
+                        turnContext.Activity.From.Role = RoleTypes.User;
+                    }
+
+                    // We should not log ContinueConversation events used by Agents to initialize the middleware.
+                    if (!(turnContext.Activity.Type == ActivityTypes.Event && turnContext.Activity.Name == ActivityEventNames.ContinueConversation))
+                    {
+                        LogActivity(transcript, CloneActivity(turnContext.Activity));
+                    }
                 }
 
-                // We should not log ContinueConversation events used by Agents to initialize the middleware.
-                if (!(turnContext.Activity.Type == ActivityTypes.Event && turnContext.Activity.Name == ActivityEventNames.ContinueConversation))
+                // hook up onSend pipeline
+                turnContext.OnSendActivities(async (ctx, activities, nextSend) =>
                 {
-                    LogActivity(transcript, CloneActivity(turnContext.Activity));
-                }
+                    // run full pipeline
+                    var responses = await nextSend().ConfigureAwait(false);
+
+                    foreach (var activity in activities)
+                    {
+                        LogActivity(transcript, CloneActivity(activity));
+                    }
+
+                    return responses;
+                });
+
+                // hook up update activity pipeline
+                turnContext.OnUpdateActivity(async (ctx, activity, nextUpdate) =>
+                {
+                    // run full pipeline
+                    var response = await nextUpdate().ConfigureAwait(false);
+
+                    // add Message Update activity
+                    var updateActivity = CloneActivity(activity);
+                    updateActivity.Type = ActivityTypes.MessageUpdate;
+                    LogActivity(transcript, updateActivity);
+                    return response;
+                });
+
+                // hook up delete activity pipeline
+                turnContext.OnDeleteActivity(async (ctx, reference, nextDelete) =>
+                {
+                    // run full pipeline
+                    await nextDelete().ConfigureAwait(false);
+
+                    // add MessageDelete activity
+                    // log as MessageDelete activity
+                    var deleteActivity = new Activity
+                    {
+                        Type = ActivityTypes.MessageDelete,
+                        Id = reference.ActivityId,
+                    }
+                        .ApplyConversationReference(reference, isIncoming: false);
+
+                    LogActivity(transcript, deleteActivity);
+                });
+
+                // process Agent logic
+                await nextTurn(cancellationToken).ConfigureAwait(false);
             }
-
-            // hook up onSend pipeline
-            turnContext.OnSendActivities(async (ctx, activities, nextSend) =>
+            finally
             {
-                // run full pipeline
-                var responses = await nextSend().ConfigureAwait(false);
-
-                foreach (var activity in activities)
-                {
-                    LogActivity(transcript, CloneActivity(activity));
-                }
-
-                return responses;
-            });
-
-            // hook up update activity pipeline
-            turnContext.OnUpdateActivity(async (ctx, activity, nextUpdate) =>
-            {
-                // run full pipeline
-                var response = await nextUpdate().ConfigureAwait(false);
-
-                // add Message Update activity
-                var updateActivity = CloneActivity(activity);
-                updateActivity.Type = ActivityTypes.MessageUpdate;
-                LogActivity(transcript, updateActivity);
-                return response;
-            });
-
-            // hook up delete activity pipeline
-            turnContext.OnDeleteActivity(async (ctx, reference, nextDelete) =>
-            {
-                // run full pipeline
-                await nextDelete().ConfigureAwait(false);
-
-                // add MessageDelete activity
-                // log as MessageDelete activity
-                var deleteActivity = new Activity
-                {
-                    Type = ActivityTypes.MessageDelete,
-                    Id = reference.ActivityId,
-                }
-                    .ApplyConversationReference(reference, isIncoming: false);
-
-                LogActivity(transcript, deleteActivity);
-            });
-
-            // process Agent logic
-            await nextTurn(cancellationToken).ConfigureAwait(false);
-
-            // flush transcript at end of turn
-            // NOTE: We are not awaiting this task by design, TryLogTranscriptAsync() observes all exceptions and we don't need to or want to block execution on the completion.
-            _ = TryLogTranscriptAsync(_logger, transcript);
+                // Ensure we flush the transcript even if there is an error.
+                // This ensures we capture the activity stream leading up to the error.
+                // flush transcript at end of turn
+                // NOTE: We are not awaiting this task by design, TryLogTranscriptAsync() observes all exceptions and we don't need to or want to block execution on the completion.
+                _ = TryLogTranscriptAsync(_logger, transcript);
+            }
         }
 
         /// <summary>

--- a/src/libraries/Storage/Microsoft.Agents.Storage.Transcript/FileTranscriptLogger.cs
+++ b/src/libraries/Storage/Microsoft.Agents.Storage.Transcript/FileTranscriptLogger.cs
@@ -21,6 +21,8 @@ namespace Microsoft.Agents.Storage.Transcript
     /// </remarks>
     public class FileTranscriptLogger : ITranscriptStore
     {
+        private const string TranscriptFileExtension = ".transcript";
+        private const int MaxFileNameSize = 100;
         private readonly string _folder;
         private readonly bool _unitTestMode;
         private readonly HashSet<string> _started = [];
@@ -289,8 +291,12 @@ namespace Microsoft.Agents.Storage.Transcript
 
             var channelFolder = GetChannelFolder(channelId);
             var fileName = SanitizeString(conversationId, Path.GetInvalidFileNameChars());
+            if (fileName != null && fileName.Length > MaxFileNameSize)
+            {
+                fileName = fileName.Substring(0, MaxFileNameSize);
+            }
 
-            return Path.Combine(channelFolder, fileName + ".transcript");
+            return Path.Combine(channelFolder, fileName + TranscriptFileExtension);
         }
 
         private string GetChannelFolder(string channelId)

--- a/src/libraries/Storage/Microsoft.Agents.Storage.Transcript/FileTranscriptLogger.cs
+++ b/src/libraries/Storage/Microsoft.Agents.Storage.Transcript/FileTranscriptLogger.cs
@@ -291,9 +291,9 @@ namespace Microsoft.Agents.Storage.Transcript
 
             var channelFolder = GetChannelFolder(channelId);
             var fileName = SanitizeString(conversationId, Path.GetInvalidFileNameChars());
-            if (fileName != null && fileName.Length > MaxFileNameSize)
+            if (fileName != null && fileName.Length > MaxFileNameSize - TranscriptFileExtension.Length)
             {
-                fileName = fileName.Substring(0, MaxFileNameSize);
+                fileName = fileName.Substring(0, MaxFileNameSize - TranscriptFileExtension.Length);
             }
 
             return Path.Combine(channelFolder, fileName + TranscriptFileExtension);


### PR DESCRIPTION
Restructured `TranscriptLoggerMiddleware.cs` to improve readability by encapsulating logging logic within a `try` block, ensuring transcripts are flushed even on errors. Added checks in `FileTranscriptLogger.cs` to truncate filenames exceeding 100 characters, preventing potential file system issues.