### PR TITLE
Add new WriteAsync condition and ETag response result

### DIFF
--- a/src/libraries/Storage/Microsoft.Agents.Storage/ItemExistsException.cs
+++ b/src/libraries/Storage/Microsoft.Agents.Storage/ItemExistsException.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Microsoft.Agents.Storage
+{
+    /// <summary>
+    /// Exception thrown when an item already exists in storage.
+    /// </summary>
+    public class ItemExistsException : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ItemExistsException"/> class.
+        /// </summary>
+        public ItemExistsException()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ItemExistsException"/> class with a specified error message.
+        /// </summary>
+        /// <param name="key">The key of the item that already exists.</param>
+        public ItemExistsException(string key) : base(key)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ItemExistsException"/> class with a specified error message and a reference to the inner exception that is the cause of this exception.
+        /// </summary>
+        /// <param name="key">The key of the item that already exists.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception.</param>
+        public ItemExistsException(string key, Exception innerException) : base(key, innerException)
+        {
+        }
+    }
+}

--- a/src/libraries/Storage/Microsoft.Agents.Storage/StorageWriteOptions.cs
+++ b/src/libraries/Storage/Microsoft.Agents.Storage/StorageWriteOptions.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Agents.Storage
+{
+    /// <summary>
+    /// Options that control write behavior for storage providers.
+    /// </summary>
+    public record StorageWriteOptions
+    {
+        /// <summary>
+        /// If true, the write operation will only succeed if the item does not already exist in storage.
+        /// </summary>
+        /// <remarks>
+        /// This is useful for scenarios where you want to ensure that you are creating a new item
+        /// and do not want to overwrite any existing data. If the item already exists, the write
+        /// operation will fail with an error.
+        ///
+        /// The default value is false, meaning that the write operation will overwrite existing items.
+        /// </remarks>
+        public bool IfNotExists { get; set; }
+    }
+}

--- a/src/libraries/Storage/Microsoft.Agents.Storage/StorageWriteResult.cs
+++ b/src/libraries/Storage/Microsoft.Agents.Storage/StorageWriteResult.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Agents.Storage
+{
+    /// <summary>
+    /// Represents the response of a storage write operation, containing the updated ETag.
+    /// </summary>
+    public class StorageWriteResponse : IStoreItem
+    {
+        /// <summary>
+        /// Gets or sets the entity tag (ETag) assigned to the item after the write operation.
+        /// </summary>
+        public string ETag { get; set; }
+    }
+}


### PR DESCRIPTION
## Description
This PR extends the functionality of the WriteAsync methods in Blobs, Cosmos, and Memory storages by allowing users to pass new options that currently contain the ifNotExists condition, and to return the created/updated ETag as a result of the operation.
The purpose of these changes is to introduce these improvements without modifying the existing signature of the IStorage interface.

There are multiple approaches to accomplish this, but the least hacky way was to add the new WriteAsync overload method to each Storage without impacting the interface or creating a second IStorageExt with new signatures.
Here are two of the most relevant alternatives (POC) to the current changes in the PR, without adding more WriteAsync overloads:
<img width="1138" height="823" alt="image" src="https://github.com/user-attachments/assets/d7518e52-a692-41ae-9d7f-77c7c5aff68f" />

### AsyncLocal + Disposable options
1. Instantiate a write options context containing the configuration options the WriteAsync will use, while also having the logic to save the options in the AsyncLocal context (non-static) and dispose them when necessary.
2. Perform the storage.WriteAsync as we normally do, and internally it gets the current context options.
3. Internally when the storage write operation returns the ETag, it assigns it to the write options context.

### StoreItem wrapper
1. Instantiate the store item wrapper by setting the options and the data to write in the storage.
2. Share the wrapper to the storage.WriteAsync method as store information.
3. The WriteAsync will detect the type is a StoreItem wrapper, extract the options and data separately.
4. Internally when the storage write operation returns the ETag, it assigns it to the StoreItem wrapper for later consumption.

### Other less fisable alternatives
<img width="3171" height="2196" alt="image" src="https://github.com/user-attachments/assets/4fead72d-ff6e-4816-b2e4-08ea1dc7fe5b" />


## Testing
Once the PR is no longer in draft, we will include tests of Agent samples working with the storages.