### PR TITLE
Only set Expiration in TokenResponse if non-default value

### DIFF
--- a/src/libraries/Core/Microsoft.Agents.Core/Models/TokenResponse.cs
+++ b/src/libraries/Core/Microsoft.Agents.Core/Models/TokenResponse.cs
@@ -24,7 +24,9 @@ namespace Microsoft.Agents.Core.Models
             ChannelId = channelId;
             ConnectionName = connectionName;
             Token = token;
-            Expiration = expiration;
+
+            if (expiration != default) // do not set the expiration if the default value is passed. If the timezone is + UTC it will cause a fault when assigned as an offset.
+                Expiration = expiration;
         }
 
         /// <summary> The channelId of the TokenResponse. </summary>


### PR DESCRIPTION
This pull request introduces a minor fix to the `TokenResponse` constructor to prevent issues when assigning the default expiration value. The change ensures that the `Expiration` property is only set if a non-default value is provided, avoiding potential faults related to time zone offsets.

* Only set `Expiration` in the `TokenResponse` constructor if a non-default value is provided, preventing faults when the default (UTC) is used.Modified TokenResponse constructor to assign Expiration property only when a non-default expiration value is provided, preventing unnecessary property assignment when the default value is passed.