### PR TITLE
Simplify error handling in ChannelAdapter.cs

### DIFF
--- a/src/libraries/Builder/Microsoft.Agents.Builder/ChannelAdapter.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/ChannelAdapter.cs
@@ -164,10 +164,6 @@ namespace Microsoft.Agents.Builder
                 {
                     await MiddlewareSet.ReceiveActivityWithStatusAsync(turnContext, callback, cancellationToken).ConfigureAwait(false);
                 }
-                catch (OperationCanceledException)
-                {
-                    throw; // Do not try to send another request if the failure is an operation cancel. 
-                }
                 catch (Exception e)
                 {
                     if (OnTurnError != null)


### PR DESCRIPTION
Removed the specific `catch (OperationCanceledException)` block, which previously re-threw the exception to prevent additional requests during operation cancellation. This change simplifies the error-handling logic by relying on the general `catch (Exception e)` block, which invokes the `OnTurnError` handler if defined. Note that this may alter behavior for operation cancellation scenarios.

Fixes #497 497