### PR TITLE
AgentUserAuthorization now accepts Event tokens/response

### DIFF
--- a/src/libraries/Builder/Microsoft.Agents.Builder/UserAuth/TokenService/AgentUserAuthorization.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/UserAuth/TokenService/AgentUserAuthorization.cs
@@ -71,6 +71,9 @@ namespace Microsoft.Agents.Builder.UserAuth.TokenService
             isMatch |= context.Activity.IsType(ActivityTypes.Invoke) &&
                 context.Activity.Name == SignInConstants.SignInFailure;
 
+            isMatch |= context.Activity.IsType(ActivityTypes.Event) &&
+                context.Activity.Name == SignInConstants.TokenResponseEventName;
+
             return isMatch;
         }
 

--- a/src/libraries/Hosting/AspNetCore/Microsoft.Agents.Hosting.AspNetCore.csproj
+++ b/src/libraries/Hosting/AspNetCore/Microsoft.Agents.Hosting.AspNetCore.csproj
@@ -42,7 +42,6 @@
 		<!-- Force System.Text.Json to a safe version. -->
 		<PackageReference Include="System.Text.Json" />
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
-		<PackageReference Include="Microsoft.AspNetCore.Authorization" />
 		<PackageReference Include="Microsoft.IdentityModel.Validators" />
 		<PackageReference Include="System.IdentityModel.Tokens.Jwt" />
 	</ItemGroup>

--- a/src/libraries/Storage/Microsoft.Agents.Storage.Blobs/Microsoft.Agents.Storage.Blobs.csproj
+++ b/src/libraries/Storage/Microsoft.Agents.Storage.Blobs/Microsoft.Agents.Storage.Blobs.csproj
@@ -32,7 +32,6 @@
     <!-- Force Microsoft.Bcl.AsyncInterfaces to a newer version. Since Microsoft.Azure.Cosmos has 1.1.1 version, which causes MSB3277 warnings. -->
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
 	<PackageReference Include="Azure.Storage.Blobs" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libraries/Storage/Microsoft.Agents.Storage.CosmosDb/Microsoft.Agents.Storage.CosmosDb.csproj
+++ b/src/libraries/Storage/Microsoft.Agents.Storage.CosmosDb/Microsoft.Agents.Storage.CosmosDb.csproj
@@ -35,7 +35,6 @@
 	<!-- Force newer NewtonSoft because Azure.Cosmos is using one that alerts -->
     <PackageReference Include="Microsoft.Azure.Cosmos" />
     <PackageReference Include="Newtonsoft.Json" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libraries/Storage/Microsoft.Agents.Storage.Transcript/Microsoft.Agents.Storage.Transcript.csproj
+++ b/src/libraries/Storage/Microsoft.Agents.Storage.Transcript/Microsoft.Agents.Storage.Transcript.csproj
@@ -32,7 +32,6 @@
     <!-- Force Microsoft.Bcl.AsyncInterfaces to a newer version. Since Microsoft.Azure.Cosmos has 1.1.1 version, which causes MSB3277 warnings. -->
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
 	<PackageReference Include="Azure.Storage.Blobs" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libraries/Storage/Microsoft.Agents.Storage/Microsoft.Agents.Storage.csproj
+++ b/src/libraries/Storage/Microsoft.Agents.Storage/Microsoft.Agents.Storage.csproj
@@ -17,7 +17,6 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
         <PackageReference Include="Microsoft.Extensions.Logging" />
-        <PackageReference Include="Microsoft.CSharp" />
     </ItemGroup>
 
 	<ItemGroup>

--- a/src/tests/Microsoft.Agents.Storage.Tests/Microsoft.Agents.Storage.Tests.csproj
+++ b/src/tests/Microsoft.Agents.Storage.Tests/Microsoft.Agents.Storage.Tests.csproj
@@ -14,7 +14,7 @@
 
 	<ItemGroup>
       <PackageReference Include="Microsoft.NET.Test.Sdk" />
-	  <PackageReference Include="System.IO.Compression" />
+	  <PackageReference Condition="'$(TargetFramework)' == 'net4.8'" Include="System.IO.Compression" />
       <PackageReference Include="xunit" />
       <PackageReference Include="xunit.runner.visualstudio">
         <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Fixes #527 

Accepts an Event of name "tokens/response", allow OAuthFlow to operate on that Activity.