### PR TITLE
Update OpenTelemetry packages and reformat props file

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,155 +1,156 @@
 <Project>
-  <!-- See: https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build?view=vs-2019#directorybuildprops-and-directorybuildtargets -->
-  <PropertyGroup>
-    <!-- Not enabled by default for the repo. -->
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <!-- To avoid NU1507 we must disable library packs from getting added by the SDK.
+    <!-- See: https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build?view=vs-2019#directorybuildprops-and-directorybuildtargets -->
+    <PropertyGroup>
+        <!-- Not enabled by default for the repo. -->
+        <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+        <!-- To avoid NU1507 we must disable library packs from getting added by the SDK.
     Error:
      The project E:\repos\msazure\One\PowerPlatform-ISVEx-ToolsCore\src\cli\Analyzers\bolt.Analyzers\bolt.Analyzers\bolt.Analyzers.csproj is using CentralPackageVersionManagement, a NuGet preview feature.
      E:\repos\msazure\One\PowerPlatform-ISVEx-ToolsCore\src\cli\Analyzers\bolt.Analyzers\bolt.Analyzers\bolt.Analyzers.csproj : warning NU1507: There are 2 package sources defined in your configuration. When using central package management, please map your package sources with package source mapping (https://aka.ms/nuget-package-source-mapping) or specify a single package source. The following sources are defined: https://pkgs.dev.azure.com/msazure/One/_packaging/CAP_ISVExp_Tools_Upstream/nuget/v3/index.json, C:\Program Files\dotnet\library-packs
      The 'library-packs' source is added by the SDK.
     -->
-    <DisableImplicitLibraryPacksFolder>true</DisableImplicitLibraryPacksFolder>
-  </PropertyGroup>
-  <PropertyGroup>
-    <Microsoft_Extentions_PkgVer>10.0.5</Microsoft_Extentions_PkgVer>
-	<Microsoft_Bcl_PkgVer>10.0.5</Microsoft_Bcl_PkgVer>
-	<Microsoft_System_PkgVer>10.0.5</Microsoft_System_PkgVer>
-    <Microsoft_AspNetCore_PkgVer>8.0.23</Microsoft_AspNetCore_PkgVer>
-	<Microsoft_IdentityModel_PkgVer>8.15.0</Microsoft_IdentityModel_PkgVer>
-	<Microsoft_IdentityClient_PkgVer>4.80.0</Microsoft_IdentityClient_PkgVer>
-	<OpenTelemetry_PkgVer>1.14.0</OpenTelemetry_PkgVer>
-	<Xunit_PackageVersion>2.9.3</Xunit_PackageVersion>
-	<Xunit_v3_PackageVersion>3.0.1</Xunit_v3_PackageVersion>  </PropertyGroup>
-  <ItemGroup>
-    <PackageVersion Include="Nerdbank.GitVersioning" Version="3.6.146" />
-	  
-    <PackageVersion Include="Microsoft.Identity.Client" Version="$(Microsoft_IdentityClient_PkgVer)" />
-    <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="$(Microsoft_IdentityClient_PkgVer)" />
-    <PackageVersion Include="Microsoft.IdentityModel.Abstractions" Version="$(Microsoft_IdentityModel_PkgVer)" />
-    <PackageVersion Include="Microsoft.IdentityModel.LoggingExtensions" Version="$(Microsoft_IdentityModel_PkgVer)" />
-    <PackageVersion Include="Microsoft.IdentityModel.Validators" Version="$(Microsoft_IdentityModel_PkgVer)" />
-    <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="$(Microsoft_IdentityModel_PkgVer)" />
-    <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="$(Microsoft_IdentityModel_PkgVer)" />
-    <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="$(Microsoft_IdentityModel_PkgVer)" />
-	<PackageVersion Include="Microsoft.Identity.Web.Certificateless" Version="4.3.0" />
+        <DisableImplicitLibraryPacksFolder>true</DisableImplicitLibraryPacksFolder>
+    </PropertyGroup>
+    <PropertyGroup>
+        <Microsoft_Extentions_PkgVer>10.0.5</Microsoft_Extentions_PkgVer>
+        <Microsoft_Bcl_PkgVer>10.0.5</Microsoft_Bcl_PkgVer>
+        <Microsoft_System_PkgVer>10.0.5</Microsoft_System_PkgVer>
+        <Microsoft_AspNetCore_PkgVer>8.0.23</Microsoft_AspNetCore_PkgVer>
+        <Microsoft_IdentityModel_PkgVer>8.15.0</Microsoft_IdentityModel_PkgVer>
+        <Microsoft_IdentityClient_PkgVer>4.80.0</Microsoft_IdentityClient_PkgVer>
+        <Xunit_PackageVersion>2.9.3</Xunit_PackageVersion>
+        <Xunit_v3_PackageVersion>3.0.1</Xunit_v3_PackageVersion>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageVersion Include="Nerdbank.GitVersioning" Version="3.6.146" />
 
-	<PackageVersion Include="Microsoft.Extensions.Logging.AzureAppServices" Version="$(Microsoft_Extentions_PkgVer)" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(Microsoft_Extentions_PkgVer)" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="$(Microsoft_Extentions_PkgVer)" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="$(Microsoft_Extentions_PkgVer)" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="$(Microsoft_Extentions_PkgVer)" />
-	<PackageVersion Include="Microsoft.Extensions.Configuration" Version="$(Microsoft_Extentions_PkgVer)" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="$(Microsoft_Extentions_PkgVer)" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="$(Microsoft_Extentions_PkgVer)" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="$(Microsoft_Extentions_PkgVer)" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(Microsoft_Extentions_PkgVer)" />
-	<PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="$(Microsoft_Extentions_PkgVer)" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="$(Microsoft_Extentions_PkgVer)" />
-	  
-	<PackageVersion Include="System.Text.Json" Version="$(Microsoft_System_PkgVer)" />
-    <PackageVersion Include="System.Memory.Data" Version="$(Microsoft_System_PkgVer)" />
-	<PackageVersion Include="System.Runtime.Caching" Version="$(Microsoft_System_PkgVer)" />
-	<PackageVersion Include="System.Configuration.ConfigurationManager" Version="$(Microsoft_System_PkgVer)" />
-    <PackageVersion Include="System.Net.ServerSentEvents" Version="$(Microsoft_System_PkgVer)" />
-	<PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
+        <PackageVersion Include="Microsoft.Identity.Client" Version="$(Microsoft_IdentityClient_PkgVer)" />
+        <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="$(Microsoft_IdentityClient_PkgVer)" />
+        <PackageVersion Include="Microsoft.IdentityModel.Abstractions" Version="$(Microsoft_IdentityModel_PkgVer)" />
+        <PackageVersion Include="Microsoft.IdentityModel.LoggingExtensions" Version="$(Microsoft_IdentityModel_PkgVer)" />
+        <PackageVersion Include="Microsoft.IdentityModel.Validators" Version="$(Microsoft_IdentityModel_PkgVer)" />
+        <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="$(Microsoft_IdentityModel_PkgVer)" />
+        <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="$(Microsoft_IdentityModel_PkgVer)" />
+        <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="$(Microsoft_IdentityModel_PkgVer)" />
+        <PackageVersion Include="Microsoft.Identity.Web.Certificateless" Version="4.3.0" />
 
-	  <!-- ASP.net Core support -->
-    <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="$(Microsoft_AspNetCore_PkgVer)" />
-	<PackageVersion Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="$(Microsoft_AspNetCore_PkgVer)" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(Microsoft_AspNetCore_PkgVer)" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="$(Microsoft_AspNetCore_PkgVer)" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Core" Version="$(Microsoft_AspNetCore_PkgVer)" />
-    <PackageVersion Include="Microsoft.AspNetCore.Http" Version="$(Microsoft_AspNetCore_PkgVer)" />
-    <!-- Test nuget packages -->
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="System.IO.Compression" Version="4.3.0" />
+        <PackageVersion Include="Microsoft.Extensions.Logging.AzureAppServices" Version="$(Microsoft_Extentions_PkgVer)" />
+        <PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(Microsoft_Extentions_PkgVer)" />
+        <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="$(Microsoft_Extentions_PkgVer)" />
+        <PackageVersion Include="Microsoft.Extensions.Logging" Version="$(Microsoft_Extentions_PkgVer)" />
+        <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="$(Microsoft_Extentions_PkgVer)" />
+        <PackageVersion Include="Microsoft.Extensions.Configuration" Version="$(Microsoft_Extentions_PkgVer)" />
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="$(Microsoft_Extentions_PkgVer)" />
+        <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="$(Microsoft_Extentions_PkgVer)" />
+        <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="$(Microsoft_Extentions_PkgVer)" />
+        <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(Microsoft_Extentions_PkgVer)" />
+        <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="$(Microsoft_Extentions_PkgVer)" />
+        <PackageVersion Include="Microsoft.Extensions.Http" Version="$(Microsoft_Extentions_PkgVer)" />
 
-    <PackageVersion Include="xunit"                                                                        Version="$(Xunit_PackageVersion)" />
-    <PackageVersion Include="xunit.abstractions"                                                           Version="2.0.3" />
-    <PackageVersion Include="xunit.assert"                                                                 Version="$(Xunit_PackageVersion)" />
-    <PackageVersion Include="xunit.assert.source"                                                          Version="$(Xunit_PackageVersion)" />
-    <PackageVersion Include="xunit.core"                                                                   Version="$(Xunit_PackageVersion)" />
-    <PackageVersion Include="xunit.extensibility.core"                                                     Version="$(Xunit_PackageVersion)" />
-    <PackageVersion Include="xunit.extensibility.execution"                                                Version="$(Xunit_PackageVersion)" />
-    <PackageVersion Include="xunit.runner.utility"                                                         Version="$(Xunit_PackageVersion)" />
-    <PackageVersion Include="xunit.runner.visualstudio"                                                    Version="2.8.2" />
+        <PackageVersion Include="System.Text.Json" Version="$(Microsoft_System_PkgVer)" />
+        <PackageVersion Include="System.Memory.Data" Version="$(Microsoft_System_PkgVer)" />
+        <PackageVersion Include="System.Runtime.Caching" Version="$(Microsoft_System_PkgVer)" />
+        <PackageVersion Include="System.Configuration.ConfigurationManager" Version="$(Microsoft_System_PkgVer)" />
+        <PackageVersion Include="System.Net.ServerSentEvents" Version="$(Microsoft_System_PkgVer)" />
+        <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
 
-    <PackageVersion Include="xunit.v3"                                                                     Version="$(Xunit_v3_PackageVersion)" />
-    <PackageVersion Include="xunit.v3.assert"                                                              Version="$(Xunit_v3_PackageVersion)" />  
-    <PackageVersion Include="xunit.v3.core"                                                                Version="$(Xunit_v3_PackageVersion)" />
-    <PackageVersion Include="xunit.v3.extensibility.core"                                                  Version="$(Xunit_v3_PackageVersion)" />      
+        <!-- ASP.net Core support -->
+        <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="$(Microsoft_AspNetCore_PkgVer)" />
+        <PackageVersion Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="$(Microsoft_AspNetCore_PkgVer)" />
+        <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="$(Microsoft_AspNetCore_PkgVer)" />
+        <PackageVersion Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="$(Microsoft_AspNetCore_PkgVer)" />
+        <PackageVersion Include="Microsoft.AspNetCore.Mvc.Core" Version="$(Microsoft_AspNetCore_PkgVer)" />
+        <PackageVersion Include="Microsoft.AspNetCore.Http" Version="$(Microsoft_AspNetCore_PkgVer)" />
+        <!-- Test nuget packages -->
+        <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+        <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+        <PackageVersion Include="Moq" Version="4.20.72" />
+        <PackageVersion Include="System.IO.Compression" Version="4.3.0" />
 
-    <!-- SDK Core -->
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="$(Microsoft_Bcl_PkgVer)" />
-	<PackageVersion Include="Microsoft.Bcl.Memory" Version="$(Microsoft_Bcl_PkgVer)" />
-	<PackageVersion Include="Azure.Identity" Version="1.17.1" />
-	<PackageVersion Include="Azure.Core" Version="1.50.0" />
-	<PackageVersion Include="Azure.Storage.Blobs" Version="12.26.0" />
-	<PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.56.0" />
-    <PackageVersion Include="Microsoft.Recognizers.Text.Choice" Version="1.3.2" />
-    <PackageVersion Include="Microsoft.Recognizers.Text.DateTime" Version="1.3.2" />
-    <PackageVersion Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.3.2" />
-	<PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4">
-		<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		<PrivateAssets>all</PrivateAssets>
-	</PackageVersion>
-	<PackageVersion Include="Microsoft.CodeAnalysis.CSharp"             Version="4.5.0" />
-	<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces"  Version="4.5.0" />
-	<PackageVersion Include="Microsoft.CodeAnalysis.Common"             Version="4.5.0" />
-	<PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common"  Version="4.5.0" />
-	<PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.5.0" />
-	<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting"   Version="4.5.0" />
-	<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.2" />
-	<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing" Version="1.1.2" />
-	<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" Version="1.1.2" />
-	<PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.2" />
-	  
-	<!-- Samples -->
-    <PackageVersion Include="AdaptiveCards" Version="3.1.0" />
-    <PackageVersion Include="AdaptiveCards.Templating" Version="2.0.3" />
-    <PackageVersion Include="AdaptiveCards.Rendering.Html" Version="2.7.3" />
-	<PackageVersion Include="Microsoft.Graph" Version="5.99.0" />
-    <PackageVersion Include="Microsoft.Graph.Core" Version="3.2.5" />
-	<PackageVersion Include="CsvHelper" Version="33.0.1" />
-	<PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />  <!-- To override older version in AdaptiveCards -->
-    <!-- Semantic Kernel Samples -->
-    <PackageVersion Include="Microsoft.SemanticKernel.Agents.Core" Version="1.73.0" />
-    <PackageVersion Include="Microsoft.SemanticKernel.Agents.OpenAI" Version="1.73.0-preview" />
-	<PackageVersion Include="Microsoft.SemanticKernel.Agents.AzureAI" Version="1.73.0-preview" />
-    <PackageVersion Include="Microsoft.SemanticKernel.Connectors.AzureOpenAI" Version="1.73.0" />
-    <PackageVersion Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.73.0" />
-    <!-- OpenAI -->
-    <PackageVersion Include="OpenAI" Version="2.8.0" />
-	<PackageVersion Include="Azure.AI.OpenAI" Version="2.8.0-beta.1" />
-	<PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="10.3.0" />
-	<PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="10.3.0" />
-    <!-- TeamsAI -->
-    <PackageVersion Include="JsonSchema.Net" Version="6.1.2" />
-    <PackageVersion Include="Microsoft.ML.Tokenizers.Data.Cl100kBase" Version="1.0.1" />
-    <PackageVersion Include="Microsoft.ML.Tokenizers.Data.O200kBase" Version="1.0.1" />
-    <PackageVersion Include="Azure.AI.ContentSafety" Version="1.0.0" />
-    <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
-    <PackageVersion Include="Google.Protobuf" Version="3.33.4" />
-	<!-- MCP -->
-	<PackageVersion Include="ModelContextProtocol" Version="0.2.0-preview.2" />
-	<PackageVersion Include="ModelContextProtocol.AspNetCore" Version="0.2.0-preview.2" />
-	<PackageVersion Include="Newtonsoft.Json.Schema" Version="4.0.1" />
+        <PackageVersion Include="xunit" Version="$(Xunit_PackageVersion)" />
+        <PackageVersion Include="xunit.abstractions" Version="2.0.3" />
+        <PackageVersion Include="xunit.assert" Version="$(Xunit_PackageVersion)" />
+        <PackageVersion Include="xunit.assert.source" Version="$(Xunit_PackageVersion)" />
+        <PackageVersion Include="xunit.core" Version="$(Xunit_PackageVersion)" />
+        <PackageVersion Include="xunit.extensibility.core" Version="$(Xunit_PackageVersion)" />
+        <PackageVersion Include="xunit.extensibility.execution" Version="$(Xunit_PackageVersion)" />
+        <PackageVersion Include="xunit.runner.utility" Version="$(Xunit_PackageVersion)" />
+        <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
 
-	  <!-- OpenTelemetry packages -->
-	  <PackageVersion Include="OpenTelemetry" Version="$(OpenTelemetry_PkgVer)" />
-	  <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="$(OpenTelemetry_PkgVer)" />
-	  <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="$(OpenTelemetry_PkgVer)" />
-	  <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="$(OpenTelemetry_PkgVer)" />
-	  <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="$(OpenTelemetry_PkgVer)" />
-	  <PackageVersion Include="OpenTelemetry.Instrumentation.Process" Version="1.14.0-beta.2" />
-	  <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="$(OpenTelemetry_PkgVer)" />
-	  <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetry_PkgVer)" />
+        <PackageVersion Include="xunit.v3" Version="$(Xunit_v3_PackageVersion)" />
+        <PackageVersion Include="xunit.v3.assert" Version="$(Xunit_v3_PackageVersion)" />
+        <PackageVersion Include="xunit.v3.core" Version="$(Xunit_v3_PackageVersion)" />
+        <PackageVersion Include="xunit.v3.extensibility.core" Version="$(Xunit_v3_PackageVersion)" />
 
