### PR TITLE
cheery pick UTC fix from main

### DIFF
--- a/src/libraries/Core/Microsoft.Agents.Core/Models/TokenResponse.cs
+++ b/src/libraries/Core/Microsoft.Agents.Core/Models/TokenResponse.cs
@@ -24,7 +24,9 @@ namespace Microsoft.Agents.Core.Models
             ChannelId = channelId;
             ConnectionName = connectionName;
             Token = token;
-            Expiration = expiration;
+
+            if (expiration != default) // do not set the expiration if the default value is passed. If the timezone is + UTC it will cause a fault when assigned as an offset.
+                Expiration = expiration;
         }
 
         /// <summary> The channelId of the TokenResponse. </summary>


### PR DESCRIPTION
This pull request introduces a small but important fix to the `TokenResponse` constructor to prevent potential faults when assigning expiration values.

- Constructor logic improvement:
  * In `TokenResponse`, the `Expiration` property is now only set if the provided `expiration` value is not the default. This prevents faults that could occur when assigning default values, especially with timezones set to UTC.