### PR TITLE
Improvements in the Adapter to IAgent pipeline

### DIFF
--- a/src/libraries/Builder/Microsoft.Agents.Builder/ChannelAdapter.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/ChannelAdapter.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Agents.Builder
             return ProcessTurnResults(context);
         }
 
-        public virtual Task ProcessProactiveAsync(ClaimsIdentity claimsIdentity, IActivity continuationActivity, string audience, AgentCallbackHandler callback, CancellationToken cancellationToken)
+        public virtual async Task ProcessProactiveAsync(ClaimsIdentity claimsIdentity, IActivity continuationActivity, string audience, AgentCallbackHandler callback, CancellationToken cancellationToken)
         {
             AssertionHelpers.ThrowIfNull(claimsIdentity, nameof(claimsIdentity));
             AssertionHelpers.ThrowIfNull(continuationActivity, nameof(continuationActivity));
@@ -147,7 +147,7 @@ namespace Microsoft.Agents.Builder
             using var context = new TurnContext(this, continuationActivity, claimsIdentity);
 
             // Run the pipeline.
-            return RunPipelineAsync(context, callback, cancellationToken);
+            await RunPipelineAsync(context, callback, cancellationToken).ConfigureAwait(false);
         }
 
         public virtual Task ProcessProactiveAsync(ClaimsIdentity claimsIdentity, IActivity continuationActivity, IAgent agent, CancellationToken cancellationToken, string audience = null)

--- a/src/libraries/Builder/Microsoft.Agents.Builder/ChannelAdapter.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/ChannelAdapter.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Agents.Builder
             AssertionHelpers.ThrowIfNull(claimsIdentity, nameof(claimsIdentity));
             AssertionHelpers.ThrowIfNull(reference, nameof(reference));
 
-            return ProcessProactiveAsync(claimsIdentity, reference.GetContinuationActivity(), claimsIdentity.GetOutgoingAudience(), callback, cancellationToken);
+            return ProcessProactiveAsync(claimsIdentity, reference.GetContinuationActivity(), null, callback, cancellationToken);
         }
 
         /// <inheritdoc/>

--- a/src/libraries/Builder/Microsoft.Agents.Builder/ChannelServiceAdapterBase.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/ChannelServiceAdapterBase.cs
@@ -100,23 +100,23 @@ namespace Microsoft.Agents.Builder
         }
 
         /// <inheritdoc/>
-        public override async Task<ResourceResponse> UpdateActivityAsync(ITurnContext turnContext, IActivity activity, CancellationToken cancellationToken)
+        public override Task<ResourceResponse> UpdateActivityAsync(ITurnContext turnContext, IActivity activity, CancellationToken cancellationToken)
         {
             _ = turnContext ?? throw new ArgumentNullException(nameof(turnContext));
             _ = activity ?? throw new ArgumentNullException(nameof(activity));
 
             var connectorClient = turnContext.Services.Get<IConnectorClient>();
-            return await connectorClient.Conversations.UpdateActivityAsync(activity, cancellationToken).ConfigureAwait(false);
+            return connectorClient.Conversations.UpdateActivityAsync(activity, cancellationToken);
         }
 
         /// <inheritdoc/>
-        public override async Task DeleteActivityAsync(ITurnContext turnContext, ConversationReference reference, CancellationToken cancellationToken)
+        public override Task DeleteActivityAsync(ITurnContext turnContext, ConversationReference reference, CancellationToken cancellationToken)
         {
             _ = turnContext ?? throw new ArgumentNullException(nameof(turnContext));
             _ = reference ?? throw new ArgumentNullException(nameof(reference));
 
             var connectorClient = turnContext.Services.Get<IConnectorClient>();
-            await connectorClient.Conversations.DeleteActivityAsync(reference.Conversation.Id, reference.ActivityId, cancellationToken).ConfigureAwait(false);
+            return connectorClient.Conversations.DeleteActivityAsync(reference.Conversation.Id, reference.ActivityId, cancellationToken);
         }
 
         /// <inheritdoc/>

--- a/src/libraries/Builder/Microsoft.Agents.Builder/ChannelServiceAdapterBase.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/ChannelServiceAdapterBase.cs
@@ -202,6 +202,7 @@ namespace Microsoft.Agents.Builder
             // Create the connector client to use for outbound requests.
             using var connectorClient = await ChannelServiceFactory.CreateConnectorClientAsync(
                 context,
+                audience,
                 useAnonymous: useAnonymousAuthCallback,
                 cancellationToken: cancellationToken).ConfigureAwait(false);
 
@@ -268,15 +269,13 @@ namespace Microsoft.Agents.Builder
             return Task.FromResult(incomingActivity?.DeliveryMode == DeliveryModes.Stream || incomingActivity?.DeliveryMode == DeliveryModes.ExpectReplies);
         }
 
-        private TurnContext SetTurnContextServices(TurnContext turnContext, IConnectorClient connectorClient, IUserTokenClient userTokenClient)
+        private void SetTurnContextServices(TurnContext turnContext, IConnectorClient connectorClient, IUserTokenClient userTokenClient)
         {
             if (connectorClient != null)
                 turnContext.Services.Set(connectorClient);
             if (userTokenClient != null)
                 turnContext.Services.Set(userTokenClient);
             turnContext.Services.Set(ChannelServiceFactory);
-
-            return turnContext;
         }
 
         private static void ValidateContinuationActivity(IActivity continuationActivity)

--- a/src/libraries/Builder/Microsoft.Agents.Builder/MiddlewareSet.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/MiddlewareSet.cs
@@ -34,9 +34,9 @@ namespace Microsoft.Agents.Builder
         }
 
         /// <inheritdoc/>
-        public async Task ReceiveActivityWithStatusAsync(ITurnContext turnContext, AgentCallbackHandler callback, CancellationToken cancellationToken)
+        public Task ReceiveActivityWithStatusAsync(ITurnContext turnContext, AgentCallbackHandler callback, CancellationToken cancellationToken)
         {
-            await ReceiveActivityInternalAsync(turnContext, callback, 0, cancellationToken).ConfigureAwait(false);
+            return ReceiveActivityInternalAsync(turnContext, callback, 0, cancellationToken);
         }
 
         /// <summary>

--- a/src/libraries/Builder/Microsoft.Agents.Builder/TurnContext.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/TurnContext.cs
@@ -265,57 +265,40 @@ namespace Microsoft.Agents.Builder
         }
 
         /// <inheritdoc/>
-        public async Task<ResourceResponse> UpdateActivityAsync(IActivity activity, CancellationToken cancellationToken = default)
+        public Task<ResourceResponse> UpdateActivityAsync(IActivity activity, CancellationToken cancellationToken = default)
         {
             AssertionHelpers.ThrowIfObjectDisposed(_disposed, nameof(UpdateActivityAsync));
             AssertionHelpers.ThrowIfNull(activity, nameof(activity));
 
             var conversationReference = Activity.GetConversationReference();
             var a = activity.ApplyConversationReference(conversationReference);
-
-            async Task<ResourceResponse> ActuallyUpdateStuffAsync()
-            {
-                return await Adapter.UpdateActivityAsync(this, a, cancellationToken).ConfigureAwait(false);
-            }
-
-            return await UpdateActivityInternalAsync(a, _onUpdateActivity, ActuallyUpdateStuffAsync, cancellationToken).ConfigureAwait(false);
+            return UpdateActivityInternalAsync(a, _onUpdateActivity, () => Adapter.UpdateActivityAsync(this, a, cancellationToken), cancellationToken);
         }
 
         /// <inheritdoc/>
-        public async Task DeleteActivityAsync(string activityId, CancellationToken cancellationToken = default)
+        public Task DeleteActivityAsync(string activityId, CancellationToken cancellationToken = default)
         {
             AssertionHelpers.ThrowIfObjectDisposed(_disposed, nameof(DeleteActivityAsync));
             AssertionHelpers.ThrowIfNullOrWhiteSpace(activityId, nameof(activityId));
 
             var cr = Activity.GetConversationReference();
             cr.ActivityId = activityId;
-
-            async Task ActuallyDeleteStuffAsync()
-            {
-                await Adapter.DeleteActivityAsync(this, cr, cancellationToken).ConfigureAwait(false);
-            }
-
-            await DeleteActivityInternalAsync(cr, _onDeleteActivity, ActuallyDeleteStuffAsync, cancellationToken).ConfigureAwait(false);
+            return DeleteActivityInternalAsync(cr, _onDeleteActivity, () => Adapter.DeleteActivityAsync(this, cr, cancellationToken), cancellationToken);
         }
 
         /// <inheritdoc/>
-        public async Task DeleteActivityAsync(ConversationReference conversationReference, CancellationToken cancellationToken = default)
+        public Task DeleteActivityAsync(ConversationReference conversationReference, CancellationToken cancellationToken = default)
         {
             AssertionHelpers.ThrowIfObjectDisposed(_disposed, nameof(DeleteActivityAsync));
             AssertionHelpers.ThrowIfNull(conversationReference, nameof(conversationReference));
 
-            async Task ActuallyDeleteStuffAsync()
-            {
-                await Adapter.DeleteActivityAsync(this, conversationReference, cancellationToken).ConfigureAwait(false);
-            }
-
-            await DeleteActivityInternalAsync(conversationReference, _onDeleteActivity, ActuallyDeleteStuffAsync, cancellationToken).ConfigureAwait(false);
+            return DeleteActivityInternalAsync(conversationReference, _onDeleteActivity, () => Adapter.DeleteActivityAsync(this, conversationReference, cancellationToken), cancellationToken);
         }
 
         /// <inheritdoc/>
-        public async Task<ResourceResponse> TraceActivityAsync(string name, object value = null, string valueType = null, [CallerMemberName] string label = null, CancellationToken cancellationToken = default)
+        public Task<ResourceResponse> TraceActivityAsync(string name, object value = null, string valueType = null, [CallerMemberName] string label = null, CancellationToken cancellationToken = default)
         {
-            return await SendActivityAsync(MessageFactory.CreateTrace(this.Activity, name, value, valueType, label), cancellationToken);
+            return SendActivityAsync(MessageFactory.CreateTrace(this.Activity, name, value, valueType, label), cancellationToken);
         }
 
         /// <summary>

--- a/src/libraries/Builder/Microsoft.Agents.Builder/TurnContext.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/TurnContext.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Agents.Builder
         }
 
         /// <inheritdoc/>
-        public async Task<ResourceResponse> SendActivityAsync(string textReplyToSend, string speak = null, string inputHint = null, CancellationToken cancellationToken = default)
+        public Task<ResourceResponse> SendActivityAsync(string textReplyToSend, string speak = null, string inputHint = null, CancellationToken cancellationToken = default)
         {
             AssertionHelpers.ThrowIfObjectDisposed(_disposed, nameof(SendActivityAsync));
             AssertionHelpers.ThrowIfNullOrWhiteSpace(textReplyToSend, nameof(textReplyToSend));
@@ -172,7 +172,7 @@ namespace Microsoft.Agents.Builder
                 activityToSend.InputHint = inputHint;
             }
 
-            return await SendActivityAsync(activityToSend, cancellationToken).ConfigureAwait(false);
+            return SendActivityAsync(activityToSend, cancellationToken);
         }
 
         /// <inheritdoc/>

--- a/src/libraries/Hosting/A2A/A2AAdapter.cs
+++ b/src/libraries/Hosting/A2A/A2AAdapter.cs
@@ -220,13 +220,12 @@ public class A2AAdapter : ChannelAdapter, IA2AHttpAdapter
 
         // Queue the activity to be processed by the ActivityBackgroundService, and stop ChannelResponseQueue when the
         // turn is done.
-        _activityTaskQueue.QueueBackgroundActivity(identity, this, activity, agentType: agent.GetType(), onComplete: (response) =>
+        _activityTaskQueue.QueueBackgroundActivity(identity, this, activity, agentType: agent.GetType(), onComplete: async (response) =>
         {
             invokeResponse = response;
 
             // Stops response handling and waits for HandleResponsesAsync to finish
-            _responseQueue.CompleteHandlerForRequest(activity.RequestId);
-            return Task.CompletedTask;
+            await _responseQueue.CompleteHandlerForRequestAsync(activity.RequestId).ConfigureAwait(false);
         });
 
         // Block until turn is complete. This is triggered by CompleteHandlerForRequest and all responses read.

--- a/src/libraries/Hosting/AspNetCore/BackgroundQueue/ActivityTaskQueue.cs
+++ b/src/libraries/Hosting/AspNetCore/BackgroundQueue/ActivityTaskQueue.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Agents.Hosting.AspNetCore.BackgroundQueue
         private readonly SemaphoreSlim _signal = new(0);
         private readonly EventWaitHandle _queueEmpty = new(true, EventResetMode.ManualReset);
         private readonly ConcurrentQueue<ActivityWithClaims> _activities = new();
-        private bool _stopped = false;
+        private volatile bool _stopped = false;
 
         /// <inheritdoc/>
         public bool QueueBackgroundActivity(ClaimsIdentity claimsIdentity, IChannelAdapter adapter, IActivity activity, bool proactive = false, string proactiveAudience = null, Type agentType = null, Func<InvokeResponse, Task> onComplete = null, IHeaderDictionary headers = null)

--- a/src/libraries/Hosting/AspNetCore/BackgroundQueue/HostedActivityService.cs
+++ b/src/libraries/Hosting/AspNetCore/BackgroundQueue/HostedActivityService.cs
@@ -97,11 +97,12 @@ namespace Microsoft.Agents.Hosting.AspNetCore.BackgroundQueue
                         try
                         {
                             // Create the task which will execute the work item.
+                            // CancellationToken.None: cleanup must always run regardless of shutdown state.
                             var task = GetTaskFromWorkItem(activityWithClaims, stoppingToken)
                                 .ContinueWith(t =>
                                 {
                                     _activitiesProcessing.TryRemove(activityWithClaims, out _);
-                                }, stoppingToken);
+                                }, CancellationToken.None);
 
                             _activitiesProcessing.TryAdd(activityWithClaims, task);
                         }

