### PR TITLE
Disable Streaming Response when channel = teams and request type is agentic. 

### DIFF
--- a/src/libraries/Builder/Microsoft.Agents.Builder/StreamingResponse.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/StreamingResponse.cs
@@ -511,11 +511,20 @@ namespace Microsoft.Agents.Builder
             }
             else if (_isTeamsChannel)
             {
-                // Teams MUST use the Activity.Id returned from the first Informative message for
-                // subsequent intermediate messages.  Do not set StreamId here.
+                if (turnContext.Activity.IsAgenticRequest())
+                {
+                    // Agentic requests do not support streaming responses at this time.
+                    // TODO : Enable streaming for agentic requests when supported.
+                    IsStreamingChannel = false;
+                }
+                else
+                {
+                    // Teams MUST use the Activity.Id returned from the first Informative message for
+                    // subsequent intermediate messages.  Do not set StreamId here.
 
-                Interval = 1000;
-                IsStreamingChannel = true;
+                    Interval = 1000;
+                    IsStreamingChannel = true;
+                }
             }
             else if (Channels.Webchat == turnContext.Activity.ChannelId?.Channel || Channels.Directline == turnContext.Activity.ChannelId?.Channel)
             {


### PR DESCRIPTION
This pull request introduces a conditional check for agentic requests within the Teams channel to improve compatibility with streaming responses. Specifically, it prevents streaming for agentic requests, as they are not currently supported, and adds a TODO for future enablement.

Channel-specific streaming logic:

* In `StreamingResponse.cs`, agentic requests in the Teams channel are now detected using `IsAgenticRequest()`, and streaming is explicitly disabled for these requests.
* A TODO comment was added to indicate that streaming for agentic requests will be enabled once supported.

Fix #516 