### PR TITLE
Update contributing guidelines in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Please read [this](GettingStarted.md) for directions on what is needed and how t
 
 ## Contributing
 
-#### Note for Microsoft intenral developers: 
+#### Note for Microsoft internal developers: 
 - Internal Microsoft Developers should join the Core identity group [Agents SDK Contrib](https://coreidentity.microsoft.com/manage/Entitlement/entitlement/agentssdkint-upyj)
 
 #### Non-Microsoft internal developers:


### PR DESCRIPTION
This pull request adds clarification to the contribution guidelines in the `README.md`, specifically distinguishing instructions for Microsoft internal developers and non-Microsoft contributors.

Contribution guidelines update:

* Added a section for Microsoft internal developers, instructing them to join the Core identity group "Agents SDK Contrib" with a provided link.
* Clarified that the existing contribution instructions apply to non-Microsoft internal developers.Added notes for Microsoft internal and non-internal developers regarding contributions.