--- a/src/libraries/Hosting/AspNetCore/BackgroundQueue/HostedActivityService.cs
+++ b/src/libraries/Hosting/AspNetCore/BackgroundQueue/HostedActivityService.cs
@@ -11,7 +11,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using System;
 using System.Collections.Concurrent;
-using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -91,33 +90,29 @@ namespace Microsoft.Agents.Hosting.AspNetCore.BackgroundQueue
                 var activityWithClaims = await _activityQueue.WaitForActivityAsync(stoppingToken).ConfigureAwait(false);
                 if (activityWithClaims != null)
                 {
-                    try
+                    // The read lock will not be acquirable if the app is shutting down.
+                    // New tasks should not be starting during shutdown.
+                    if (_lock.TryEnterReadLock(500))
                     {
-                        // The read lock will not be acquirable if the app is shutting down.
-                        // New tasks should not be starting during shutdown.
-                        if (_lock.TryEnterReadLock(500))
+                        try
                         {
                             // Create the task which will execute the work item.
                             var task = GetTaskFromWorkItem(activityWithClaims, stoppingToken)
                                 .ContinueWith(t =>
                                 {
-                                    // After the work item completes, clear the running tasks of all completed tasks.
-                                    foreach (var kv in _activitiesProcessing.Where(tsk => tsk.Value.IsCompleted))
-                                    {
-                                        _activitiesProcessing.TryRemove(kv.Key, out Task removed);
-                                    }
+                                    _activitiesProcessing.TryRemove(activityWithClaims, out _);
                                 }, stoppingToken);
 
                             _activitiesProcessing.TryAdd(activityWithClaims, task);
                         }
-                        else
+                        finally
                         {
-                            _logger.LogError("Work item for '{ConversationId}' not processed.  Server is shutting down?", activityWithClaims.Activity.Conversation.Id);
+                            _lock.ExitReadLock();
                         }
                     }
-                    finally
+                    else
                     {
-                        _lock.ExitReadLock();
+                        _logger.LogError("Work item for '{ConversationId}' not processed.  Server is shutting down?", activityWithClaims.Activity.Conversation.Id);
                     }
                 }
             }

--- a/src/libraries/Hosting/AspNetCore/ChannelResponseQueue.cs
+++ b/src/libraries/Hosting/AspNetCore/ChannelResponseQueue.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
@@ -25,26 +25,24 @@ namespace Microsoft.Agents.Hosting.AspNetCore
     public class ChannelResponseQueue(ILogger logger)
     {
         private readonly ConcurrentDictionary<string, ChannelInfo> _conversations = new();
-        private static readonly TimeSpan HandlerWaitTimeout = TimeSpan.FromSeconds(30);
 
         /// <summary>
         /// Processes queued responses.  This blocks until CompleteHandlerForRequest is called.
         /// </summary>
         /// <param name="requestId"></param>
-        /// <param name="action">Action to call when an Activity is received.</param>
+        /// <param name="action">Async action to call when an Activity is received.</param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public async Task HandleResponsesAsync(string requestId, Action<IActivity> action, CancellationToken cancellationToken)
+        public async Task HandleResponsesAsync(string requestId, Func<IActivity, Task> action, CancellationToken cancellationToken)
         {
             if (_conversations.TryGetValue(requestId, out var channelInfo))
             {
-                channelInfo.readStarted.Set();
                 try
                 {
                     while (await channelInfo.channel.Reader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
                     {
                         var activity = await channelInfo.channel.Reader.ReadAsync(cancellationToken).ConfigureAwait(false);
-                        action(activity);
+                        await action(activity).ConfigureAwait(false);
                     }
                 }
                 catch (OperationCanceledException)
@@ -54,34 +52,12 @@ namespace Microsoft.Agents.Hosting.AspNetCore
                 }
                 finally
                 {
-                    channelInfo.readDone.Set();
+                    channelInfo.readDone.Release();
                 }
             }
             else
             {
                 logger.LogWarning("ChannelResponseQueue received unknown requestId '{RequestId}' in HandleResponsesAsync.", requestId);
-            }
-        }
-
-        /// <summary>
-        /// Reads all available responses for the specified request and invokes the provided action for each response.
-        /// </summary>
-        /// <remarks>This method processes all currently available responses for the given request. If no
-        /// responses are available, the action is not invoked. The method does not wait for additional responses to
-        /// arrive after it is called.</remarks>
-        /// <param name="requestId">The identifier of the request whose responses are to be read. Must not be null.</param>
-        /// <param name="action">An action to invoke for each response activity. Cannot be null.</param>
-        public void ReadAllResponsesAsync(string requestId, Action<IActivity> action)
-        {
-            if (_conversations.TryGetValue(requestId, out var channelInfo))
-            {
-
-                while (channelInfo.channel.Reader.TryRead(out var activity))
-                {
-                    action(activity);
-                }
-
-                channelInfo.readDone.Set();
             }
         }
 
@@ -95,25 +71,35 @@ namespace Microsoft.Agents.Hosting.AspNetCore
         }
 
         /// <summary>
-        /// Completes channel response handling.  This will wait for all reads to complete.  Once called,
-        /// any subsequent SendActivitiesAsync are ignored.
+        /// Completes channel response handling synchronously. Blocks until all reads complete.
+        /// Prefer <see cref="CompleteHandlerForRequestAsync"/> when calling from an async context.
         /// </summary>
         /// <param name="requestId"></param>
         public void CompleteHandlerForRequest(string requestId)
         {
             if (_conversations.TryGetValue(requestId, out var channelInfo))
             {
-                // need to wait for HandleResponsesAsync to start
-                channelInfo.readStarted.WaitOne(HandlerWaitTimeout);
-
                 if (channelInfo.channel.Writer.TryComplete())
                 {
                     _conversations.Remove(requestId, out _);
+                    channelInfo.readDone.Wait();
+                    channelInfo.readDone.Dispose();
+                }
+            }
+        }
 
-                    channelInfo.readStarted.Dispose();
-
-                    // wait for reads to be done
-                    channelInfo.readDone.WaitOne();
+        /// <summary>
+        /// Completes channel response handling asynchronously. Waits without blocking a thread pool thread.
+        /// </summary>
+        /// <param name="requestId"></param>
+        public async Task CompleteHandlerForRequestAsync(string requestId)
+        {
+            if (_conversations.TryGetValue(requestId, out var channelInfo))
+            {
+                if (channelInfo.channel.Writer.TryComplete())
+                {
+                    _conversations.Remove(requestId, out _);
+                    await channelInfo.readDone.WaitAsync().ConfigureAwait(false);
                     channelInfo.readDone.Dispose();
                 }
             }
@@ -153,14 +139,9 @@ namespace Microsoft.Agents.Hosting.AspNetCore
         }
     }
 
-    struct ChannelInfo
+    sealed class ChannelInfo
     {
-        public ChannelInfo()
-        {
-        }
-
-        public EventWaitHandle readDone = new(false, EventResetMode.ManualReset);
-        public EventWaitHandle readStarted = new(false, EventResetMode.ManualReset);
+        public SemaphoreSlim readDone = new(0, 1);
         public Channel<IActivity> channel = Channel.CreateUnbounded<IActivity>();
     }
 }

--- a/src/libraries/Hosting/AspNetCore/ChannelResponseQueue.cs
+++ b/src/libraries/Hosting/AspNetCore/ChannelResponseQueue.cs
@@ -81,8 +81,10 @@ namespace Microsoft.Agents.Hosting.AspNetCore
             {
                 if (channelInfo.channel.Writer.TryComplete())
                 {
-                    _conversations.Remove(requestId, out _);
+                    // Wait for HandleResponsesAsync to finish BEFORE removing the entry.
+                    // Removing first would cause HandleResponsesAsync to find no entry and skip reading.
                     channelInfo.readDone.Wait();
+                    _conversations.Remove(requestId, out _);
                     channelInfo.readDone.Dispose();
                 }
             }
@@ -98,8 +100,10 @@ namespace Microsoft.Agents.Hosting.AspNetCore
             {
                 if (channelInfo.channel.Writer.TryComplete())
                 {
-                    _conversations.Remove(requestId, out _);
+                    // Wait for HandleResponsesAsync to finish BEFORE removing the entry.
+                    // Removing first would cause HandleResponsesAsync to find no entry and skip reading.
                     await channelInfo.readDone.WaitAsync().ConfigureAwait(false);
+                    _conversations.Remove(requestId, out _);
                     channelInfo.readDone.Dispose();
                 }
             }

--- a/src/libraries/Hosting/AspNetCore/HttpHelper.cs
+++ b/src/libraries/Hosting/AspNetCore/HttpHelper.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.IdentityModel.Tokens.Jwt;
-using System.IO;
 using System.Linq;
 using System.Net;
 using System.Security.Claims;
@@ -32,12 +31,7 @@ namespace Microsoft.Agents.Hosting.AspNetCore
             try
             {
                 ArgumentNullException.ThrowIfNull(request);
-
-                using var memoryStream = new MemoryStream();
-                await request.Body.CopyToAsync(memoryStream).ConfigureAwait(false);
-                memoryStream.Seek(0, SeekOrigin.Begin);
-
-                return ProtocolJsonSerializer.ToObject<T>(memoryStream);
+                return await JsonSerializer.DeserializeAsync<T>(request.Body, ProtocolJsonSerializer.SerializationOptions).ConfigureAwait(false);
             }
             catch (JsonException)
             {
@@ -70,8 +64,7 @@ namespace Microsoft.Agents.Hosting.AspNetCore
                     response.ContentType = "application/json";
 
                     var json = ProtocolJsonSerializer.ToJson(invokeResponse.Body);
-                    using var memoryStream = new MemoryStream(Encoding.ASCII.GetBytes(json));
-                    await memoryStream.CopyToAsync(response.Body).ConfigureAwait(false);
+                    await response.Body.WriteAsync(Encoding.UTF8.GetBytes(json)).ConfigureAwait(false);
                 }
             }
         }

--- a/src/libraries/Hosting/AspNetCore/HttpHelper.cs
+++ b/src/libraries/Hosting/AspNetCore/HttpHelper.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Agents.Hosting.AspNetCore
 
                 if (invokeResponse.Body != null)
                 {
-                    response.ContentType = "application/json";
+                    response.ContentType = "application/json; charset=utf-8";
 
                     var json = ProtocolJsonSerializer.ToJson(invokeResponse.Body);
                     await response.Body.WriteAsync(Encoding.UTF8.GetBytes(json)).ConfigureAwait(false);

--- a/src/tests/Microsoft.Agents.Builder.Tests/ChannelServiceAdapterBaseTests.cs
+++ b/src/tests/Microsoft.Agents.Builder.Tests/ChannelServiceAdapterBaseTests.cs
@@ -317,6 +317,127 @@ namespace Microsoft.Agents.Builder.Tests
             await Assert.ThrowsAsync<ArgumentException>(async () => await adapter.SendActivitiesAsync(context, [], default));
         }
 
