### PR TITLE
Added BotServiceAudience setting to RestChannelServiceClientFactory

### DIFF
--- a/src/libraries/Builder/Microsoft.Agents.Builder/RestChannelServiceClientFactory.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/RestChannelServiceClientFactory.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Agents.Builder
     {
         private readonly string _tokenServiceEndpoint;
         private readonly string _tokenServiceAudience;
+        private readonly string _botServiceAudience;
         private readonly int? _iMaxApxConversationIdLength;
         private readonly ILogger _logger;
         private readonly IConnections _connections;
@@ -41,6 +42,7 @@ namespace Microsoft.Agents.Builder
         /// <param name="connections"></param>
         /// <param name="tokenServiceEndpoint"></param>
         /// <param name="tokenServiceAudience"></param>
+        /// <param name="botServiceAudience"></param>
         /// <param name="logger"></param>
         /// <param name="customClient">For testing purposes only.</param>
         public RestChannelServiceClientFactory(
@@ -49,6 +51,7 @@ namespace Microsoft.Agents.Builder
             IConnections connections,
             string tokenServiceEndpoint = AuthenticationConstants.BotFrameworkOAuthUrl,
             string tokenServiceAudience = AuthenticationConstants.BotFrameworkAudience,
+            string botServiceAudience = AuthenticationConstants.BotFrameworkAudience,
             ILogger logger = null)
         {
             AssertionHelpers.ThrowIfNull(configuration, nameof(configuration));
@@ -66,6 +69,11 @@ namespace Microsoft.Agents.Builder
             _tokenServiceAudience = string.IsNullOrWhiteSpace(tokenAudience)
                 ? tokenServiceAudience ?? throw new ArgumentNullException(nameof(tokenServiceAudience))
                 : tokenAudience;
+
+            var botAudience = configuration?.GetValue<string>($"{nameof(RestChannelServiceClientFactory)}:BotServiceAudience");
+            _botServiceAudience = string.IsNullOrWhiteSpace(botAudience)
+                ? botServiceAudience ?? throw new ArgumentNullException(nameof(botServiceAudience))
+                : botAudience;
 
             _iMaxApxConversationIdLength = configuration?.GetValue<int?>($"{nameof(RestChannelServiceClientFactory)}:MaxApxConversationIdLength");
         }
@@ -137,7 +145,7 @@ namespace Microsoft.Agents.Builder
                 {
                     try
                     {
-                        audience ??= claimsIdentity.GetOutgoingAudience();
+                        audience ??= claimsIdentity.IsAgent() ? claimsIdentity.GetOutgoingAudience() : _botServiceAudience;
                         scopes ??= claimsIdentity.GetOutgoingScopes(defaultABSScopes: false); // Do not default ABS scopes because we want to use the value from config
                         var tokenAccess = _connections.GetTokenProvider(claimsIdentity, serviceUrl);
                         return tokenAccess.GetAccessTokenAsync(audience, scopes);

--- a/src/libraries/Core/Microsoft.Agents.Authentication/AuthenticationConstants.cs
+++ b/src/libraries/Core/Microsoft.Agents.Authentication/AuthenticationConstants.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using static System.Net.WebRequestMethods;
 
 namespace Microsoft.Agents.Authentication
 {

--- a/src/libraries/Core/Microsoft.Agents.Authentication/AuthenticationConstants.cs
+++ b/src/libraries/Core/Microsoft.Agents.Authentication/AuthenticationConstants.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using static System.Net.WebRequestMethods;
 
 namespace Microsoft.Agents.Authentication
 {
@@ -27,6 +28,11 @@ namespace Microsoft.Agents.Authentication
         public const string GovBotFrameworkAudience = "https://api.botframework.us";
 
         /// <summary>
+        /// Bot Framework China audience to request.
+        /// </summary>
+        public const string ChinaBotFrameworkAudience = "https://api.botframework.azure.cn";
+
+        /// <summary>
         /// Bot Framework OAuth scope to request.
         /// </summary>
         public const string BotFrameworkDefaultScope = "https://api.botframework.com/.default";
@@ -35,6 +41,11 @@ namespace Microsoft.Agents.Authentication
         /// Bot Framework Gov OAuth scope to request.
         /// </summary>
         public const string GovBotFrameworkDefaultScope = "https://api.botframework.us/.default";
+
+        /// <summary>
+        /// Bot Framework China (Gallatin/Mooncake) OAuth scope to request.
+        /// </summary>
+        public const string ChinaBotFrameworkDefaultScope = "https://api.botframework.azure.cn/.default";
 
         /// <summary>
         /// Token issuer for ABS tokens.
@@ -47,6 +58,26 @@ namespace Microsoft.Agents.Authentication
         public const string GovBotFrameworkTokenIssuer = "https://api.botframework.us";
 
         /// <summary>
+        /// Token issuer for China (Gallatin/Mooncake) ABS tokens.
+        /// </summary>
+        public const string ChinaBotFrameworkTokenIssuer = "https://api.botframework.azure.cn";
+
+        /// <summary>
+        /// Gets the URL template for the Bot Framework login authority, which includes a placeholder for the tenant ID.
+        /// </summary>
+        public const string BotFrameworkLoginUrlTemplate = "https://login.microsoftonline.com/{0}";
+
+        /// <summary>
+        /// Gets the URL template for the Gov Bot Framework login authority, which includes a placeholder for the tenant ID.
+        /// </summary>
+        public const string GovBotFrameworkLoginUrlTemplate = "https://login.microsoftonline.us/{0}";
+
+        /// <summary>
+        /// Gets the URL template for the China (Gallatin/Mooncake) Bot Framework login authority, which includes a placeholder for the tenant ID.
+        /// </summary>
+        public const string ChinaBotFrameworkLoginUrlTemplate = "https://login.partner.microsoftonline.cn/0b4a31a2-c1a0-475d-b363-5f26668660a3/{0}";
+
+        /// <summary>
         /// Default Url for the Azure Bot Token Service.
         /// </summary>
         public const string BotFrameworkOAuthUrl = "https://api.botframework.com";
@@ -55,6 +86,11 @@ namespace Microsoft.Agents.Authentication
         /// Default Url for the Gov Azure Bot Token Service.
         /// </summary>
         public const string GovBotFrameworkOAuthUrl = "https://api.botframework.azure.us";
+
+        /// <summary>
+        /// Default Url for the China (Gallatin/Mooncake) Azure Bot Token Service.
+        /// </summary>
+        public const string ChinaBotFrameworkOAuthUrl = "https://token.botframework.azure.cn/";
 
         /// <summary>
         /// The OpenID metadata URL for the public Azure Bot Service.
@@ -82,6 +118,16 @@ namespace Microsoft.Agents.Authentication
         public const string GovOpenIdMetadataUrl = "https://login.microsoftonline.us/cab8a31a-1906-4287-a0d8-4eef66b95f6e/v2.0/.well-known/openid-configuration";
 
         /// <summary>
+        /// The OpenID metadata URL for the China (Gallatin/Mooncake) Azure Bot Service.
+        /// </summary>
+        public const string ChinaAzureBotServiceOpenIdMetadataUrl = "https://login.botframework.azure.cn/v1/.well-known/openidconfiguration";
+
+        /// <summary>
+        /// The OpenID metadata URL for China (Gallatin/Mooncake)
+        /// </summary>
+        public const string ChinaOpenIdMetadataUrl = "https://login.partner.microsoftonline.cn/a55a4d5b-9241-49b1-b4ff-befa8db00269/.well-known/openid-configuration";
+
+        /// <summary>
         /// The V1 Azure AD token issuer URL template that will contain the tenant id where the token was issued from.
         /// </summary>
         public const string ValidTokenIssuerUrlTemplateV1 = "https://sts.windows.net/{0}/";
@@ -95,6 +141,11 @@ namespace Microsoft.Agents.Authentication
         /// The Government V2 Azure AD token issuer URL template that will contain the tenant id where the token was issued from.
         /// </summary>
         public const string ValidGovernmentTokenIssuerUrlTemplateV2 = "https://login.microsoftonline.us/{0}/v2.0";
+
+        /// <summary>
+        /// The China (Gallatin/Mooncake) V2 Azure AD token issuer URL template that will contain the tenant id where the token was issued from.
+        /// </summary>
+        public const string ValidChinaTokenIssuerUrlTemplateV2 = "https://login.partner.microsoftonline.cn/0b4a31a2-c1a0-475d-b363-5f26668660a3/{0}/v2.0";
 
         /// <summary>
         /// "azp" Claim.

--- a/src/samples/EmptyAgent/AspNetExtensions.cs
+++ b/src/samples/EmptyAgent/AspNetExtensions.cs
@@ -24,24 +24,46 @@ public static class AspNetExtensions
     private static readonly ConcurrentDictionary<string, ConfigurationManager<OpenIdConnectConfiguration>> _openIdMetadataCache = new();
 
     /// <summary>
-    /// Adds AspNet token validation typical for ABS/SMBA and agent-to-agent using settings in configuration.
+    /// Adds JWT bearer token validation for Azure Bot Service and agent-to-agent requests, reading settings from configuration.
     /// </summary>
-    /// <param name="services"></param>
-    /// <param name="configuration"></param>
-    /// <param name="tokenValidationSectionName">Name of the config section to read.</param>
-    /// <param name="logger">Optional logger to use for authentication event logging.</param>
+    /// <param name="services">The <see cref="IServiceCollection"/> to add authentication services to.</param>
+    /// <param name="configuration">The application configuration containing a <see cref="TokenValidationOptions"/> section.</param>
+    /// <param name="tokenValidationSectionName">
+    /// Name of the configuration section to read <see cref="TokenValidationOptions"/> from.  Defaults to <c>"TokenValidation"</c>.
+    /// </param>
     /// <remarks>
-    /// <para>This extension reads <see cref="TokenValidationOptions"/> settings from configuration.  If configuration is missing JWT token
-    /// is not enabled.</para>
-    /// The minimum, but typical, configuration is:
+    /// <para>
+    /// If the configuration section is absent or contains <c>"Enabled": false</c>, authentication is not configured and
+    /// all requests will be treated as unauthenticated.  This is useful for local development only.
+    /// </para>
+    /// <para>
+    /// Minimum configuration for Azure Public cloud:
     /// <code>
     /// "TokenValidation": {
-    ///    "Audiences": [
-    ///      "{{ClientId}}" // this is the Client ID used for the Azure Bot
-    ///    ],
-    ///    "TenantId": "{{TenantId}}"
+    ///   "Audiences": [ "{{ClientId}}" ],
+    ///   "TenantId": "{{TenantId}}"
     /// }
     /// </code>
+    /// </para>
+    /// <para>
+    /// Minimum configuration for Azure Government cloud — add <c>"IsGov": true</c>:
+    /// <code>
+    /// "TokenValidation": {
+    ///   "Audiences": [ "{{ClientId}}" ],
+    ///   "TenantId": "{{TenantId}}",
+    ///   "IsGov": true
+    /// }
+    /// </code>
+    /// Setting <c>IsGov</c> automatically selects the correct government-cloud issuer URLs and OpenID metadata
+    /// endpoints.  See <see cref="TokenValidationOptions.IsGov"/> for the full list of defaults that are applied.
+    /// </para>
+    /// <para>
+    /// For China or other sovereign clouds, omit <c>IsGov</c> and set
+    /// <see cref="TokenValidationOptions.AzureBotServiceOpenIdMetadataUrl"/>,
+    /// <see cref="TokenValidationOptions.OpenIdMetadataUrl"/>, and
+    /// <see cref="TokenValidationOptions.ValidIssuers"/> explicitly.
+    /// See <see cref="TokenValidationOptions"/> for the full set of available settings.
+    /// </para>
     /// </remarks>
     public static void AddAgentAspNetAuthentication(this IServiceCollection services, IConfiguration configuration, string tokenValidationSectionName = "TokenValidation")
     {
@@ -58,8 +80,10 @@ public static class AspNetExtensions
     }
 
     /// <summary>
-    /// Adds AspNet token validation typical for ABS/SMBA and agent-to-agent.
+    /// Adds JWT bearer token validation for Azure Bot Service and agent-to-agent requests using the supplied options.
     /// </summary>
+    /// <param name="services">The <see cref="IServiceCollection"/> to add authentication services to.</param>
+    /// <param name="validationOptions">The fully populated <see cref="TokenValidationOptions"/> to use.</param>
     public static void AddAgentAspNetAuthentication(this IServiceCollection services, TokenValidationOptions validationOptions)
     {
         AssertionHelpers.ThrowIfNull(validationOptions, nameof(validationOptions));
@@ -87,6 +111,8 @@ public static class AspNetExtensions
                 validationOptions.ValidIssuers =
                 [
                     AuthenticationConstants.GovBotFrameworkTokenIssuer,
+                    "https://sts.windows.net/cab8a31a-1906-4287-a0d8-4eef66b95f6e/",
+                    "https://login.microsoftonline.us/cab8a31a-1906-4287-a0d8-4eef66b95f6e/v2.0"
                 ];
 
                 if (!string.IsNullOrEmpty(validationOptions.TenantId) && Guid.TryParse(validationOptions.TenantId, out _))
@@ -180,7 +206,10 @@ public static class AspNetExtensions
                     JwtSecurityToken token = new(parts[1]);
                     string issuer = token.Claims.FirstOrDefault(claim => claim.Type == AuthenticationConstants.IssuerClaim)?.Value!;
 
-                    if (validationOptions.AzureBotServiceTokenHandling && (AuthenticationConstants.BotFrameworkTokenIssuer.Equals(issuer) || AuthenticationConstants.GovBotFrameworkTokenIssuer.Equals(issuer)))
+                    if (validationOptions.AzureBotServiceTokenHandling 
+                        && (AuthenticationConstants.BotFrameworkTokenIssuer.Equals(issuer) 
+                        || AuthenticationConstants.GovBotFrameworkTokenIssuer.Equals(issuer)
+                        || AuthenticationConstants.ChinaBotFrameworkTokenIssuer.Equals(issuer)))
                     {
                         // Use the Azure Bot authority for this configuration manager
                         context.Options.TokenValidationParameters.ConfigurationManager = _openIdMetadataCache.GetOrAdd(validationOptions.AzureBotServiceOpenIdMetadataUrl, key =>
@@ -221,46 +250,91 @@ public static class AspNetExtensions
         });
     }
 
+    /// <summary>
+    /// Settings that control JWT bearer token validation for Azure Bot Service and agent-to-agent requests.
+    /// Read from the <c>TokenValidation</c> configuration section by <see cref="AddAgentAspNetAuthentication(IServiceCollection, IConfiguration, string)"/>.
+    /// </summary>
+    /// <remarks>
+    /// An <c>Enabled</c> key may also appear in the same configuration section.  When set to <c>false</c>,
+    /// authentication is disabled entirely and this class is not read.  This key is not a property of
+    /// <see cref="TokenValidationOptions"/> because it is evaluated before deserialization.
+    /// </remarks>
     public class TokenValidationOptions
     {
+        /// <summary>
+        /// One or more Client IDs of the Azure Bot registration.  At least one value is required.
+        /// </summary>
         public IList<string>? Audiences { get; set; }
 
         /// <summary>
-        /// TenantId of the Azure Bot.  Optional but recommended. 
+        /// Tenant ID of the Azure Bot.  Optional but recommended.
+        /// When provided, tenant-specific issuer URLs are added to <see cref="ValidIssuers"/> automatically.
         /// </summary>
         public string? TenantId { get; set; }
 
         /// <summary>
-        /// Additional valid issuers.  Optional, in which case the Public Azure Bot Service issuers are used.
+        /// Override the list of trusted token issuers.  Optional.
+        /// When omitted, default issuers are derived from <see cref="IsGov"/> and <see cref="TenantId"/>.
+        /// For Public cloud the defaults include the Azure Bot Service issuer and common Microsoft tenant issuers.
+        /// For Gov cloud the defaults include <see cref="AuthenticationConstants.GovBotFrameworkTokenIssuer"/> plus
+        /// tenant-specific issuer URLs built from <see cref="AuthenticationConstants.ValidTokenIssuerUrlTemplateV1"/>
+        /// and <see cref="AuthenticationConstants.ValidGovernmentTokenIssuerUrlTemplateV2"/>.
+        /// For China or other clouds all issuers must be set explicitly since there is no corresponding <c>IsChina</c> flag.
         /// </summary>
         public IList<string>? ValidIssuers { get; set; }
 
         /// <summary>
-        /// Can be omitted, in which case public Azure Bot Service and Azure Cloud metadata urls are used.
+        /// Set to <c>true</c> for Azure Government (USGov) cloud deployments.  Defaults to <c>false</c> (Public cloud).
+        /// When <c>true</c>, the following defaults are applied to any property that is not set explicitly:
+        /// <list type="bullet">
+        /// <item><description>
+        /// <see cref="AzureBotServiceOpenIdMetadataUrl"/> →
+        /// <see cref="AuthenticationConstants.GovAzureBotServiceOpenIdMetadataUrl"/>
+        /// (<c>https://login.botframework.azure.us/v1/.well-known/openidconfiguration</c>)
+        /// </description></item>
+        /// <item><description>
+        /// <see cref="OpenIdMetadataUrl"/> →
+        /// <see cref="AuthenticationConstants.GovOpenIdMetadataUrl"/>
+        /// (<c>https://login.microsoftonline.us/cab8a31a-1906-4287-a0d8-4eef66b95f6e/v2.0/.well-known/openid-configuration</c>)
+        /// </description></item>
+        /// <item><description>
+        /// <see cref="ValidIssuers"/> →
+        /// <see cref="AuthenticationConstants.GovBotFrameworkTokenIssuer"/> (<c>https://api.botframework.us</c>),
+        /// plus tenant-specific v1 and v2 issuer URLs when <see cref="TenantId"/> is provided.
+        /// </description></item>
+        /// </list>
+        /// For China or other sovereign clouds, leave this <c>false</c> and set all URLs and issuers explicitly.
         /// </summary>
         public bool IsGov { get; set; } = false;
 
         /// <summary>
-        /// Azure Bot Service OpenIdMetadataUrl.  Optional, in which case default value depends on IsGov.
+        /// OpenID Connect metadata URL used to validate tokens issued by Azure Bot Service.  Optional.
+        /// When omitted, defaults to <see cref="AuthenticationConstants.PublicAzureBotServiceOpenIdMetadataUrl"/> when
+        /// <see cref="IsGov"/> is <c>false</c>, or <see cref="AuthenticationConstants.GovAzureBotServiceOpenIdMetadataUrl"/>
+        /// when <see cref="IsGov"/> is <c>true</c>.
+        /// Set explicitly for China or other sovereign clouds.
         /// </summary>
-        /// <see cref="AuthenticationConstants.PublicAzureBotServiceOpenIdMetadataUrl"/>
-        /// <see cref="AuthenticationConstants.GovAzureBotServiceOpenIdMetadataUrl"/>
         public string? AzureBotServiceOpenIdMetadataUrl { get; set; }
 
         /// <summary>
-        /// Entra OpenIdMetadataUrl.  Optional, in which case default value depends on IsGov.
+        /// OpenID Connect metadata URL used to validate Entra ID (AAD) tokens.  Optional.
+        /// When omitted, defaults to <see cref="AuthenticationConstants.PublicOpenIdMetadataUrl"/> when
+        /// <see cref="IsGov"/> is <c>false</c>, or <see cref="AuthenticationConstants.GovOpenIdMetadataUrl"/>
+        /// when <see cref="IsGov"/> is <c>true</c>.
+        /// Set explicitly for China or other sovereign clouds.
         /// </summary>
-        /// <see cref="AuthenticationConstants.PublicOpenIdMetadataUrl"/>
-        /// <see cref="AuthenticationConstants.GovOpenIdMetadataUrl"/>
         public string? OpenIdMetadataUrl { get; set; }
 
         /// <summary>
-        /// Determines if Azure Bot Service tokens are handled.  Defaults to true and should always be true until Azure Bot Service sends Entra ID token.
+        /// Enables special handling for tokens issued directly by Azure Bot Service (as opposed to Entra ID tokens).
+        /// Defaults to <c>true</c> and should remain <c>true</c> until Azure Bot Service sends Entra ID tokens exclusively.
+        /// When <c>true</c>, the <see cref="AzureBotServiceOpenIdMetadataUrl"/> endpoint is used for ABS token validation
+        /// and <see cref="OpenIdMetadataUrl"/> is used for all other tokens.
         /// </summary>
         public bool AzureBotServiceTokenHandling { get; set; } = true;
 
         /// <summary>
-        /// OpenIdMetadata refresh interval.  Defaults to 12 hours.
+        /// How frequently the OpenID Connect metadata is refreshed from the identity provider.  Defaults to 12 hours.
         /// </summary>
         public TimeSpan? OpenIdMetadataRefresh { get; set; }
     }

--- a/src/samples/EmptyAgent/AspNetExtensions.cs
+++ b/src/samples/EmptyAgent/AspNetExtensions.cs
@@ -207,9 +207,9 @@ public static class AspNetExtensions
                     string issuer = token.Claims.FirstOrDefault(claim => claim.Type == AuthenticationConstants.IssuerClaim)?.Value!;
 
                     if (validationOptions.AzureBotServiceTokenHandling 
-                        && (AuthenticationConstants.BotFrameworkTokenIssuer.Equals(issuer) 
-                        || AuthenticationConstants.GovBotFrameworkTokenIssuer.Equals(issuer)
-                        || AuthenticationConstants.ChinaBotFrameworkTokenIssuer.Equals(issuer)))
+                        && (AuthenticationConstants.BotFrameworkTokenIssuer.Equals(issuer, StringComparison.OrdinalIgnoreCase) 
+                        || AuthenticationConstants.GovBotFrameworkTokenIssuer.Equals(issuer, StringComparison.OrdinalIgnoreCase)
+                        || AuthenticationConstants.ChinaBotFrameworkTokenIssuer.Equals(issuer, StringComparison.OrdinalIgnoreCase)))
                     {
                         // Use the Azure Bot authority for this configuration manager
                         context.Options.TokenValidationParameters.ConfigurationManager = _openIdMetadataCache.GetOrAdd(validationOptions.AzureBotServiceOpenIdMetadataUrl, key =>

--- a/src/tests/Microsoft.Agents.Builder.Tests/ChannelServiceClientFactoryTests.cs
+++ b/src/tests/Microsoft.Agents.Builder.Tests/ChannelServiceClientFactoryTests.cs
@@ -19,6 +19,7 @@ using Microsoft.Agents.Core.Errors;
 using System.Text;
 using Microsoft.Agents.TestSupport;
 using Microsoft.Agents.Builder.Errors;
+using System.Security.Claims;
 
 namespace Microsoft.Agents.Builder.Tests
 {
@@ -204,6 +205,186 @@ namespace Microsoft.Agents.Builder.Tests
             Assert.IsType<RestUserTokenClient>(tokeClient);
             Assert.Equal(new Uri(AuthenticationConstants.BotFrameworkOAuthUrl).ToString(), ((RestUserTokenClient)tokeClient).BaseUri.ToString());
         }
+
+        [Fact]
+        public void NullBotServiceAudienceThrows()
+        {
+            var config = new ConfigurationBuilder().Build();
+            var connections = new Mock<IConnections>();
+            var httpFactory = new Mock<IHttpClientFactory>();
+
+            Assert.Throws<ArgumentNullException>(() => new RestChannelServiceClientFactory(
+                config, httpFactory.Object, connections.Object, botServiceAudience: null));
+        }
+
+        [Fact]
+        public async Task BotServiceAudienceFromConstructorIsUsedAsync()
+        {
+            var config = new ConfigurationBuilder().Build();
+            string capturedAudience = null;
+
+            var tokenProvider = new Mock<IAccessTokenProvider>();
+            tokenProvider
+                .Setup(x => x.GetAccessTokenAsync(It.IsAny<string>(), It.IsAny<IList<string>>(), It.IsAny<bool>()))
+                .Callback<string, IList<string>, bool>((aud, scopes, force) => capturedAudience = aud)
+                .ReturnsAsync("fake-token");
+
+            var connections = new Mock<IConnections>();
+            connections
+                .Setup(x => x.GetTokenProvider(It.IsAny<ClaimsIdentity>(), It.IsAny<string>()))
+                .Returns(tokenProvider.Object);
+
+            var httpFactory = new Mock<IHttpClientFactory>();
+            httpFactory
+                .Setup(x => x.CreateClient(It.IsAny<string>()))
+                .Returns(new HttpClient());
+
+            var factory = new RestChannelServiceClientFactory(
+                config, httpFactory.Object, connections.Object,
+                botServiceAudience: AuthenticationConstants.GovBotFrameworkAudience);
+
+            var connector = await factory.CreateConnectorClientAsync(
+                new ClaimsIdentity(), "http://serviceurl", null, CancellationToken.None);
+
+            await ((IRestTransport)connector).GetHttpClientAsync();
+
+            Assert.Equal(AuthenticationConstants.GovBotFrameworkAudience, capturedAudience);
+        }
+
+        [Fact]
+        public async Task BotServiceAudienceFromConfigIsUsedAsync()
+        {
+            var config = new ConfigurationRoot(new List<IConfigurationProvider>
+            {
+                new MemoryConfigurationProvider(new MemoryConfigurationSource
+                {
+                    InitialData = new Dictionary<string, string>
+                    {
+                        { "RestChannelServiceClientFactory:BotServiceAudience", AuthenticationConstants.GovBotFrameworkAudience }
+                    }
+                })
+            });
+            string capturedAudience = null;
+
+            var tokenProvider = new Mock<IAccessTokenProvider>();
+            tokenProvider
+                .Setup(x => x.GetAccessTokenAsync(It.IsAny<string>(), It.IsAny<IList<string>>(), It.IsAny<bool>()))
+                .Callback<string, IList<string>, bool>((aud, scopes, force) => capturedAudience = aud)
+                .ReturnsAsync("fake-token");
+
+            var connections = new Mock<IConnections>();
+            connections
+                .Setup(x => x.GetTokenProvider(It.IsAny<ClaimsIdentity>(), It.IsAny<string>()))
+                .Returns(tokenProvider.Object);
+
+            var httpFactory = new Mock<IHttpClientFactory>();
+            httpFactory
+                .Setup(x => x.CreateClient(It.IsAny<string>()))
+                .Returns(new HttpClient());
+
+            // Default botServiceAudience is BotFrameworkAudience, but config key overrides it
+            var factory = new RestChannelServiceClientFactory(config, httpFactory.Object, connections.Object);
+
+            var connector = await factory.CreateConnectorClientAsync(
+                new ClaimsIdentity(), "http://serviceurl", null, CancellationToken.None);
+
+            await ((IRestTransport)connector).GetHttpClientAsync();
+
+            Assert.Equal(AuthenticationConstants.GovBotFrameworkAudience, capturedAudience);
+        }
+
+        [Fact]
+        public async Task AgentIdentityUsesScopesFromClaimsAsync()
+        {
+            // When the incoming identity is an agent-to-agent call (IsAgent == true),
+            // scopes are derived from the caller's appId in the claims: ["{callerAppId}/.default"]
+            var config = new ConfigurationBuilder().Build();
+            IList<string> capturedScopes = null;
+
+            var callerAppId = "caller-app-id";
+            var myAppId = "my-app-id";
+            var agentIdentity = AgentClaims.CreateIdentity(audience: myAppId, appId: callerAppId);
+
+            var tokenProvider = new Mock<IAccessTokenProvider>();
+            tokenProvider
+                .Setup(x => x.GetAccessTokenAsync(It.IsAny<string>(), It.IsAny<IList<string>>(), It.IsAny<bool>()))
+                .Callback<string, IList<string>, bool>((aud, scopes, force) => capturedScopes = scopes)
+                .ReturnsAsync("fake-token");
+
+            var connections = new Mock<IConnections>();
+            connections
+                .Setup(x => x.GetTokenProvider(It.IsAny<ClaimsIdentity>(), It.IsAny<string>()))
+                .Returns(tokenProvider.Object);
+
+            var httpFactory = new Mock<IHttpClientFactory>();
+            httpFactory
+                .Setup(x => x.CreateClient(It.IsAny<string>()))
+                .Returns(new HttpClient());
+
+            var factory = new RestChannelServiceClientFactory(config, httpFactory.Object, connections.Object);
+
+            var connector = await factory.CreateConnectorClientAsync(
+                agentIdentity, "http://serviceurl", null, CancellationToken.None);
+
+            await ((IRestTransport)connector).GetHttpClientAsync();
+
+            Assert.NotNull(capturedScopes);
+            Assert.Single(capturedScopes);
+            Assert.Equal($"{callerAppId}/.default", capturedScopes[0]);
+        }
+
+        [Theory]
+        [InlineData(AuthenticationConstants.BotFrameworkTokenIssuer, AuthenticationConstants.BotFrameworkDefaultScope)]
+        [InlineData(AuthenticationConstants.GovBotFrameworkTokenIssuer, AuthenticationConstants.GovBotFrameworkDefaultScope)]
+        public async Task AbsIdentityUsesConnectionSettingsScopesAsync(string absAudience, string configuredScope)
+        {
+            // When the incoming identity is from Azure Bot Service (any cloud, IsAgent == false),
+            // the factory passes null scopes to GetAccessTokenAsync. The IAccessTokenProvider then
+            // uses its ConnectionSettings.Scopes — i.e., the Scopes value from appsettings.
+            var config = new ConfigurationBuilder().Build();
+            IList<string> effectiveScopes = null;
+
+            var absIdentity = AgentClaims.CreateIdentity(audience: absAudience);
+
+            // Simulate the connection's settings as loaded from appsettings (e.g., Connections:...:Settings:Scopes)
+            var connectionSettings = new ImmutableConnectionSettings(
+                new TestConnectionSettings { Scopes = [configuredScope] });
+
+            var tokenProvider = new Mock<IAccessTokenProvider>();
+            tokenProvider.Setup(x => x.ConnectionSettings).Returns(connectionSettings);
+            tokenProvider
+                .Setup(x => x.GetAccessTokenAsync(It.IsAny<string>(), It.IsAny<IList<string>>(), It.IsAny<bool>()))
+                .Returns<string, IList<string>, bool>((aud, scopes, force) =>
+                {
+                    // Simulate real IAccessTokenProvider: when the factory passes null scopes for ABS,
+                    // fall back to the configured ConnectionSettings.Scopes from appsettings.
+                    effectiveScopes = scopes ?? tokenProvider.Object.ConnectionSettings.Scopes;
+                    return Task.FromResult("fake-token");
+                });
+
+            var connections = new Mock<IConnections>();
+            connections
+                .Setup(x => x.GetTokenProvider(It.IsAny<ClaimsIdentity>(), It.IsAny<string>()))
+                .Returns(tokenProvider.Object);
+
+            var httpFactory = new Mock<IHttpClientFactory>();
+            httpFactory
+                .Setup(x => x.CreateClient(It.IsAny<string>()))
+                .Returns(new HttpClient());
+
+            var factory = new RestChannelServiceClientFactory(config, httpFactory.Object, connections.Object);
+
+            var connector = await factory.CreateConnectorClientAsync(
+                absIdentity, "http://serviceurl", null, CancellationToken.None);
+
+            await ((IRestTransport)connector).GetHttpClientAsync();
+
+            Assert.NotNull(effectiveScopes);
+            Assert.Single(effectiveScopes);
+            Assert.Equal(configuredScope, effectiveScopes[0]);
+        }
+
+        private sealed class TestConnectionSettings : ConnectionSettingsBase { }
 
         [Fact]
         public async Task ConnectionFoundWithConfigTokenEndpointAsync()


### PR DESCRIPTION
RestChannelServiceClientFactory would use claims to set the audience/resourceUrl when getting a token.  For non-Public clouds this isn't optimal as it requires us to add that logic to `AgentClaims.GetOutgoingAudience`.  This adds a setting for  this factory instead.

[gov-cloud-configuration.md](https://github.com/user-attachments/files/26613216/gov-cloud-configuration.md)
