### PR TITLE
Using Collection attribute for StorageScopeTests

### DIFF
--- a/src/tests/Microsoft.Agents.Storage.Tests/Telemetry/StorageScopeTests.cs
+++ b/src/tests/Microsoft.Agents.Storage.Tests/Telemetry/StorageScopeTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Microsoft.Agents.Storage.Tests.Telemetry
 {
-    [CollectionDefinition("TelemetryTests", DisableParallelization = true)]
+    [Collection("TelemetryTests")]
     public class StorageScopeTests : TelemetryScopeTestBase
     {
 


### PR DESCRIPTION
The code previously misused the CollectionDefinition attribute instead, causing occasional test failures due to lack of test isolation with telemetry listening.