+        [Fact]
+        public async Task ProcessActivityAsync_ShouldInvokeCallback()
+        {
+            // Arrange
+            _callbackInvoked = false;
+            var adapter = new TestChannelAdapter(CreateMockChannelServiceClientFactory().Object);
+            var activity = new Activity(type: ActivityTypes.Message)
+            {
+                Conversation = new ConversationAccount(id: "conv-id"),
+                ServiceUrl = "http://mybot.com"
+            };
+            var identity = new ClaimsIdentity();
+
+            // Act
+            await adapter.ProcessActivityAsync(identity, activity, ContinueCallback, CancellationToken.None);
+
+            // Assert
+            Assert.True(_callbackInvoked);
+        }
+
+        [Fact]
+        public async Task ProcessActivityAsync_ShouldNotCreateConnectorClientForExpectRepliesWithoutServiceUrl()
+        {
+            // Arrange
+            _callbackInvoked = false;
+            var factory = CreateMockChannelServiceClientFactory();
+            var adapter = new TestChannelAdapter(factory.Object);
+            var activity = new Activity(type: ActivityTypes.Message)
+            {
+                Conversation = new ConversationAccount(id: "conv-id"),
+                DeliveryMode = DeliveryModes.ExpectReplies
+                // no ServiceUrl
+            };
+            var identity = new ClaimsIdentity();
+
+            // Act
+            await adapter.ProcessActivityAsync(identity, activity, ContinueCallback, CancellationToken.None);
+
+            // Assert - connector client should not have been created (no ServiceUrl + ExpectReplies)
+            factory.Verify(
+                f => f.CreateConnectorClientAsync(It.IsAny<ITurnContext>(), It.IsAny<string>(), It.IsAny<IList<string>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task ProcessProactiveAsync_ShouldInvokeCallback()
+        {
+            // Arrange
+            _callbackInvoked = false;
+            var adapter = new TestChannelAdapter(CreateMockChannelServiceClientFactory().Object);
+            var identity = new ClaimsIdentity();
+
+            // Act
+            await adapter.ProcessProactiveAsync(identity, _activity, audience: null, ContinueCallback, CancellationToken.None);
+
+            // Assert
+            Assert.True(_callbackInvoked);
+        }
+
+        [Fact]
+        public async Task ProcessProactiveAsync_ShouldPassAudienceToConnectorClientFactory()
+        {
+            // Arrange
+            const string expectedAudience = "my-audience";
+            var factory = CreateMockChannelServiceClientFactory();
+            var adapter = new TestChannelAdapter(factory.Object);
+            var identity = new ClaimsIdentity();
+
+            // Act
+            await adapter.ProcessProactiveAsync(identity, _activity, expectedAudience, ContinueCallback, CancellationToken.None);
+
+            // Assert - audience must be forwarded to CreateConnectorClientAsync (regression test)
+            factory.Verify(
+                f => f.CreateConnectorClientAsync(
+                    It.IsAny<ITurnContext>(),
+                    expectedAudience,
+                    It.IsAny<IList<string>>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task ProcessProactiveAsync_ShouldThrowWhenConversationIsNull()
+        {
+            // Arrange
+            var adapter = new TestChannelAdapter(CreateMockChannelServiceClientFactory().Object);
+            var identity = new ClaimsIdentity();
+            var activityWithNoConversation = new Activity(type: ActivityTypes.Event); // Conversation is null
+
+            // Act & Assert
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                () => adapter.ProcessProactiveAsync(identity, activityWithNoConversation, audience: null, ContinueCallback, CancellationToken.None));
+        }
+
+        [Fact]
+        public async Task SendActivitiesAsync_ShouldNotUseConnectorForExpectReplies()
+        {
+            // Arrange
+            var connectorClient = CreateMockConnectorClient();
+            var adapter = new TestChannelAdapter(new Mock<IChannelServiceClientFactory>().Object);
+            var incomingActivity = new Activity { DeliveryMode = DeliveryModes.ExpectReplies };
+            var context = new TurnContext(adapter, incomingActivity);
+            context.Services.Set<IConnectorClient>(connectorClient.Object);
+            var activities = new Activity[]
+            {
+                new Activity(type: ActivityTypes.Message, text: "reply")
+            };
+
+            // Act
+            var responses = await adapter.SendActivitiesAsync(context, activities, CancellationToken.None);
+
+            // Assert - connector should never be called for ExpectReplies delivery mode
+            connectorClient.Verify(
+                c => c.Conversations.ReplyToActivityAsync(It.IsAny<Activity>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+            connectorClient.Verify(
+                c => c.Conversations.SendToConversationAsync(It.IsAny<Activity>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
         private Task ContinueCallback(ITurnContext turnContext, CancellationToken cancellationToken)
         {
             _callbackInvoked = true;

--- a/src/tests/Microsoft.Agents.Builder.Tests/TurnContextTests.cs
+++ b/src/tests/Microsoft.Agents.Builder.Tests/TurnContextTests.cs
@@ -622,6 +622,39 @@ namespace Microsoft.Agents.Builder.Tests
             }
         }
 
+        [Fact]
+        public async Task SendActivityAsync_ShouldThrowAfterDispose()
+        {
+            var adapter = new SimpleAdapter();
+            var context = new TurnContext(adapter, new Activity());
+            context.Dispose();
+
+            await Assert.ThrowsAsync<ObjectDisposedException>(
+                () => context.SendActivityAsync("hello"));
+        }
+
+        [Fact]
+        public async Task UpdateActivityAsync_ShouldThrowAfterDispose()
+        {
+            var adapter = new SimpleAdapter();
+            var context = new TurnContext(adapter, new Activity());
+            context.Dispose();
+
+            await Assert.ThrowsAsync<ObjectDisposedException>(
+                () => context.UpdateActivityAsync(new Activity()));
+        }
+
+        [Fact]
+        public async Task DeleteActivityAsync_ShouldThrowAfterDispose()
+        {
+            var adapter = new SimpleAdapter();
+            var context = new TurnContext(adapter, new Activity());
+            context.Dispose();
+
+            await Assert.ThrowsAsync<ObjectDisposedException>(
+                () => context.DeleteActivityAsync("some-activity-id"));
+        }
+
         private async Task MyBotLogic(ITurnContext turnContext, CancellationToken cancellationToken)
         {
             if (turnContext.Activity.Text == "TestResponded")

--- a/src/tests/Microsoft.Agents.Hosting.AspNetCore/CloudAdapterTests.cs
+++ b/src/tests/Microsoft.Agents.Hosting.AspNetCore/CloudAdapterTests.cs
@@ -18,6 +18,7 @@ using Microsoft.Agents.Storage;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -26,6 +27,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Security.Claims;
 using System.Text;
 using System.Text.Json;
@@ -38,6 +40,7 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
     [Collection("CloudAdapter Collection")]
     public class CloudAdapterTests
     {
+        private const string TestServiceUrl = "https://test.serviceurl.com/";
 
         [Fact]
         public void Constructor_ShouldThrowWithNullActivityTaskQueue()
@@ -185,24 +188,15 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
             var record = UseRecord((record) => new RespondingActivityHandler());
             var activity = CreateMessageActivity(DeliveryModes.Normal, activityId: Guid.NewGuid().ToString());
             var context = CreateHttpContext(activity);
-            EventWaitHandle turnStarted = new(false, EventResetMode.ManualReset);
-
+            var turnStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var sentActivities = new List<IActivity>();
-            var mockConnectorClient = new Mock<IConnectorClient>();
-            mockConnectorClient.Setup(c => c.Conversations.ReplyToActivityAsync(It.IsAny<Activity>(), It.IsAny<CancellationToken>()))
-                .Callback<IActivity, CancellationToken>((response, _) => { turnStarted.Set(); sentActivities.Add(response); })
-                .Returns(Task.FromResult(new ResourceResponse("replyResourceId")));
-            mockConnectorClient.Setup(c => c.Conversations.SendToConversationAsync(It.IsAny<Activity>(), It.IsAny<CancellationToken>()))
-                .Callback<IActivity, CancellationToken>((response, _) => { turnStarted.Set(); sentActivities.Add(response); })
-                .Returns(Task.FromResult(new ResourceResponse("sendResourceId")));
-            record.Factory
-                .Setup(c => c.CreateConnectorClientAsync(It.IsAny<ITurnContext>(), It.IsAny<string>(), It.IsAny<IList<string>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(mockConnectorClient.Object));
+            SetupConnectorClient(record, sentActivities, firstActivitySent: turnStarted);
 
             await record.Service.StartAsync(CancellationToken.None);
             await record.Adapter.ProcessAsync(context.Request, context.Response, record.Agent, CancellationToken.None);
 
-            Assert.True(turnStarted.WaitOne(TimeSpan.FromSeconds(10)), "Background turn did not complete within timeout");
+            var timedOut = await Task.WhenAny(turnStarted.Task, Task.Delay(TimeSpan.FromSeconds(10)));
+            Assert.True(timedOut == turnStarted.Task, "Background turn did not complete within timeout");
             await record.Service.StopAsync(CancellationToken.None);
 
             Assert.Equal(StatusCodes.Status202Accepted, context.Response.StatusCode);
@@ -218,24 +212,16 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
             var record = UseRecord((record) => new RespondingActivityHandler());
             var activity = CreateMessageActivity(DeliveryModes.Normal, text: "throw");
             var context = CreateHttpContext(activity);
-            EventWaitHandle turnStarted = new(false, EventResetMode.ManualReset);
 
+            var turnStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             var sentActivities = new List<IActivity>();
-            var mockConnectorClient = new Mock<IConnectorClient>();
-            mockConnectorClient.Setup(c => c.Conversations.ReplyToActivityAsync(It.IsAny<Activity>(), It.IsAny<CancellationToken>()))
-                .Callback<IActivity, CancellationToken>((response, _) => { turnStarted.Set(); sentActivities.Add(response); })
-                .Returns(Task.FromResult(new ResourceResponse("replyResourceId")));
-            mockConnectorClient.Setup(c => c.Conversations.SendToConversationAsync(It.IsAny<Activity>(), It.IsAny<CancellationToken>()))
-                .Callback<IActivity, CancellationToken>((response, _) => { turnStarted.Set(); sentActivities.Add(response); })
-                .Returns(Task.FromResult(new ResourceResponse("sendResourceId")));
-            record.Factory
-                .Setup(c => c.CreateConnectorClientAsync(It.IsAny<ITurnContext>(), It.IsAny<string>(), It.IsAny<IList<string>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(mockConnectorClient.Object));
+            SetupConnectorClient(record, sentActivities, firstActivitySent: turnStarted);
 
             await record.Service.StartAsync(CancellationToken.None);
             await record.Adapter.ProcessAsync(context.Request, context.Response, record.Agent, CancellationToken.None);
 
-            Assert.True(turnStarted.WaitOne(TimeSpan.FromSeconds(10)), "Background turn did not complete within timeout");
+            var timedOut = await Task.WhenAny(turnStarted.Task, Task.Delay(TimeSpan.FromSeconds(10)));
+            Assert.True(timedOut == turnStarted.Task, "Background turn did not complete within timeout");
             await record.Service.StopAsync(CancellationToken.None);
 
             Assert.Equal(StatusCodes.Status202Accepted, context.Response.StatusCode);
@@ -538,16 +524,7 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
 
             // Proactive replies use ReplyToActivity (has replyToId); SendToConversation should never be called
             var responses = new List<IActivity>();
-            var mockConnectorClient = new Mock<IConnectorClient>();
-            mockConnectorClient.Setup(c => c.Conversations.ReplyToActivityAsync(It.IsAny<Activity>(), It.IsAny<CancellationToken>()))
-                .Callback<IActivity, CancellationToken>((response, _) => responses.Add(response))
-                .Returns(Task.FromResult(new ResourceResponse("replyResourceId")));
-            mockConnectorClient.Setup(c => c.Conversations.SendToConversationAsync(It.IsAny<Activity>(), It.IsAny<CancellationToken>()))
-                .Callback<IActivity, CancellationToken>((_, _) => Assert.Fail("SendToConversation should not be called; all replies have a replyToId"))
-                .Returns(Task.FromResult(new ResourceResponse("sendResourceId")));
-            record.Factory
-                .Setup(c => c.CreateConnectorClientAsync(It.IsAny<ITurnContext>(), It.IsAny<string>(), It.IsAny<IList<string>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(mockConnectorClient.Object));
+            var handler = SetupConnectorClient(record, responses);
 
             var activity = CreateMessageActivity(DeliveryModes.Normal, conversationId: initialConversationId, text: "user message", activityId: "1", serviceUrl: serviceUrl);
             var context = CreateHttpContext(activity);
@@ -562,6 +539,7 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
 
             Assert.True(turnDone.WaitOne(TimeSpan.FromSeconds(10)), "Turn did not complete within timeout");
 
+            Assert.False(handler.SendToConversationCalled, "SendToConversation should not be called; all replies have a replyToId");
             Assert.Equal(2, responses.Count);
             Assert.Equal("Original Conversation: user message", responses[0].Text);
             Assert.Equal(initialConversationId, responses[0].Conversation.Id);
@@ -712,6 +690,108 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
             Assert.Equal(StatusCodes.Status202Accepted, context.Response.StatusCode);
         }
 
+        [Fact]
+        public async Task ProcessAsync_NormalMessage_ConnectorNetworkError_ShouldReturn202()
+        {
+            var record = UseRecord((record) => new RespondingActivityHandler());
+            var activity = CreateMessageActivity(DeliveryModes.Normal);
+            var context = CreateHttpContext(activity);
+            var handler = SetupConnectorClient(record);
+            handler.Override = _ => throw new HttpRequestException("Simulated network error");
+
+            await record.Service.StartAsync(CancellationToken.None);
+            await record.Adapter.ProcessAsync(context.Request, context.Response, record.Agent, CancellationToken.None);
+            await record.Service.StopAsync(CancellationToken.None);
+
+            Assert.Equal(StatusCodes.Status202Accepted, context.Response.StatusCode);
+        }
+
+        [Fact]
+        public async Task ProcessAsync_NormalMessage_ConnectorHttpError_ShouldReturn202()
+        {
+            var record = UseRecord((record) => new RespondingActivityHandler());
+            var activity = CreateMessageActivity(DeliveryModes.Normal);
+            var context = CreateHttpContext(activity);
+            var handler = SetupConnectorClient(record);
+            handler.Override = _ => new HttpResponseMessage(HttpStatusCode.InternalServerError);
+
+            await record.Service.StartAsync(CancellationToken.None);
+            await record.Adapter.ProcessAsync(context.Request, context.Response, record.Agent, CancellationToken.None);
+            await record.Service.StopAsync(CancellationToken.None);
+
+            Assert.Equal(StatusCodes.Status202Accepted, context.Response.StatusCode);
+        }
+
+        [Fact]
+        public async Task ProcessAsync_NormalMessage_ConnectorNetworkError_ShouldCallOnTurnError()
+        {
+            // OnTurnError is called with the raw HttpRequestException from the broken connector
+            var errorCaptured = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var record = UseRecord((record) => new RespondingActivityHandler());
+            record.Adapter.OnTurnError = (_, ex) => { errorCaptured.TrySetResult(ex); return Task.CompletedTask; };
+            var activity = CreateMessageActivity(DeliveryModes.Normal);
+            var context = CreateHttpContext(activity);
+            var handler = SetupConnectorClient(record);
+            handler.Override = _ => throw new HttpRequestException("Simulated network error");
+
+            await record.Service.StartAsync(CancellationToken.None);
+            await record.Adapter.ProcessAsync(context.Request, context.Response, record.Agent, CancellationToken.None);
+
+            var timedOut = await Task.WhenAny(errorCaptured.Task, Task.Delay(TimeSpan.FromSeconds(10)));
+            Assert.True(timedOut == errorCaptured.Task, "OnTurnError was not called within timeout");
+            await record.Service.StopAsync(CancellationToken.None);
+
+            var captured = await errorCaptured.Task;
+            Assert.IsType<HttpRequestException>(captured);
+            Assert.Equal("Simulated network error", captured.Message);
+        }
+
+        [Fact]
+        public async Task ProcessAsync_NormalMessage_ConnectorHttpError_ShouldCallOnTurnError()
+        {
+            // A non-2xx HTTP response from the connector produces an ErrorResponseException in OnTurnError
+            var errorCaptured = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var record = UseRecord((record) => new RespondingActivityHandler());
+            record.Adapter.OnTurnError = (_, ex) => { errorCaptured.TrySetResult(ex); return Task.CompletedTask; };
+            var activity = CreateMessageActivity(DeliveryModes.Normal);
+            var context = CreateHttpContext(activity);
+            var handler = SetupConnectorClient(record);
+            handler.Override = _ => new HttpResponseMessage(HttpStatusCode.InternalServerError);
+
+            await record.Service.StartAsync(CancellationToken.None);
+            await record.Adapter.ProcessAsync(context.Request, context.Response, record.Agent, CancellationToken.None);
+
+            var timedOut = await Task.WhenAny(errorCaptured.Task, Task.Delay(TimeSpan.FromSeconds(10)));
+            Assert.True(timedOut == errorCaptured.Task, "OnTurnError was not called within timeout");
+            await record.Service.StopAsync(CancellationToken.None);
+
+            Assert.IsType<ErrorResponseException>(await errorCaptured.Task);
+        }
+
+        [Fact]
+        public async Task ProcessAsync_NormalMessage_ConnectorUnauthorized_ShouldCallOnTurnError()
+        {
+            // A 401 response is special-cased by the connector: it produces OperationCanceledException (invalid token)
+            var errorCaptured = new TaskCompletionSource<Exception>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var record = UseRecord((record) => new RespondingActivityHandler());
+            record.Adapter.OnTurnError = (_, ex) => { errorCaptured.TrySetResult(ex); return Task.CompletedTask; };
+            var activity = CreateMessageActivity(DeliveryModes.Normal);
+            var context = CreateHttpContext(activity);
+            var handler = SetupConnectorClient(record);
+            handler.Override = _ => new HttpResponseMessage(HttpStatusCode.Unauthorized);
+
+            await record.Service.StartAsync(CancellationToken.None);
+            await record.Adapter.ProcessAsync(context.Request, context.Response, record.Agent, CancellationToken.None);
+
+            var timedOut = await Task.WhenAny(errorCaptured.Task, Task.Delay(TimeSpan.FromSeconds(10)));
+            Assert.True(timedOut == errorCaptured.Task, "OnTurnError was not called within timeout");
+            await record.Service.StopAsync(CancellationToken.None);
+
+            var captured = await errorCaptured.Task;
+            Assert.IsType<OperationCanceledException>(captured);
+            Assert.IsType<ErrorResponseException>(captured.InnerException);
+        }
+
         private static Activity CreateMessageActivity(
             string deliveryMode = DeliveryModes.Normal,
             string conversationId = null,
@@ -761,34 +841,30 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
         }
 
         /// <summary>
-        /// Sets up a mock IConnectorClient on the factory that optionally captures sent activities.
+        /// Sets up the connector client factory to return a real RestConnectorClient backed by a TestHttpHandler,
+        /// covering the full HTTP stack including serialization/deserialization.
         /// </summary>
-        private static Mock<IConnectorClient> SetupConnectorClient(
+        private static TestHttpHandler SetupConnectorClient(
             Record record,
             List<IActivity> captured = null,
-            string newConversationId = null)
+            string newConversationId = null,
+            TaskCompletionSource<bool> firstActivitySent = null)
         {
-            var mock = new Mock<IConnectorClient>();
-
-            mock.Setup(c => c.Conversations.ReplyToActivityAsync(It.IsAny<Activity>(), It.IsAny<CancellationToken>()))
-                .Callback<IActivity, CancellationToken>((a, _) => captured?.Add(a))
-                .Returns(Task.FromResult(new ResourceResponse("replyResourceId")));
-
-            mock.Setup(c => c.Conversations.SendToConversationAsync(It.IsAny<Activity>(), It.IsAny<CancellationToken>()))
-                .Callback<IActivity, CancellationToken>((a, _) => captured?.Add(a))
-                .Returns(Task.FromResult(new ResourceResponse("sendResourceId")));
-
-            if (newConversationId != null)
-            {
-                mock.Setup(c => c.Conversations.CreateConversationAsync(It.IsAny<ConversationParameters>(), It.IsAny<CancellationToken>()))
-                    .Returns(Task.FromResult(new ConversationResourceResponse { Id = newConversationId }));
-            }
+            var handler = new TestHttpHandler(captured, newConversationId, firstActivitySent);
+            var httpFactory = new Mock<IHttpClientFactory>();
+            httpFactory.Setup(f => f.CreateClient(It.IsAny<string>()))
+                .Returns(() => new HttpClient(handler, disposeHandler: false));
 
             record.Factory
                 .Setup(c => c.CreateConnectorClientAsync(It.IsAny<ITurnContext>(), It.IsAny<string>(), It.IsAny<IList<string>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(mock.Object));
+                .Returns<ITurnContext, string, IList<string>, bool, CancellationToken>((ctx, _, _, _, _) =>
+                {
+                    var serviceUrl = string.IsNullOrEmpty(ctx.Activity.ServiceUrl) ? TestServiceUrl : ctx.Activity.ServiceUrl;
+                    return Task.FromResult<IConnectorClient>(
+                        new RestConnectorClient(new Uri(serviceUrl), httpFactory.Object, () => Task.FromResult("test-token")));
+                });
 
-            return mock;
+            return handler;
         }
 
         private static DefaultHttpContext CreateHttpContext(Activity activity = null)
@@ -907,6 +983,60 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
                     Body = new TokenResponse() { Token = $"token:{turnContext.Activity.Conversation.Id}" }
                 };
             }
+        }
+
+        /// <summary>
+        /// An <see cref="HttpMessageHandler"/> that intercepts connector HTTP calls, enabling tests to cover
+        /// the full <see cref="RestConnectorClient"/> stack without real network I/O.
+        /// </summary>
+        private class TestHttpHandler : HttpMessageHandler
+        {
+            private readonly List<IActivity> _captured;
+            private readonly string _newConversationId;
+            private readonly TaskCompletionSource<bool> _firstActivitySent;
+
+            /// <summary>Gets whether <c>SendToConversation</c> was called (path ends with <c>/activities</c>).</summary>
+            public bool SendToConversationCalled { get; private set; }
+
+            /// <summary>When set, called instead of the default routing logic — use to inject network errors or HTTP error codes.</summary>
+            public Func<HttpRequestMessage, HttpResponseMessage> Override { get; set; }
+
+            public TestHttpHandler(List<IActivity> captured = null, string newConversationId = null, TaskCompletionSource<bool> firstActivitySent = null)
+            {
+                _captured = captured;
+                _newConversationId = newConversationId;
+                _firstActivitySent = firstActivitySent;
+            }
+
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                if (Override != null)
+                    return Override(request);
+
+                var path = request.RequestUri.AbsolutePath;
+                var body = request.Content != null ? await request.Content.ReadAsStringAsync(cancellationToken) : string.Empty;
+
+                // ReplyToActivity: /v3/conversations/{convId}/activities/{actId}
+                // SendToConversation: /v3/conversations/{convId}/activities
+                if (path.Contains("/activities"))
+                {
+                    if (path.EndsWith("/activities"))
+                        SendToConversationCalled = true;
+                    if (_captured != null && !string.IsNullOrEmpty(body))
+                        _captured.Add(ProtocolJsonSerializer.ToObject<Activity>(body));
+                    _firstActivitySent?.TrySetResult(true);
+                    return OkJson(ProtocolJsonSerializer.ToJson(new ResourceResponse("replyResourceId")));
+                }
+
+                // CreateConversation: /v3/conversations
+                if (path == "/v3/conversations")
+                    return OkJson(ProtocolJsonSerializer.ToJson(new ConversationResourceResponse { Id = _newConversationId ?? "new-convo-id" }));
+
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            }
+
+            private static HttpResponseMessage OkJson(string json) =>
+                new(HttpStatusCode.OK) { Content = new StringContent(json, Encoding.UTF8, "application/json") };
         }
     }
 }

--- a/src/tests/Microsoft.Agents.Hosting.AspNetCore/CloudAdapterTests.cs
+++ b/src/tests/Microsoft.Agents.Hosting.AspNetCore/CloudAdapterTests.cs
@@ -127,96 +127,31 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
             record.VerifyMocks();
         }
 
-        /*
-        [Fact]
-        public async Task ProcessAsync_NoOnTurnErrorLog()
-        {
-            var bot = new RespondingActivityHandler();
-            var record = UseRecord(bot);
-            var context = CreateHttpContext(new(ActivityTypes.Message, serviceUrl: "http://localhost", conversation: new(id: Guid.NewGuid().ToString())));
-
-            record.Adapter.OnTurnError = null;
-
-            var mockConnectorClient = new Mock<IConnectorClient>();
-            mockConnectorClient
-                .Setup(c => c.Conversations.ReplyToActivityAsync(It.IsAny<Activity>(), It.IsAny<CancellationToken>()))
-                .Throws(new Exception("ReplyToActivityAsync"));
-            mockConnectorClient
-                .Setup(c => c.Conversations.SendToConversationAsync(It.IsAny<Activity>(), It.IsAny<CancellationToken>()))
-                .Throws(new Exception("SendToConversationAsync"));
-            record.Factory
-                .Setup(c => c.CreateConnectorClientAsync(It.IsAny<ClaimsIdentity>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>(), It.IsAny<IList<string>>(), It.IsAny<bool>()))
-                .Returns(Task.FromResult(mockConnectorClient.Object));
-
-            record.HostedServiceLogger
-                .Setup(e => e.Log(
-                    LogLevel.Error,
-                    It.IsAny<EventId>(),
-                    It.Is<It.IsAnyType>((e, _) => e.ToString().Contains("Error occurred executing WorkItem")),
-                    It.IsAny<Exception>(),
-                    (Func<It.IsAnyType, Exception, string>)It.IsAny<object>()))
-                .Verifiable(Times.Once);
-
-            await record.Service.StartAsync(CancellationToken.None);
-            await record.Adapter.ProcessAsync(context.Request, context.Response, bot, CancellationToken.None);
-            await record.Service.StopAsync(CancellationToken.None);
-
-            Assert.Equal(StatusCodes.Status202Accepted, context.Response.StatusCode);
-            Mock.Verify(record.HostedServiceLogger);
-        }
-        */
-
         [Fact]
         public async Task ProcessAsync_ShouldSetInvokeResponseNotImplemented()
         {
             var record = UseRecord((record) => new ActivityHandler());
-
-            var activity = new Activity()
-            {
-                ChannelId = Channels.Test,
-                Type = ActivityTypes.Invoke,
-                Name = "invoke",
-                DeliveryMode = DeliveryModes.ExpectReplies,
-                Conversation = new(id: Guid.NewGuid().ToString()),
-                Recipient = new(id: "recipientId", role: RoleTypes.Agent),
-                From = new(id: "fromId", role: RoleTypes.User)
-            };
-            var context = CreateHttpContext(activity);
+            var context = CreateHttpContext(CreateInvokeActivity());
 
             await record.Adapter.ProcessAsync(context.Request, context.Response, record.Agent, CancellationToken.None);
 
-            // this is because ActivityHandler by default will return 501 for unnamed Invokes
+            // ActivityHandler returns 501 for unnamed Invokes by default
             Assert.Equal(StatusCodes.Status501NotImplemented, context.Response.StatusCode);
         }
 
         [Fact]
         public async Task ProcessAsync_InvokeShouldSetExpectedReplies()
         {
-            // Returns an ExpectedReplies with one Activity, and Body of "TokenResponse"
+            // Returns an ExpectedReplies with one Activity and a Body of TokenResponse
             var record = UseRecord((record) => new RespondingActivityHandler());
-
-            var activity = new Activity()
-            {
-                ChannelId = Channels.Test,
-                Type = ActivityTypes.Invoke,
-                Name = "invoke",
-                DeliveryMode = DeliveryModes.ExpectReplies,
-                Conversation = new(id: Guid.NewGuid().ToString()),
-                Recipient = new(id: "recipientId", role: RoleTypes.Agent),
-                From = new(id: "fromId", role: RoleTypes.User)
-            };
+            var activity = CreateInvokeActivity();
             var context = CreateHttpContext(activity);
 
             await record.Adapter.ProcessAsync(context.Request, context.Response, record.Agent, CancellationToken.None);
 
             Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
 
-            context.Response.Body.Seek(0, SeekOrigin.Begin);
-            var reader = new StreamReader(context.Response.Body);
-            var streamText = reader.ReadToEnd();
-
-            var expectedReplies = ProtocolJsonSerializer.ToObject<ExpectedReplies>(streamText);
-
+            var expectedReplies = ReadExpectedReplies(context);
             Assert.NotNull(expectedReplies);
             Assert.NotEmpty(expectedReplies.Activities);
             Assert.NotNull(expectedReplies.Body);
@@ -230,105 +165,47 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
         public async Task ProcessAsync_DeliveryModeNormalShouldSetInvokeResponse()
         {
             var record = UseRecord((record) => new RespondingActivityHandler());
-
-            var convoId = Guid.NewGuid().ToString();
-            var activity = new Activity()
-            {
-                ChannelId = Channels.Test,
-                Type = ActivityTypes.Invoke,
-                Name = "invoke",
-                DeliveryMode = DeliveryModes.Normal,
-                Conversation = new(id: convoId),
-                Recipient = new(id: "recipientId", role: RoleTypes.Agent),
-                From = new(id: "userId", role: RoleTypes.User)
-            };
+            var activity = CreateInvokeActivity(DeliveryModes.Normal);
             var context = CreateHttpContext(activity);
+            SetupConnectorClient(record);
 
-            var mockConnectorClient = new Mock<IConnectorClient>();
-            mockConnectorClient.Setup(c => c.Conversations.ReplyToActivityAsync(It.IsAny<Activity>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(
-                    new ResourceResponse("replyResourceId")
-                ));
-            mockConnectorClient.Setup(c => c.Conversations.SendToConversationAsync(It.IsAny<Activity>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(
-                        new ResourceResponse("sendResourceId")
-                    ));
-
-            record.Factory
-                .Setup(c => c.CreateConnectorClientAsync(It.IsAny<ITurnContext>(), It.IsAny<string>(), It.IsAny<IList<string>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(mockConnectorClient.Object));
-
-
-            // Test
             await record.Adapter.ProcessAsync(context.Request, context.Response, record.Agent, CancellationToken.None);
 
             Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
 
-            // This is testing what was actually written to the HttpResponse
             context.Response.Body.Seek(0, SeekOrigin.Begin);
-            var reader = new StreamReader(context.Response.Body);
-            var streamText = reader.ReadToEnd();
-
-            var tokenResponse = ProtocolJsonSerializer.ToObject<TokenResponse>(streamText);
+            var tokenResponse = ProtocolJsonSerializer.ToObject<TokenResponse>(new StreamReader(context.Response.Body).ReadToEnd());
             Assert.NotNull(tokenResponse);
-            Assert.Equal($"token:{convoId}", tokenResponse.Token);
+            Assert.Equal($"token:{activity.Conversation.Id}", tokenResponse.Token);
         }
 
         [Fact]
         public async Task ProcessAsync_DeliveryModeNormalMessage()
         {
             var record = UseRecord((record) => new RespondingActivityHandler());
-
-            var activity = new Activity()
-            {
-                Id = Guid.NewGuid().ToString(),
-                ChannelId = Channels.Test,
-                Type = ActivityTypes.Message,
-                DeliveryMode = DeliveryModes.Normal,
-                Conversation = new(id: Guid.NewGuid().ToString()),
-                Recipient = new(id: "recipientId", role: RoleTypes.Agent),
-                From = new(id: "userId", role: RoleTypes.User)
-            };
+            var activity = CreateMessageActivity(DeliveryModes.Normal, activityId: Guid.NewGuid().ToString());
             var context = CreateHttpContext(activity);
             EventWaitHandle turnStarted = new(false, EventResetMode.ManualReset);
 
-            // capture ConnectorClient sends
             var sentActivities = new List<IActivity>();
             var mockConnectorClient = new Mock<IConnectorClient>();
             mockConnectorClient.Setup(c => c.Conversations.ReplyToActivityAsync(It.IsAny<Activity>(), It.IsAny<CancellationToken>()))
-                .Callback<IActivity, CancellationToken>((response, ct) =>
-                {
-                    turnStarted.Set();
-                    sentActivities.Add(response);
-                })
-                .Returns(Task.FromResult(
-                    new ResourceResponse("replyResourceId")
-                ));
+                .Callback<IActivity, CancellationToken>((response, _) => { turnStarted.Set(); sentActivities.Add(response); })
+                .Returns(Task.FromResult(new ResourceResponse("replyResourceId")));
             mockConnectorClient.Setup(c => c.Conversations.SendToConversationAsync(It.IsAny<Activity>(), It.IsAny<CancellationToken>()))
-                .Callback<IActivity, CancellationToken>((response, ct) =>
-                {
-                    turnStarted.Set();
-                    sentActivities.Add(response);
-                })
-                .Returns(Task.FromResult(
-                        new ResourceResponse("sendResourceId")
-                    ));
-
+                .Callback<IActivity, CancellationToken>((response, _) => { turnStarted.Set(); sentActivities.Add(response); })
+                .Returns(Task.FromResult(new ResourceResponse("sendResourceId")));
             record.Factory
                 .Setup(c => c.CreateConnectorClientAsync(It.IsAny<ITurnContext>(), It.IsAny<string>(), It.IsAny<IList<string>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(mockConnectorClient.Object));
 
-
-            // Test
             await record.Service.StartAsync(CancellationToken.None);
             await record.Adapter.ProcessAsync(context.Request, context.Response, record.Agent, CancellationToken.None);
 
-            turnStarted.WaitOne();
+            Assert.True(turnStarted.WaitOne(TimeSpan.FromSeconds(10)), "Background turn did not complete within timeout");
             await record.Service.StopAsync(CancellationToken.None);
 
             Assert.Equal(StatusCodes.Status202Accepted, context.Response.StatusCode);
-
-            Assert.NotEmpty(sentActivities);
             Assert.Equal(3, sentActivities.Count);
             Assert.Equal($"Response {activity.Conversation.Id}:{activity.Id}:0", sentActivities[0].Text);
             Assert.Equal($"Response {activity.Conversation.Id}:{activity.Id}:1", sentActivities[1].Text);
@@ -339,57 +216,29 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
         public async Task ProcessAsync_DeliveryModeNormalMessageWithThrow()
         {
             var record = UseRecord((record) => new RespondingActivityHandler());
-
-            var convoId = Guid.NewGuid().ToString();
-            var activity = new Activity()
-            {
-                ChannelId = Channels.Test,
-                Type = ActivityTypes.Message,
-                DeliveryMode = DeliveryModes.Normal,
-                Conversation = new(id: convoId),
-                Recipient = new(id: "recipientId", role: RoleTypes.Agent),
-                From = new(id: "userId", role: RoleTypes.User),
-                Text = "throw"
-            };
+            var activity = CreateMessageActivity(DeliveryModes.Normal, text: "throw");
             var context = CreateHttpContext(activity);
             EventWaitHandle turnStarted = new(false, EventResetMode.ManualReset);
 
-            // capture ConnectorClient sends
             var sentActivities = new List<IActivity>();
             var mockConnectorClient = new Mock<IConnectorClient>();
             mockConnectorClient.Setup(c => c.Conversations.ReplyToActivityAsync(It.IsAny<Activity>(), It.IsAny<CancellationToken>()))
-                .Callback<IActivity, CancellationToken>((response, ct) =>
-                {
-                    turnStarted.Set();
-                    sentActivities.Add(response);
-                })
-                .Returns(Task.FromResult(
-                    new ResourceResponse("replyResourceId")
-                ));
+                .Callback<IActivity, CancellationToken>((response, _) => { turnStarted.Set(); sentActivities.Add(response); })
+                .Returns(Task.FromResult(new ResourceResponse("replyResourceId")));
             mockConnectorClient.Setup(c => c.Conversations.SendToConversationAsync(It.IsAny<Activity>(), It.IsAny<CancellationToken>()))
-                .Callback<IActivity, CancellationToken>((response, ct) =>
-                {
-                    turnStarted.Set();
-                    sentActivities.Add(response);
-                })
-                .Returns(Task.FromResult(
-                        new ResourceResponse("sendResourceId")
-                    ));
-
+                .Callback<IActivity, CancellationToken>((response, _) => { turnStarted.Set(); sentActivities.Add(response); })
+                .Returns(Task.FromResult(new ResourceResponse("sendResourceId")));
             record.Factory
                 .Setup(c => c.CreateConnectorClientAsync(It.IsAny<ITurnContext>(), It.IsAny<string>(), It.IsAny<IList<string>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(mockConnectorClient.Object));
 
-
-            // Test
             await record.Service.StartAsync(CancellationToken.None);
             await record.Adapter.ProcessAsync(context.Request, context.Response, record.Agent, CancellationToken.None);
 
-            turnStarted.WaitOne();
+            Assert.True(turnStarted.WaitOne(TimeSpan.FromSeconds(10)), "Background turn did not complete within timeout");
             await record.Service.StopAsync(CancellationToken.None);
 
             Assert.Equal(StatusCodes.Status202Accepted, context.Response.StatusCode);
-
             Assert.Single(sentActivities);
             Assert.Equal("Test exception", sentActivities[0].Text);
         }
@@ -399,33 +248,14 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
         {
             var record = UseRecord((record) => new RespondingActivityHandler());
             var convoId = Guid.NewGuid().ToString();
-            var activity = new Activity()
-            {
-                ChannelId = Channels.Test,
-                Type = ActivityTypes.Message,
-                Id = convoId,
-                DeliveryMode = DeliveryModes.ExpectReplies,
-                Conversation = new(id: convoId),
-                Text = convoId,
-                Recipient = new(id: "recipientId", role: RoleTypes.Agent),
-                From = new(id: "fromId", role: RoleTypes.User)
-            };
-
+            var activity = CreateMessageActivity(DeliveryModes.ExpectReplies, conversationId: convoId, text: convoId, activityId: convoId);
             var context = CreateHttpContext(activity);
 
-            // Test
             await record.Adapter.ProcessAsync(context.Request, context.Response, record.Agent, CancellationToken.None);
 
-            context.Response.Body.Seek(0, SeekOrigin.Begin);
-            var reader = new StreamReader(context.Response.Body);
-            var streamText = reader.ReadToEnd();
-
-            Assert.False(string.IsNullOrEmpty(streamText));
-            var expectedReplies = ProtocolJsonSerializer.ToObject<ExpectedReplies>(streamText);
-
+            var expectedReplies = ReadExpectedReplies(context);
             Assert.NotNull(expectedReplies);
             Assert.Equal(3, expectedReplies.Activities.Count);
-
             Assert.Equal($"Response {convoId}:{convoId}:0", expectedReplies.Activities[0].Text);
             Assert.Equal($"Response {convoId}:{convoId}:1", expectedReplies.Activities[1].Text);
             Assert.Equal($"Response {convoId}:{convoId}:2", expectedReplies.Activities[2].Text);
@@ -435,17 +265,7 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
         public async Task ProcessAsync_ShouldStreamResponses()
         {
             var record = UseRecord((record) => new RespondingActivityHandler());
-            var context = CreateHttpContext(new Activity()
-            {
-                Id = Guid.NewGuid().ToString(),
-                ChannelId = Channels.Test,
-                Type = ActivityTypes.Invoke,
-                Name = "invoke",
-                DeliveryMode = DeliveryModes.Stream,
-                Conversation = new(id: Guid.NewGuid().ToString()),
-                Recipient = new(id: "recipientId", role: RoleTypes.Agent),
-                From = new(id: "fromId", role: RoleTypes.User)
-            });
+            var context = CreateHttpContext(CreateInvokeActivity(DeliveryModes.Stream, activityId: Guid.NewGuid().ToString()));
 
             // Test
             await record.Adapter.ProcessAsync(context.Request, context.Response, record.Agent, CancellationToken.None);
@@ -502,14 +322,10 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
         [Fact]
         public async Task ProcessAsync_ExpectRepliesWithContinueConversation()
         {
-            // Arrange
+            var fromId = Guid.NewGuid().ToString();
             var record = UseRecord((record) =>
             {
-                var options = new TestApplicationOptions(record.Storage);
-                var agent = new TestApplication(options);
-
-                // This is the scenario where a new "inner" turn is needed, using the ConversationReference of the 
-                // incoming Activity.
+                var agent = new TestApplication(new TestApplicationOptions(record.Storage));
                 agent.OnActivity(ActivityTypes.Message, async (context, state, ct) =>
                 {
                     await context.SendActivityAsync($"Outer: {context.Activity.Text}", cancellationToken: ct);
@@ -523,68 +339,48 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
                         },
                         ct);
                 });
-
                 return agent;
             });
 
-            var activity = new Activity()
-            {
-                Type = ActivityTypes.Message,
-                DeliveryMode = DeliveryModes.ExpectReplies,
-                Conversation = new(id: Guid.NewGuid().ToString()),
-                Text = "user message",
-                ChannelId = Channels.Test,
-                From = new ChannelAccount(id: Guid.NewGuid().ToString(), role: RoleTypes.User),
-                Recipient = new(id: "recipientId", role: RoleTypes.Agent),
-                Id = "1"
-            };
+            var activity = CreateMessageActivity(DeliveryModes.ExpectReplies, text: "user message", activityId: "1", fromId: fromId);
             var context = CreateHttpContext(activity);
 
-            // Test
             await record.Adapter.ProcessAsync(context.Request, context.Response, record.Agent, CancellationToken.None);
 
             Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
 
-            context.Response.Body.Seek(0, SeekOrigin.Begin);
-            var reader = new StreamReader(context.Response.Body);
-            var streamText = reader.ReadToEnd();
-
-            var expectedReplies = ProtocolJsonSerializer.ToObject<ExpectedReplies>(streamText);
-
+            var expectedReplies = ReadExpectedReplies(context);
             Assert.NotNull(expectedReplies);
             Assert.Equal(2, expectedReplies.Activities.Count);
 
             Assert.Equal("Outer: user message", expectedReplies.Activities[0].Text);
             Assert.Equal(activity.Conversation.Id, expectedReplies.Activities[0].Conversation.Id);
-            Assert.Equal(activity.From.Id, expectedReplies.Activities[0].Recipient.Id);
+            Assert.Equal(fromId, expectedReplies.Activities[0].Recipient.Id);
             Assert.Equal("1", expectedReplies.Activities[0].ReplyToId);
 
-            // Inner turn has same conversation info as Incoming
+            // Inner turn has same conversation info as incoming
             Assert.Equal("Inner: user message", expectedReplies.Activities[1].Text);
             Assert.Equal(activity.Conversation.Id, expectedReplies.Activities[1].Conversation.Id);
-            Assert.Equal(activity.From.Id, expectedReplies.Activities[1].Recipient.Id);
+            Assert.Equal(fromId, expectedReplies.Activities[1].Recipient.Id);
             Assert.Equal("1", expectedReplies.Activities[1].ReplyToId);
         }
 
         [Fact]
         public async Task ProcessAsync_Proactive()
         {
-            // Arrange
             var proactiveReference = new ConversationReference()
             {
                 ServiceUrl = "https://madeup.com",
-                DeliveryMode = DeliveryModes.Normal,   // DeliverMode for proactive doesn't matter here.  Not used.
                 Conversation = new(id: Guid.NewGuid().ToString()),
                 ActivityId = Guid.NewGuid().ToString(),
                 User = new ChannelAccount(id: Guid.NewGuid().ToString(), role: RoleTypes.User),
                 Agent = new(id: "recipientId", role: RoleTypes.Agent),
             };
 
+            var fromId = Guid.NewGuid().ToString();
             var record = UseRecord((record) =>
             {
-                var options = new TestApplicationOptions(record.Storage);
-                var agent = new TestApplication(options);
-
+                var agent = new TestApplication(new TestApplicationOptions(record.Storage));
                 agent.OnActivity(ActivityTypes.Message, async (context, state, ct) =>
                 {
                     await context.SendActivityAsync($"Outer: {context.Activity.Text}", cancellationToken: ct);
@@ -597,58 +393,29 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
                         },
                         ct);
                 });
-
                 return agent;
             });
 
-            // Capture Connector ReplyToActivity.  Proactive is always via Connector
+            // Capture Connector calls. Proactive is always via Connector; outer (ExpectReplies) response is not.
             var proactiveActivities = new List<IActivity>();
-            var mockConnectorClient = new Mock<IConnectorClient>();
-            mockConnectorClient.Setup(c => c.Conversations.ReplyToActivityAsync(It.IsAny<Activity>(), It.IsAny<CancellationToken>()))
-                .Callback<IActivity, CancellationToken>((response, ct) => proactiveActivities.Add(response))
-                .Returns(Task.FromResult(
-                    new ResourceResponse("replyResourceId")
-                ));
+            SetupConnectorClient(record, proactiveActivities);
 
-            record.Factory
-                .Setup(c => c.CreateConnectorClientAsync(It.IsAny<ITurnContext>(), It.IsAny<string>(), It.IsAny<IList<string>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(mockConnectorClient.Object));
-
-            // Using ExpectReplies, but it doesn't matter.  Do this to help separate responses to make Asserts easier
-            var activity = new Activity()
-            {
-                Type = ActivityTypes.Message,
-                DeliveryMode = DeliveryModes.ExpectReplies,
-                Conversation = new(id: Guid.NewGuid().ToString()),
-                Text = "user message",
-                ChannelId = Channels.Test,
-                From = new ChannelAccount(id: Guid.NewGuid().ToString(), role: RoleTypes.User),
-                Recipient = new(id: "recipientId", role: RoleTypes.Agent),
-                Id = "1"
-            };
+            // ExpectReplies outer delivery isolates the outer response from the proactive one for easier assertions
+            var activity = CreateMessageActivity(DeliveryModes.ExpectReplies, text: "user message", activityId: "1", fromId: fromId);
             var context = CreateHttpContext(activity);
 
-            // Test
             await record.Adapter.ProcessAsync(context.Request, context.Response, record.Agent, CancellationToken.None);
 
             Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
 
-            context.Response.Body.Seek(0, SeekOrigin.Begin);
-            var reader = new StreamReader(context.Response.Body);
-            var streamText = reader.ReadToEnd();
-
-            var expectedReplies = ProtocolJsonSerializer.ToObject<ExpectedReplies>(streamText);
-
+            var expectedReplies = ReadExpectedReplies(context);
             Assert.NotNull(expectedReplies);
             Assert.Single(expectedReplies.Activities);
-
-            // Assert initial response was via ExpectReplies
             Assert.Equal("Outer: user message", expectedReplies.Activities[0].Text);
             Assert.Equal(activity.Conversation.Id, expectedReplies.Activities[0].Conversation.Id);
-            Assert.Equal(activity.From.Id, expectedReplies.Activities[0].Recipient.Id);
+            Assert.Equal(fromId, expectedReplies.Activities[0].Recipient.Id);
             Assert.Equal("1", expectedReplies.Activities[0].ReplyToId);
 
-            // Assert the proactive response was through Connector and to correct conversation
             Assert.Single(proactiveActivities);
             Assert.Equal("Proactive: user message", proactiveActivities[0].Text);
             Assert.Equal(proactiveReference.Conversation.Id, proactiveActivities[0].Conversation.Id);
@@ -659,16 +426,14 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
         [Fact]
         public async Task ProcessAsync_CreateConversationNormalDelivery()
         {
-            // Arrange
             var turnDone = new EventWaitHandle(false, EventResetMode.AutoReset);
             var origConversationId = Guid.NewGuid().ToString();
             var newConversationId = Guid.NewGuid().ToString();
-            var serviceUrl = "https://service.com";
+            const string serviceUrl = "https://service.com";
+
             var record = UseRecord((record) =>
             {
-                var options = new TestApplicationOptions(record.Storage);
-                var agent = new TestApplication(options);
-
+                var agent = new TestApplication(new TestApplicationOptions(record.Storage));
                 agent.OnActivity(ActivityTypes.Message, async (context, state, ct) =>
                 {
                     await context.SendActivityAsync($"Original Conversation: {context.Activity.Text}", cancellationToken: ct);
@@ -683,63 +448,27 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
                             Assert.Equal("appid", innerContext.Activity.Recipient.Id);
                             Assert.Equal("userid", innerContext.Activity.From.Id);
 
-                            // TurnState isn't provided in the continuation lambda.  Lets test it manually.
+                            // TurnState isn't provided in the continuation lambda - load it manually
                             var turnState = agent.Options.TurnStateFactory();
                             await turnState.LoadStateAsync(innerContext, cancellationToken: innerCt);
-
                             turnState.Conversation.SetValue("lastConvoMessage", context.Activity.Text);
                             turnState.User.SetValue("lastConvoMessage", context.Activity.Text);
                             await innerContext.SendActivityAsync($"New Conversation: {context.Activity.Text}", cancellationToken: innerCt);
-
                             await turnState.SaveStateAsync(innerContext, cancellationToken: innerCt);
                         },
                         ct);
                     turnDone.Set();
                 });
-
                 return agent;
             });
 
-            // Capture Connector ReplyToActivity.  Proactive is always via Connector
             var responses = new List<IActivity>();
-            var mockConnectorClient = new Mock<IConnectorClient>();
-            mockConnectorClient.Setup(c => c.Conversations.ReplyToActivityAsync(It.IsAny<Activity>(), It.IsAny<CancellationToken>()))
-                .Callback<IActivity, CancellationToken>((response, ct) => responses.Add(response))
-                .Returns(Task.FromResult(
-                    new ResourceResponse("replyResourceId")
-                ));
-            mockConnectorClient.Setup(c => c.Conversations.SendToConversationAsync(It.IsAny<Activity>(), It.IsAny<CancellationToken>()))
-                .Callback<IActivity, CancellationToken>((response, ct) => responses.Add(response))
-                .Returns(Task.FromResult(
-                    new ResourceResponse("sendResourceId")
-                ));
-            mockConnectorClient
-                .Setup(c => c.Conversations.CreateConversationAsync(It.IsAny<ConversationParameters>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(
-                    new ConversationResourceResponse() { Id = newConversationId }
-                ));
+            SetupConnectorClient(record, responses, newConversationId);
 
-            record.Factory
-                .Setup(c => c.CreateConnectorClientAsync(It.IsAny<ITurnContext>(), It.IsAny<string>(), It.IsAny<IList<string>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(mockConnectorClient.Object));
-
-            var activity = new Activity()
-            {
-                Type = ActivityTypes.Message,
-                DeliveryMode = DeliveryModes.Normal,
-                ServiceUrl = serviceUrl,
-                Conversation = new(id: origConversationId),
-                Text = "user message",
-                ChannelId = Channels.Test,
-                From = new ChannelAccount(id: "userid", role: RoleTypes.User),
-                Recipient = new(id: "appid", role: RoleTypes.Agent),
-                Id = "1"
-            };
+            var activity = CreateMessageActivity(DeliveryModes.Normal, conversationId: origConversationId, text: "user message", activityId: "1", fromId: "userid", serviceUrl: serviceUrl);
             var context = CreateHttpContext(activity);
 
-            // Test
             await record.Service.StartAsync(CancellationToken.None);
-
             await Task.Run(async () =>
             {
                 await record.Adapter.ProcessAsync(context.Request, context.Response, record.Agent, CancellationToken.None);
@@ -747,27 +476,20 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
                 Assert.Equal(0, context.Response.Body.Length);
             });
 
-            // Wait for turn done since we don't really know this with Normal delivery.
-            turnDone.WaitOne();
+            Assert.True(turnDone.WaitOne(TimeSpan.FromSeconds(10)), "Turn did not complete within timeout");
 
             Assert.Equal(2, responses.Count);
-
             Assert.Equal("Original Conversation: user message", responses[0].Text);
             Assert.Equal(origConversationId, responses[0].Conversation.Id);
             Assert.Equal("1", responses[0].ReplyToId);
-
             Assert.Equal("New Conversation: user message", responses[1].Text);
             Assert.Equal(newConversationId, responses[1].Conversation.Id);
             Assert.Null(responses[1].ReplyToId);
 
-            // Just read directly from conversation state
             var items = await record.Storage.ReadAsync<IDictionary<string, object>>([$"{responses[1].ChannelId}/conversations/{responses[1].Conversation.Id}"]);
-            var newConvoState = items.First().Value;
-            Assert.True(newConvoState.ContainsKey("lastConvoMessage"));
-            
+            Assert.True(items.First().Value.ContainsKey("lastConvoMessage"));
             items = await record.Storage.ReadAsync<IDictionary<string, object>>([$"{responses[1].ChannelId}/users/{responses[1].Recipient.Id}"]);
-            var newUserState = items.First().Value;
-            Assert.True(newUserState.ContainsKey("lastConvoMessage"));
+            Assert.True(items.First().Value.ContainsKey("lastConvoMessage"));
 
             await record.Service.StopAsync(CancellationToken.None);
         }
@@ -775,16 +497,14 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
         [Fact]
         public async Task ProcessAsync_ContinueConversationNormalDelivery()
         {
-            // Arrange
             var turnDone = new EventWaitHandle(false, EventResetMode.AutoReset);
             var initialConversationId = Guid.NewGuid().ToString();
             var proactiveConversationId = Guid.NewGuid().ToString();
-            var serviceUrl = "https://service.com";
+            const string serviceUrl = "https://service.com";
 
             var proactiveReference = new ConversationReference()
             {
                 ServiceUrl = serviceUrl,
-                DeliveryMode = DeliveryModes.Normal,   // DeliverMode for proactive doesn't matter here.  Not used.
                 Conversation = new(id: proactiveConversationId),
                 ActivityId = Guid.NewGuid().ToString(),
                 User = new ChannelAccount(id: Guid.NewGuid().ToString(), role: RoleTypes.User),
@@ -794,9 +514,7 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
 
             var record = UseRecord((record) =>
             {
-                var options = new TestApplicationOptions(record.Storage);
-                var agent = new TestApplication(options);
-
+                var agent = new TestApplication(new TestApplicationOptions(record.Storage));
                 agent.OnActivity(ActivityTypes.Message, async (context, state, ct) =>
                 {
                     await context.SendActivityAsync($"Original Conversation: {context.Activity.Text}", cancellationToken: ct);
@@ -805,57 +523,36 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
                         proactiveReference,
                         async (innerContext, innerCt) =>
                         {
-                            // TurnState isn't provided in the continuation lambda.  Lets test it manually.
+                            // TurnState isn't provided in the continuation lambda - load it manually
                             var turnState = agent.Options.TurnStateFactory();
                             await turnState.LoadStateAsync(innerContext, cancellationToken: innerCt);
-
                             turnState.Conversation.SetValue("lastConvoMessage", context.Activity.Text);
                             await innerContext.SendActivityAsync($"Proactive Conversation: {context.Activity.Text}", cancellationToken: innerCt);
-
                             await turnState.SaveStateAsync(innerContext, cancellationToken: innerCt);
                         },
                         ct);
                     turnDone.Set();
                 });
-
                 return agent;
             });
 
-            // Capture Connector ReplyToActivity.  Proactive is always via Connector
+            // Proactive replies use ReplyToActivity (has replyToId); SendToConversation should never be called
             var responses = new List<IActivity>();
             var mockConnectorClient = new Mock<IConnectorClient>();
             mockConnectorClient.Setup(c => c.Conversations.ReplyToActivityAsync(It.IsAny<Activity>(), It.IsAny<CancellationToken>()))
-                .Callback<IActivity, CancellationToken>((response, ct) => responses.Add(response))
-                .Returns(Task.FromResult(
-                    new ResourceResponse("replyResourceId")
-                ));
+                .Callback<IActivity, CancellationToken>((response, _) => responses.Add(response))
+                .Returns(Task.FromResult(new ResourceResponse("replyResourceId")));
             mockConnectorClient.Setup(c => c.Conversations.SendToConversationAsync(It.IsAny<Activity>(), It.IsAny<CancellationToken>()))
-                .Callback<IActivity, CancellationToken>((response, ct) => Assert.Fail())
-                .Returns(Task.FromResult(
-                    new ResourceResponse("sendResourceId")
-                ));
-
+                .Callback<IActivity, CancellationToken>((_, _) => Assert.Fail("SendToConversation should not be called; all replies have a replyToId"))
+                .Returns(Task.FromResult(new ResourceResponse("sendResourceId")));
             record.Factory
                 .Setup(c => c.CreateConnectorClientAsync(It.IsAny<ITurnContext>(), It.IsAny<string>(), It.IsAny<IList<string>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(mockConnectorClient.Object));
 
-            var activity = new Activity()
-            {
-                Type = ActivityTypes.Message,
-                DeliveryMode = DeliveryModes.Normal,
-                ServiceUrl = serviceUrl,
-                Conversation = new(id: initialConversationId),
-                Text = "user message",
-                ChannelId = Channels.Test,
-                From = new ChannelAccount(id: Guid.NewGuid().ToString(), role: RoleTypes.User),
-                Recipient = new(id: "recipientId", role: RoleTypes.Agent),
-                Id = "1"
-            };
+            var activity = CreateMessageActivity(DeliveryModes.Normal, conversationId: initialConversationId, text: "user message", activityId: "1", serviceUrl: serviceUrl);
             var context = CreateHttpContext(activity);
 
-            // Test
             await record.Service.StartAsync(CancellationToken.None);
-
             await Task.Run(async () =>
             {
                 await record.Adapter.ProcessAsync(context.Request, context.Response, record.Agent, CancellationToken.None);
@@ -863,23 +560,18 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
                 Assert.Equal(0, context.Response.Body.Length);
             });
 
-            // Wait for turn done since we don't really know this with Normal delivery.
-            turnDone.WaitOne();
+            Assert.True(turnDone.WaitOne(TimeSpan.FromSeconds(10)), "Turn did not complete within timeout");
 
             Assert.Equal(2, responses.Count);
-
             Assert.Equal("Original Conversation: user message", responses[0].Text);
             Assert.Equal(initialConversationId, responses[0].Conversation.Id);
             Assert.Equal("1", responses[0].ReplyToId);
-
             Assert.Equal("Proactive Conversation: user message", responses[1].Text);
             Assert.Equal(proactiveConversationId, responses[1].Conversation.Id);
             Assert.Equal(proactiveReference.ActivityId, responses[1].ReplyToId);
 
-            // Just read directly from conversation state
             var items = await record.Storage.ReadAsync<IDictionary<string, object>>([$"{responses[1].ChannelId}/conversations/{responses[1].Conversation.Id}"]);
-            var newConvoState = items.First().Value;
-            Assert.True(newConvoState.ContainsKey("lastConvoMessage"));
+            Assert.True(items.First().Value.ContainsKey("lastConvoMessage"));
 
             await record.Service.StopAsync(CancellationToken.None);
         }
@@ -887,31 +579,20 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
         [Fact]
         public async Task ProcessAsync_OAuthExpectReplies()
         {
-            // Arrange
             int attempt = 0;
-            var MockGraph = new Mock<IUserAuthorization>();
-            MockGraph
+            var mockGraph = new Mock<IUserAuthorization>();
+            mockGraph
                 .Setup(e => e.SignInUserAsync(It.IsAny<ITurnContext>(), It.IsAny<bool>(), It.IsAny<string>(), It.IsAny<IList<string>>(), It.IsAny<CancellationToken>()))
-                .Returns(() =>
-                {
-                    if (attempt++ == 0)
-                    {
-                        return Task.FromResult((TokenResponse)null);
-                    }
-                    return Task.FromResult(new TokenResponse() { Token = "GraphToken", Expiration = DateTime.UtcNow + TimeSpan.FromMinutes(30) });
-                });
-            MockGraph
-                .Setup(e => e.Name)
-                .Returns("graph");
+                .Returns(() => attempt++ == 0
+                    ? Task.FromResult((TokenResponse)null)
+                    : Task.FromResult(new TokenResponse() { Token = "GraphToken", Expiration = DateTime.UtcNow + TimeSpan.FromMinutes(30) }));
+            mockGraph.Setup(e => e.Name).Returns("graph");
 
-            var MockConnections = new Mock<IConnections>();
-
-            // Setup AgentApplication
             var record = UseRecord((record) =>
             {
                 var options = new TestApplicationOptions(record.Storage)
                 {
-                    UserAuthorization = new UserAuthorizationOptions(NullLoggerFactory.Instance, record.Storage, MockConnections.Object, MockGraph.Object) { AutoSignIn = UserAuthorizationOptions.AutoSignInOff }
+                    UserAuthorization = new UserAuthorizationOptions(NullLoggerFactory.Instance, record.Storage, new Mock<IConnections>().Object, mockGraph.Object) { AutoSignIn = UserAuthorizationOptions.AutoSignInOff }
                 };
                 var agent = new TestApplication(options);
                 agent.OnMessage("-signin", async (context, state, ct) =>
@@ -920,70 +601,38 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
                     Assert.Equal("GraphToken", token);
                     await context.SendActivityAsync(token, cancellationToken: ct);
                 }, autoSignInHandlers: ["graph"]);
-
                 return agent;
             });
 
-            // Test
             await record.Service.StartAsync(CancellationToken.None);
 
-            // start signin
-            var activity = new Activity()
-            {
-                Type = ActivityTypes.Message,
-                DeliveryMode = DeliveryModes.ExpectReplies,
-                Conversation = new(id: Guid.NewGuid().ToString()),
-                Text = "-signin",
-                ChannelId = Channels.Test,
-                From = new ChannelAccount(id: Guid.NewGuid().ToString(), role: RoleTypes.User),
-                Recipient = new(id: "recipientId", role: RoleTypes.Agent),
-                Id = "1"
-            };
+            // First request: start sign-in (returns empty ExpectedReplies while waiting for code)
+            var fromId = Guid.NewGuid().ToString();
+            var activity = CreateMessageActivity(DeliveryModes.ExpectReplies, text: "-signin", activityId: "1", fromId: fromId);
             var context = CreateHttpContext(activity);
 
             await record.Adapter.ProcessAsync(context.Request, context.Response, record.Agent, CancellationToken.None);
 
             Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
-
-            // get ExpectedReplies
-            context.Response.Body.Seek(0, SeekOrigin.Begin);
-            var reader = new StreamReader(context.Response.Body);
-            var streamText = reader.ReadToEnd();
-            var expectedReplies = ProtocolJsonSerializer.ToObject<ExpectedReplies>(streamText);
+            var expectedReplies = ReadExpectedReplies(context);
             Assert.NotNull(expectedReplies);
             Assert.Empty(expectedReplies.Activities);
 
-
-            // send code
-            activity = new Activity()
-            {
-                Type = ActivityTypes.Message,
-                DeliveryMode = DeliveryModes.ExpectReplies,
-                Conversation = new(id: activity.Conversation.Id),
-                Text = "123456",
-                ChannelId = Channels.Test,
-                From = new ChannelAccount(id: activity.From.Id, role: RoleTypes.User),
-                Recipient = new(id: "recipientId", role: RoleTypes.Agent),
-                Id = "2"
-            };
-            context = CreateHttpContext(activity);
+            // Second request: submit auth code (response should include the token)
+            var activity2 = CreateMessageActivity(DeliveryModes.ExpectReplies, conversationId: activity.Conversation.Id, text: "123456", activityId: "2", fromId: fromId);
+            context = CreateHttpContext(activity2);
 
             await record.Adapter.ProcessAsync(context.Request, context.Response, record.Agent, CancellationToken.None);
 
             Assert.Equal(StatusCodes.Status200OK, context.Response.StatusCode);
-
-            // get ExpectedReplies, should have received the token in a response
-            context.Response.Body.Seek(0, SeekOrigin.Begin);
-            reader = new StreamReader(context.Response.Body);
-            streamText = reader.ReadToEnd();
-            expectedReplies = ProtocolJsonSerializer.ToObject<ExpectedReplies>(streamText);
+            expectedReplies = ReadExpectedReplies(context);
             Assert.NotNull(expectedReplies);
             Assert.NotEmpty(expectedReplies.Activities);
 
-            // Assert the response was to the initial message (the "-signin" message)
+            // Response is to the original "-signin" message (replyToId = "1")
             Assert.Equal("GraphToken", expectedReplies.Activities[0].Text);
             Assert.Equal(activity.Conversation.Id, expectedReplies.Activities[0].Conversation.Id);
-            Assert.Equal(activity.From.Id, expectedReplies.Activities[0].Recipient.Id);
+            Assert.Equal(fromId, expectedReplies.Activities[0].Recipient.Id);
             Assert.Equal("1", expectedReplies.Activities[0].ReplyToId);
         }
 
@@ -1034,36 +683,113 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
         [Fact]
         public async Task ProcessAsync_CancellationDuringStream_ShouldNotThrow()
         {
-            // Arrange: use an agent that delays long enough to be cancelled
             var agentStarted = new TaskCompletionSource<bool>();
             var record = UseRecord((_) => new DelayedActivityHandler(agentStarted));
-
-            var activity = new Activity()
-            {
-                ChannelId = Channels.Test,
-                Type = ActivityTypes.Invoke,
-                Name = "invoke",
-                DeliveryMode = DeliveryModes.Stream,
-                Conversation = new(id: Guid.NewGuid().ToString()),
-                Recipient = new(id: "recipientId", role: RoleTypes.Agent),
-                From = new(id: "fromId", role: RoleTypes.User)
-            };
-            var context = CreateHttpContext(activity);
+            var context = CreateHttpContext(CreateInvokeActivity(DeliveryModes.Stream));
 
             using var cts = new CancellationTokenSource();
 
-            // Act: start processing, wait for the agent to begin, then cancel
             await record.Adapter.ProcessAsync(context.Request, context.Response, record.Agent, cts.Token);
-
-            // Wait until the agent handler has started processing
             await agentStarted.Task;
-
-            // Cancel the request (simulates client disconnect)
             cts.Cancel();
 
             Assert.NotEqual(StatusCodes.Status500InternalServerError, context.Response.StatusCode);
         }
 
+        [Fact]
+        public async Task ProcessAsync_ShouldTreatNullDeliveryModeAsNormal()
+        {
+            // Null DeliveryMode should be treated the same as Normal: queued for background processing, returns 202
+            var record = UseRecord((record) => new RespondingActivityHandler());
+            var activity = CreateMessageActivity(deliveryMode: null);
+            var context = CreateHttpContext(activity);
+            SetupConnectorClient(record);
+
+            await record.Service.StartAsync(CancellationToken.None);
+            await record.Adapter.ProcessAsync(context.Request, context.Response, record.Agent, CancellationToken.None);
+            await record.Service.StopAsync(CancellationToken.None);
+
+            Assert.Equal(StatusCodes.Status202Accepted, context.Response.StatusCode);
+        }
+
+        private static Activity CreateMessageActivity(
+            string deliveryMode = DeliveryModes.Normal,
+            string conversationId = null,
+            string text = null,
+            string activityId = null,
+            string fromId = "userId",
+            string serviceUrl = null)
+        {
+            var activity = new Activity
+            {
+                ChannelId = Channels.Test,
+                Type = ActivityTypes.Message,
+                DeliveryMode = deliveryMode,
+                Conversation = new(id: conversationId ?? Guid.NewGuid().ToString()),
+                Recipient = new(id: "recipientId", role: RoleTypes.Agent),
+                From = new(id: fromId, role: RoleTypes.User)
+            };
+            if (activityId != null) activity.Id = activityId;
+            if (text != null) activity.Text = text;
+            if (serviceUrl != null) activity.ServiceUrl = serviceUrl;
+            return activity;
+        }
+
+        private static Activity CreateInvokeActivity(
+            string deliveryMode = DeliveryModes.ExpectReplies,
+            string conversationId = null,
+            string activityId = null)
+        {
+            var activity = new Activity
+            {
+                ChannelId = Channels.Test,
+                Type = ActivityTypes.Invoke,
+                Name = "invoke",
+                DeliveryMode = deliveryMode,
+                Conversation = new(id: conversationId ?? Guid.NewGuid().ToString()),
+                Recipient = new(id: "recipientId", role: RoleTypes.Agent),
+                From = new(id: "fromId", role: RoleTypes.User)
+            };
+            if (activityId != null) activity.Id = activityId;
+            return activity;
+        }
+
+        private static ExpectedReplies ReadExpectedReplies(DefaultHttpContext context)
+        {
+            context.Response.Body.Seek(0, SeekOrigin.Begin);
+            return ProtocolJsonSerializer.ToObject<ExpectedReplies>(new StreamReader(context.Response.Body).ReadToEnd());
+        }
+
+        /// <summary>
+        /// Sets up a mock IConnectorClient on the factory that optionally captures sent activities.
+        /// </summary>
+        private static Mock<IConnectorClient> SetupConnectorClient(
+            Record record,
+            List<IActivity> captured = null,
+            string newConversationId = null)
+        {
+            var mock = new Mock<IConnectorClient>();
+
+            mock.Setup(c => c.Conversations.ReplyToActivityAsync(It.IsAny<Activity>(), It.IsAny<CancellationToken>()))
+                .Callback<IActivity, CancellationToken>((a, _) => captured?.Add(a))
+                .Returns(Task.FromResult(new ResourceResponse("replyResourceId")));
+
+            mock.Setup(c => c.Conversations.SendToConversationAsync(It.IsAny<Activity>(), It.IsAny<CancellationToken>()))
+                .Callback<IActivity, CancellationToken>((a, _) => captured?.Add(a))
+                .Returns(Task.FromResult(new ResourceResponse("sendResourceId")));
+
+            if (newConversationId != null)
+            {
+                mock.Setup(c => c.Conversations.CreateConversationAsync(It.IsAny<ConversationParameters>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult(new ConversationResourceResponse { Id = newConversationId }));
+            }
+
+            record.Factory
+                .Setup(c => c.CreateConnectorClientAsync(It.IsAny<ITurnContext>(), It.IsAny<string>(), It.IsAny<IList<string>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(mock.Object));
+
+            return mock;
+        }
 
         private static DefaultHttpContext CreateHttpContext(Activity activity = null)
         {
@@ -1079,15 +805,15 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
         private static Record UseRecord(Func<Record, IAgent> createAgent, Builder.IMiddleware[] middleware = null)
         {
             var factory = new Mock<IChannelServiceClientFactory>();
-            var adatperLogger = new Mock<ILogger<CloudAdapter>>();
+            var adapterLogger = new Mock<ILogger<CloudAdapter>>();
             var serviceLogger = new Mock<ILogger<HostedActivityService>>();
 
             var sp = new Mock<IServiceProvider>();
             var queue = new ActivityTaskQueue();
-            var adapter = new CloudAdapter(factory.Object, queue, adatperLogger.Object, middlewares: middleware);
+            var adapter = new CloudAdapter(factory.Object, queue, adapterLogger.Object, middlewares: middleware);
             var service = new HostedActivityService(sp.Object, new ConfigurationBuilder().Build(), queue, serviceLogger.Object);
 
-            var record = new Record(null, adapter, factory, service, queue, adatperLogger, serviceLogger);
+            var record = new Record(null, adapter, factory, service, queue, adapterLogger, serviceLogger);
 
             if (createAgent != null)
             {
@@ -1105,12 +831,12 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
             Mock<IChannelServiceClientFactory> Factory,
             HostedActivityService Service,
             IActivityTaskQueue Queue,
-            Mock<ILogger<CloudAdapter>> QueueLogger,
+            Mock<ILogger<CloudAdapter>> AdapterLogger,
             Mock<ILogger<HostedActivityService>> HostedServiceLogger)
         {
             public void VerifyMocks()
             {
-                Mock.Verify(Factory, QueueLogger, HostedServiceLogger);
+                Mock.Verify(Factory, AdapterLogger, HostedServiceLogger);
             }
 
             public IStorage Storage { get; } = new MemoryStorage();
@@ -1156,8 +882,6 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
 
         private class RespondingActivityHandler : ActivityHandler
         {
-            private readonly Random random = new Random();
-
             protected override async Task OnMessageActivityAsync(ITurnContext<IMessageActivity> turnContext, CancellationToken cancellationToken)
             {
                 if (turnContext.Activity.Text == "throw")
@@ -1167,8 +891,7 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
 
                 for (var i = 0; i < 3; i++)
                 {
-                    var delay = 200 + random.Next(-101, 401);
-                    await Task.Delay(delay, cancellationToken);
+                    await Task.Delay(50, cancellationToken);
 
                     var message = $"Response {turnContext.Activity.Conversation.Id}:{turnContext.Activity.Id}:{i}";
                     await turnContext.SendActivityAsync(message, cancellationToken: cancellationToken);


### PR DESCRIPTION
## Overview

Bug fixes and async/pipeline correctness improvements across the adapter, hosting, and turn context layers. No public API additions; one minor behavioral change and **one public signature change** (low risk, see below).

---

## Changes

### Bug Fixes

**`ChannelServiceAdapterBase` — audience not passed to `CreateConnectorClientAsync`**
- `audience` was missing from the `CreateConnectorClientAsync` call in `ProcessProactiveAsync`. This meant connector clients created for proactive messages could use the wrong audience, breaking auth in some scenarios.

**`ChannelAdapter.ContinueConversationAsync` — incorrect audience forwarded**
- Was passing `claimsIdentity.GetOutgoingAudience()` to `ProcessProactiveAsync`. Changed to `null` so the audience is derived correctly downstream rather than being double-set.

**`ChannelResponseQueue` — race condition on `readStarted`**
- `CompleteHandlerForRequest` waited for a `readStarted` event before completing the channel writer, but if `HandleResponsesAsync` hadn't started yet, the write could complete before any reads occurred, silently dropping activities.
- Fixed by removing `readStarted` entirely. `CompleteHandlerForRequest` now completes the channel writer and then waits for the reader to drain (`readDone`), which is the correct ordering.
- `EventWaitHandle` (blocking) replaced with `SemaphoreSlim` for `readDone` to enable async waiting.

**`HostedActivityService` — lock/try-finally ordering**
- `try/finally` wrapped the lock attempt instead of the lock body, meaning `ExitReadLock` could be called even when the lock was never acquired. Restructured so `finally` only runs inside the successful lock path.

**`HostedActivityService` — task cleanup used O(n) scan**
- Post-task cleanup iterated all in-flight tasks looking for completed ones. Changed to a targeted `TryRemove` on the specific `activityWithClaims` key after its task completes.

**`HostedActivityService` — task continuation could be cancelled**
- `ContinueWith` was passed `stoppingToken`, meaning cleanup could be skipped if the host was shutting down. Changed to `CancellationToken.None` so cleanup always runs.

**`ActivityTaskQueue._stopped` — missing `volatile`**
- `_stopped` flag accessed from multiple threads without `volatile`, risking stale reads.

### API / Behavioral Changes

**`ChannelResponseQueue.HandleResponsesAsync` — action changed to `Func<IActivity, Task>`** *(breaking for direct callers)*
- Was `Action<IActivity>`, now `Func<IActivity, Task>`. Allows async activity handling without fire-and-forget.

**`ChannelResponseQueue` — removed `ReadAllResponsesAsync`**
- Unused method removed. Only affects callers who referenced it directly (internal use only).

**`ChannelResponseQueue` — added `CompleteHandlerForRequestAsync`**
- Async counterpart to `CompleteHandlerForRequest`. `A2AAdapter` now uses this to avoid blocking a thread pool thread during shutdown signaling.

### Performance / Correctness (async state machine elimination)

Unnecessary `async`/`await` wrapping removed from several hot-path methods. Each was a single-await method that allocated a state machine with no benefit:

- `TurnContext.SendActivityAsync(string, ...)`
- `TurnContext.UpdateActivityAsync`
- `TurnContext.DeleteActivityAsync` (both overloads)
- `TurnContext.TraceActivityAsync`
- `ChannelServiceAdapterBase.UpdateActivityAsync`
- `ChannelServiceAdapterBase.DeleteActivityAsync`
- `MiddlewareSet.ReceiveActivityWithStatusAsync`

Inline local `async Task` lambdas in `TurnContext` also replaced with direct lambda expressions.

### Minor Fixes

**`HttpHelper` — deserialization no longer buffers request body**
- Replaced `MemoryStream` copy + `ProtocolJsonSerializer.ToObject<T>(stream)` with direct `JsonSerializer.DeserializeAsync` on the request body. Reduces one allocation and one copy per request.

**`HttpHelper` — response content-type corrected**
- Changed `application/json` to `application/json; charset=utf-8` and response body write to use UTF-8 encoding (was ASCII).

---

## Breaking Changes

| Change | Scope | Impact |
|--------|-------|--------|
| `ChannelResponseQueue.HandleResponsesAsync` action parameter: `Action<IActivity>` → `Func<IActivity, Task>` | Public class, but internal usage only | Low risk, but needed. Any external code calling `HandleResponsesAsync` directly must update the delegate type |
| `ReadAllResponsesAsync` removed from `ChannelResponseQueue` | Public method | Low risk, but was problematic anyway. Any caller must remove usage |

Both affected types (`ChannelResponseQueue`) are public but not part of the primary public surface; typical agent authors won't reference them directly.

---

## Tests

- `CloudAdapterTests` expanded to cover `RestConnectorClient` via a mocked `HttpMessageHandler` (previously used a fake client).
- `ChannelServiceAdapterBaseTests` added (121 new lines).
- `TurnContextTests` expanded (+33 lines).