-	  <!-- Azure Monitor (Application Insights) Exporter -->
-	  <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.5.0" />
-  
-  </ItemGroup>
+        <!-- SDK Core -->
+        <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="$(Microsoft_Bcl_PkgVer)" />
+        <PackageVersion Include="Microsoft.Bcl.Memory" Version="$(Microsoft_Bcl_PkgVer)" />
+        <PackageVersion Include="Azure.Identity" Version="1.17.1" />
+        <PackageVersion Include="Azure.Core" Version="1.50.0" />
+        <PackageVersion Include="Azure.Storage.Blobs" Version="12.26.0" />
+        <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.56.0" />
+        <PackageVersion Include="Microsoft.Recognizers.Text.Choice" Version="1.3.2" />
+        <PackageVersion Include="Microsoft.Recognizers.Text.DateTime" Version="1.3.2" />
+        <PackageVersion Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.3.2" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageVersion>
+        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.5.0" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="4.5.0" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.5.0" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.5.0" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.5.0" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.2" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing" Version="1.1.2" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing" Version="1.1.2" />
+        <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.2" />
+
+        <!-- Samples -->
+        <PackageVersion Include="AdaptiveCards" Version="3.1.0" />
+        <PackageVersion Include="AdaptiveCards.Templating" Version="2.0.3" />
+        <PackageVersion Include="AdaptiveCards.Rendering.Html" Version="2.7.3" />
+        <PackageVersion Include="Microsoft.Graph" Version="5.99.0" />
+        <PackageVersion Include="Microsoft.Graph.Core" Version="3.2.5" />
+        <PackageVersion Include="CsvHelper" Version="33.0.1" />
+        <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
+        <!-- To override older version in AdaptiveCards -->
+        <!-- Semantic Kernel Samples -->
+        <PackageVersion Include="Microsoft.SemanticKernel.Agents.Core" Version="1.73.0" />
+        <PackageVersion Include="Microsoft.SemanticKernel.Agents.OpenAI" Version="1.73.0-preview" />
+        <PackageVersion Include="Microsoft.SemanticKernel.Agents.AzureAI" Version="1.73.0-preview" />
+        <PackageVersion Include="Microsoft.SemanticKernel.Connectors.AzureOpenAI" Version="1.73.0" />
+        <PackageVersion Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.73.0" />
+        <!-- OpenAI -->
+        <PackageVersion Include="OpenAI" Version="2.8.0" />
+        <PackageVersion Include="Azure.AI.OpenAI" Version="2.8.0-beta.1" />
+        <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="10.3.0" />
+        <PackageVersion Include="Microsoft.Extensions.AI.Abstractions" Version="10.3.0" />
+        <!-- TeamsAI -->
+        <PackageVersion Include="JsonSchema.Net" Version="6.1.2" />
+        <PackageVersion Include="Microsoft.ML.Tokenizers.Data.Cl100kBase" Version="1.0.1" />
+        <PackageVersion Include="Microsoft.ML.Tokenizers.Data.O200kBase" Version="1.0.1" />
+        <PackageVersion Include="Azure.AI.ContentSafety" Version="1.0.0" />
+        <PackageVersion Include="System.Linq.Async" Version="6.0.1" />
+        <PackageVersion Include="Google.Protobuf" Version="3.33.4" />
+        <!-- MCP -->
+        <PackageVersion Include="ModelContextProtocol" Version="0.2.0-preview.2" />
+        <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="0.2.0-preview.2" />
+        <PackageVersion Include="Newtonsoft.Json.Schema" Version="4.0.1" />
+
+        <!-- OpenTelemetry packages -->
+        <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
+        <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+        <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+        <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+        <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
+        <PackageVersion Include="OpenTelemetry.Instrumentation.Process" Version="1.15.1-beta.1" />
+        <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
+        <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+
+        <!-- Azure Monitor (Application Insights) Exporter -->
+        <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.5.0" />
+
+    </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -34,16 +34,6 @@
 		<PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="$(Microsoft_IdentityModel_PkgVer)" />
 		<PackageVersion Include="Microsoft.Identity.Web.Certificateless" Version="4.3.0" />
 
