### PR TITLE
Fix security: prevent arbitrary file access in TranscriptUtilities test helper

### DIFF
--- a/src/tests/Microsoft.Agents.Storage.Tests/TranscriptUtilities.cs
+++ b/src/tests/Microsoft.Agents.Storage.Tests/TranscriptUtilities.cs
@@ -233,8 +233,10 @@ namespace Microsoft.Agents.Storage.Tests
             var fullRoot = Path.GetFullPath(root);
             var fullTarget = Path.GetFullPath(targetPath);
 
-            var relativePath = Path.GetRelativePath(fullRoot, fullTarget);
-            if (relativePath.StartsWith("..") || Path.IsPathRooted(relativePath))
+            // Manual relative path check for .NET Framework compatibility
+            // This works for both .NET Framework and .NET Core/.NET
+            if (!fullTarget.StartsWith(fullRoot.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase)
+                && !string.Equals(fullTarget, fullRoot, StringComparison.OrdinalIgnoreCase))
             {
                 throw new UnauthorizedAccessException($"Access to path '{targetPath}' is denied.");
             }


### PR DESCRIPTION
Fixes S360 issue:
```
[CodeQL.SM02729] 'Arbitrary file access during archive extraction ("Zip Slip")' in src/tests/Microsoft.Agents.Storage.Tests/TranscriptUtilities.cs
```

This fix was analyzed and fixed using GitHub Copilot. 