### PR TITLE
Dynamic Entity Type Handling in Serialization

### DIFF
--- a/src/libraries/Core/Microsoft.Agents.Core/Serialization/Converters/EntityConverter.cs
+++ b/src/libraries/Core/Microsoft.Agents.Core/Serialization/Converters/EntityConverter.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Agents.Core.Models;
 using System;
+using System.Linq;
 using System.Text.Json;
 
 namespace Microsoft.Agents.Core.Serialization.Converters
@@ -41,13 +42,22 @@ namespace Microsoft.Agents.Core.Serialization.Converters
             {
                 return JsonSerializer.Deserialize<ProductInfo>(JsonSerializer.Serialize(entity, options), options);
             }
-            
             else if (string.Equals(EntityTypes.AICitation, entity.Type, StringComparison.OrdinalIgnoreCase))
             {
                 return JsonSerializer.Deserialize<AIEntity>(JsonSerializer.Serialize(entity, options), options);
             }
-
-            return entity;
+            else
+            {
+                bool bFound = ProtocolJsonSerializer.EntityTypes.Where(w=>w.Key.Equals(entity.Type, StringComparison.OrdinalIgnoreCase)).Any();
+                if (bFound)
+                {
+                    Type type = ProtocolJsonSerializer.EntityTypes.Where(w => w.Key.Equals(entity.Type, StringComparison.OrdinalIgnoreCase)).First().Value;
+                    return (Entity)JsonSerializer.Deserialize(JsonSerializer.Serialize(entity, options), type, options);
+                    //return JsonSerializer.Deserialize(JsonSerializer.Serialize(entity, options), type, options) as typeof(type);
+                }
+            }
+                
+                return entity;
         }
 
         protected override void ReadExtensionData(ref Utf8JsonReader reader, Entity value, string propertyName, JsonSerializerOptions options)

--- a/src/libraries/Core/Microsoft.Agents.Core/Serialization/EntityNameAttribute.cs
+++ b/src/libraries/Core/Microsoft.Agents.Core/Serialization/EntityNameAttribute.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Agents.Core.Serialization
+{
+    /// <summary>
+    /// This allows you to mark a class with the name of the Entity it represents.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    public sealed class EntityNameAttribute : Attribute
+    {
+        /// <summary>
+        /// Gets the Entity name for the entity class
+        /// </summary>
+        public string EntityName { get; private set; }
+
+        public EntityNameAttribute(string name)
+            : base()
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            this.EntityName = name;
+        }
+    }
+}

--- a/src/libraries/Core/Microsoft.Agents.Core/Serialization/ProtocolJsonSerializer.cs
+++ b/src/libraries/Core/Microsoft.Agents.Core/Serialization/ProtocolJsonSerializer.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
@@ -27,6 +28,8 @@ namespace Microsoft.Agents.Core.Serialization
         /// It is not recommended to set false without guidance.
         /// </summary>
         public static bool ChannelIdIncludesProduct { get; set; } = true;
+
+        public static ConcurrentDictionary<string,Type> EntityTypes { get; private set; } = new();
 
         private static readonly object _optionsLock = new object();
 
@@ -74,6 +77,11 @@ namespace Microsoft.Agents.Core.Serialization
 
                 SerializationOptions = applyFunc(newOptions);
             }
+        }
+
+        public static void AddEntityType(string entityTypeName, Type entityType)
+        {
+            EntityTypes[entityTypeName] = entityType;
         }
 
         private static JsonSerializerOptions ApplyCoreOptions(this JsonSerializerOptions options)


### PR DESCRIPTION
Introduce a dynamic mechanism for handling entity types in the serialization process. Replace hardcoded entity type checks in `EntityConverter.cs` with a lookup in `ProtocolJsonSerializer.EntityTypes`. Add `EntityNameAttribute` to map classes to entity names. Use a `ConcurrentDictionary` in `ProtocolJsonSerializer` to store entity type mappings, with a method to add new types. Update `SerializationInitAssemblyAttribute.cs` to populate this dictionary by iterating over subclasses of `Entity`, using `EntityNameAttribute` or class names as keys. This enhances flexibility and extensibility in the serialization logic.