### PR TITLE
Minor refactoring of Adapter.ContinueConversation methods

### DIFF
--- a/src/libraries/Builder/Microsoft.Agents.Builder/ChannelServiceAdapterBase.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/ChannelServiceAdapterBase.cs
@@ -208,7 +208,6 @@ namespace Microsoft.Agents.Builder
 
             ValidateContinuationActivity(continuationActivity);
 
-            audience = audience ?? AgentClaims.GetTokenAudience(claimsIdentity);
             bool useAnonymousAuthCallback = AgentClaims.AllowAnonymous(claimsIdentity);
 
             // Create a turn context and clients
@@ -217,7 +216,6 @@ namespace Microsoft.Agents.Builder
             // Create the connector client to use for outbound requests.
             using var connectorClient = await ChannelServiceFactory.CreateConnectorClientAsync(
                 context,
-                audience,
                 useAnonymous: useAnonymousAuthCallback,
                 cancellationToken: cancellationToken).ConfigureAwait(false);
 

--- a/src/libraries/Builder/Microsoft.Agents.Builder/IChannelAdapter.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/IChannelAdapter.cs
@@ -77,6 +77,9 @@ namespace Microsoft.Agents.Builder
         /// or threads to receive notice of cancellation.</param>
         /// <remarks>
         /// <para>This is a convenience wrapper for <see cref="ProcessProactiveAsync(ClaimsIdentity, IActivity, string, AgentCallbackHandler, CancellationToken)"/>.</para>
+        /// <para>Using this overload will only work against Azure Bot Service and Agentic.  For proactive to other agents (including Copilot Studio), use 
+        /// <see cref="ContinueConversationAsync(ClaimsIdentity, ConversationReference, AgentCallbackHandler, CancellationToken)"/>.  Use <see cref="Microsoft.Agents.Authentication.AgentClaims.CreateIdentity(string, bool, string)"/>
+        /// to create a ClaimsIdentity with both the audience (your agents ClientId) and appId (the other agents ClientId).</para>
         /// </remarks>
         [Obsolete("Use ContinueConversationAsync(ClaimsIdentity, ConversationReference, AgentCallbackHandler, CancellationToken)")]
         Task ContinueConversationAsync(string agentId, ConversationReference reference, AgentCallbackHandler callback, CancellationToken cancellationToken);
@@ -104,6 +107,9 @@ namespace Microsoft.Agents.Builder
         /// or threads to receive notice of cancellation.</param>
         /// <remarks>
         /// <para>This is a convenience wrapper for <see cref="ProcessProactiveAsync(ClaimsIdentity, IActivity, string, AgentCallbackHandler, CancellationToken)"/>.</para>
+        /// <para>Using this overload will only work against Azure Bot Service and Agentic.  For proactive to other agents (including Copilot Studio), use 
+        /// <see cref="ContinueConversationAsync(ClaimsIdentity, IActivity, AgentCallbackHandler, CancellationToken)"/>.  Use <see cref="Microsoft.Agents.Authentication.AgentClaims.CreateIdentity(string, bool, string)"/>
+        /// to create a ClaimsIdentity with both the audience (your agents ClientId) and appId (the other agents ClientId).</para>
         /// </remarks>
         [Obsolete("Use ContinueConversationAsync(ClaimsIdentity, IActivity, AgentCallbackHandler, CancellationToken)")]
         Task ContinueConversationAsync(string agentId, IActivity continuationActivity, AgentCallbackHandler callback, CancellationToken cancellationToken);
@@ -119,6 +125,7 @@ namespace Microsoft.Agents.Builder
         /// <remarks>
         /// <para>This is a convenience wrapper for <see cref="ProcessProactiveAsync(ClaimsIdentity, IActivity, string, AgentCallbackHandler, CancellationToken)"/>.</para>
         /// </remarks>
+        [Obsolete("This method will be removed in future versions of the SDK")]
         Task ContinueConversationAsync(ClaimsIdentity claimsIdentity, IActivity continuationActivity, AgentCallbackHandler callback, CancellationToken cancellationToken);
 
         /// <summary>
@@ -147,7 +154,7 @@ namespace Microsoft.Agents.Builder
         /// <remarks>
         /// <para>This is a convenience wrapper for <see cref="ProcessProactiveAsync(ClaimsIdentity, IActivity, string, AgentCallbackHandler, CancellationToken)"/>.</para>
         /// </remarks>
-        [Obsolete("Use ProcessProactiveAsync")]
+        [Obsolete("This method will be removed in future versions of the SDK. Use ProcessProactiveAsync instead.")]
         Task ContinueConversationAsync(ClaimsIdentity claimsIdentity, IActivity continuationActivity, string audience, AgentCallbackHandler callback, CancellationToken cancellationToken);
 
         /// <summary>

--- a/src/libraries/Builder/Microsoft.Agents.Builder/RestChannelServiceClientFactory.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/RestChannelServiceClientFactory.cs
@@ -107,9 +107,11 @@ namespace Microsoft.Agents.Builder
 
             if (!AgenticAuthorization.IsAgenticRequest(turnContext))
             {
+                // Non agentic, so use legacy tokens
                 return CreateConnectorClientAsync(turnContext.Identity, turnContext.Activity.ServiceUrl, audience ?? AgentClaims.GetTokenAudience(turnContext.Identity), cancellationToken, scopes, useAnonymous);
             }
 
+            // Use an Agentic token for the ConnectorClient
             return Task.FromResult<IConnectorClient>(new RestConnectorClient(
                 new Uri(turnContext.Activity.ServiceUrl),
                 _httpClientFactory,

--- a/src/libraries/Core/Microsoft.Agents.Authentication/AgentClaims.cs
+++ b/src/libraries/Core/Microsoft.Agents.Authentication/AgentClaims.cs
@@ -202,14 +202,22 @@ namespace Microsoft.Agents.Authentication
         /// <returns></returns>
         public static ClaimsIdentity CreateIdentity(string audience, bool anonymous = false, string appId = null)
         {
-            return anonymous
-                ? new ClaimsIdentity()
-                : new ClaimsIdentity(
-                [
+            if (anonymous)
+            {
+                return new ClaimsIdentity();
+            }
+
+            IEnumerable<Claim> claims = [
                     new(AuthenticationConstants.AudienceClaim, audience),
-                    new(AuthenticationConstants.AppIdClaim, appId ?? audience),
                     new(AuthenticationConstants.VersionClaim, "1.0")
-                ]);
+                ];
+
+            if (!string.IsNullOrEmpty(appId))
+            {
+                claims = claims.Append(new(AuthenticationConstants.AppIdClaim, appId));
+            }
+
+            return new ClaimsIdentity(claims);
         }
     }
 }


### PR DESCRIPTION
Minor cleanup of ContinueConversation for clarity

## Obsoletions
While functional against ABS, some ContinueConversation variants are not applicable for proactive to other agents.  For consistency, these variants should be removed (marked obsolete for now) and the variants that require ClaimsIdentiy should be used instead.

At a usage level, this means when storing a ConversationReference, the ITurnContext.Identity should be stored with it.  They go together.

The same functionality can be achieved with:

```csharp
var claims = AgentsClaims.CreateIdentity(botId);
await adapter.ContinueConversation(claims, ...);
```

Though proactive to another agent would be:

```csharp
var claims = AgentsClaims.CreateIdentity(botId, appId: originalCallerAppId);
await adapter.ContinueConversation(claims, ...);
```
