### PR TITLE
Update pull request workflows to include 'rel/**' branches

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "rel/**" ]
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "rel/**" ]
 
 jobs:
   build:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - rel/**
 
 env:
   AzDevOpsPipelineId: 25676


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow triggers to ensure that CI and PR workflows also run for pull requests targeting release branches in addition to the main branch. This change helps maintain code quality across both main and release branches by ensuring all relevant checks are executed.

**Workflow trigger updates:**

* [`.github/workflows/ci-linux.yml`](diffhunk://#diff-6af0b0fccc3cf263e0c4d190262250468de88454afb5dbee155414ad812536b9L8-R8): Modified the `pull_request` trigger to include both `main` and any branch matching `rel/**`, so CI runs for PRs targeting release branches as well as main.
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL8-R8): Updated the `pull_request` trigger to also include `rel/**`, ensuring CI checks are performed for PRs against release branches.
* [`.github/workflows/pr.yml`](diffhunk://#diff-15c806aa509538190832852f439e9921a23bec2da81f95ed0e4bf13c14e5b160R7): Added `rel/**` to the list of branches for the `pull_request` trigger, so PR workflow runs on release branches.