-		<PackageVersion Include="Microsoft.Identity.Client" Version="$(Microsoft_IdentityClient_PkgVer)" />
-		<PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="$(Microsoft_IdentityClient_PkgVer)" />
-		<PackageVersion Include="Microsoft.IdentityModel.Abstractions" Version="$(Microsoft_IdentityModel_PkgVer)" />
-		<PackageVersion Include="Microsoft.IdentityModel.LoggingExtensions" Version="$(Microsoft_IdentityModel_PkgVer)" />
-		<PackageVersion Include="Microsoft.IdentityModel.Validators" Version="$(Microsoft_IdentityModel_PkgVer)" />
-		<PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="$(Microsoft_IdentityModel_PkgVer)" />
-		<PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="$(Microsoft_IdentityModel_PkgVer)" />
-		<PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="$(Microsoft_IdentityModel_PkgVer)" />
-		<PackageVersion Include="Microsoft.Identity.Web.Certificateless" Version="4.3.0" />
-
 		<PackageVersion Include="Microsoft.Extensions.Logging.AzureAppServices" Version="$(Microsoft_Extentions_PkgVer)" />
 		<PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(Microsoft_Extentions_PkgVer)" />
 		<PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="$(Microsoft_Extentions_PkgVer)" />


### PR DESCRIPTION
Refactored indentation and formatting in Directory.Packages.props for clarity. Updated OpenTelemetry packages to latest 1.15.x versions and replaced the OpenTelemetry_PkgVer property with explicit version numbers. No other package versions were changed.


This pull request updates the OpenTelemetry dependencies to newer versions and makes minor formatting improvements in the `Directory.Packages.props` file. The most significant changes are the version bumps for OpenTelemetry-related packages, which may include bug fixes, new features, and security enhancements.

Dependency updates:

* Updated all OpenTelemetry-related packages to the latest available versions (`OpenTelemetry` to 1.15.3, `OpenTelemetry.Extensions.Hosting` to 1.15.3, `OpenTelemetry.Instrumentation.AspNetCore` to 1.15.2, etc.), replacing the previous version 1.14.0 references. (`Directory.Packages.props`)

Formatting and maintenance:

* Cleaned up and corrected indentation and comments for package version entries, including `Newtonsoft.Json` and `Xunit_v3_PackageVersion`. (`Directory.Packages.props`) [[1]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L21-R23) [[2]](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L117-R118)