### PR TITLE
Add forceBaseChannel option to GetConversationReference

### DIFF
--- a/src/libraries/Client/Microsoft.Agents.Connector/RestUserTokenClient.cs
+++ b/src/libraries/Client/Microsoft.Agents.Connector/RestUserTokenClient.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Agents.Connector
             var tokenExchangeState = new TokenExchangeState
             {
                 ConnectionName = connectionName,
-                Conversation = activity.GetConversationReference(),
+                Conversation = activity.GetConversationReference(forceBaseChannel:true),
                 RelatesTo = activity.RelatesTo,
                 MsAppId = appId,
             };

--- a/src/libraries/Core/Microsoft.Agents.Core/Models/Activity.cs
+++ b/src/libraries/Core/Microsoft.Agents.Core/Models/Activity.cs
@@ -353,7 +353,7 @@ namespace Microsoft.Agents.Core.Models
 
 
         /// <inheritdoc/>
-        public ConversationReference GetConversationReference()
+        public ConversationReference GetConversationReference(bool? forceBaseChannel = null)
         {
             var reference = new ConversationReference
             {
@@ -361,7 +361,7 @@ namespace Microsoft.Agents.Core.Models
                 User = From,
                 Agent = Recipient,
                 Conversation = Conversation,
-                ChannelId = ChannelId?.ToString(),
+                ChannelId = forceBaseChannel.HasValue && forceBaseChannel.Value ? ChannelId?.Channel.ToString() : ChannelId.ToString(),
                 Locale = Locale,
                 ServiceUrl = ServiceUrl,
                 DeliveryMode = DeliveryMode,

--- a/src/libraries/Core/Microsoft.Agents.Core/Models/Activity.cs
+++ b/src/libraries/Core/Microsoft.Agents.Core/Models/Activity.cs
@@ -361,7 +361,7 @@ namespace Microsoft.Agents.Core.Models
                 User = From,
                 Agent = Recipient,
                 Conversation = Conversation,
-                ChannelId = forceBaseChannel.HasValue && forceBaseChannel.Value ? ChannelId?.Channel.ToString() : ChannelId.ToString(),
+                ChannelId = forceBaseChannel.HasValue && forceBaseChannel.Value ? ChannelId?.Channel : ChannelId?.ToString(),
                 Locale = Locale,
                 ServiceUrl = ServiceUrl,
                 DeliveryMode = DeliveryMode,

--- a/src/libraries/Core/Microsoft.Agents.Core/Models/Activity.cs
+++ b/src/libraries/Core/Microsoft.Agents.Core/Models/Activity.cs
@@ -351,6 +351,11 @@ namespace Microsoft.Agents.Core.Models
             return activity;
         }
 
+        /// <inheritdoc/>
+        public ConversationReference GetConversationReference()
+        {
+          return GetConversationReference(forceBaseChannel: null);
+        }
 
         /// <inheritdoc/>
         public ConversationReference GetConversationReference(bool? forceBaseChannel = null)

--- a/src/libraries/Core/Microsoft.Agents.Core/Models/IActivity.cs
+++ b/src/libraries/Core/Microsoft.Agents.Core/Models/IActivity.cs
@@ -306,6 +306,12 @@ namespace Microsoft.Agents.Core.Models
         /// <summary>
         /// Creates a <see cref="Microsoft.Agents.Core.Models.ConversationReference"/> based on this Activity.
         /// </summary>
+        /// <returns>A conversation reference for the conversation that contains this Activity.</returns>
+        ConversationReference GetConversationReference();
+
+        /// <summary>
+        /// Creates a <see cref="Microsoft.Agents.Core.Models.ConversationReference"/> based on this Activity.
+        /// </summary>
         /// <param name="forceBaseChannel">Optional, <c>true</c> to force the use of the base channel in the conversation reference; otherwise, <c>false</c>.</param>
         /// <returns>A conversation reference for the conversation that contains this Activity.</returns>
         ConversationReference GetConversationReference(bool? forceBaseChannel = null);

--- a/src/libraries/Core/Microsoft.Agents.Core/Models/IActivity.cs
+++ b/src/libraries/Core/Microsoft.Agents.Core/Models/IActivity.cs
@@ -306,8 +306,9 @@ namespace Microsoft.Agents.Core.Models
         /// <summary>
         /// Creates a <see cref="Microsoft.Agents.Core.Models.ConversationReference"/> based on this Activity.
         /// </summary>
+        /// <param name="forceBaseChannel">Optional, <c>true</c> to force the use of the base channel in the conversation reference; otherwise, <c>false</c>.</param>
         /// <returns>A conversation reference for the conversation that contains this Activity.</returns>
-        ConversationReference GetConversationReference();
+        ConversationReference GetConversationReference(bool? forceBaseChannel = null);
 
         /// <summary>
         /// Creates a new message Activity as a response to this Activity.


### PR DESCRIPTION
fix for #827

Introduced an optional forceBaseChannel parameter to the GetConversationReference method in IActivity and its implementation, allowing the use of the base channel in ConversationReference. Updated CreateTokenExchangeState to utilize this option for more precise channel representation.

This pull request updates how conversation references are generated from activities, adding support for optionally forcing the use of the base channel in the conversation reference. The change propagates through the `IActivity` interface and its implementations, and updates code that depends on this method.

**Conversation Reference Handling:**

* The `GetConversationReference` method in `IActivity` and its implementation in `Activity` now accept an optional `forceBaseChannel` parameter. When set to `true`, this forces the use of the base channel in the conversation reference's `ChannelId` property. [[1]](diffhunk://#diff-158aa264eb9814625522c1018619f6d7e962184325b06d9e9cde91ad463434f2R309-R311) [[2]](diffhunk://#diff-238f671808b4c9862c2c3d046212f05bb7fb24a4396bc2aa87816bf018a6de61L356-R364)
* The `CreateTokenExchangeState` method in `RestUserTokenClient` is updated to call `GetConversationReference(forceBaseChannel:true)`, ensuring that the base channel is used when creating token exchange state.