### PR TITLE
Restore CLR type fidelity for primitive arrays in IDictionary<string, object> round-trip

### DIFF
--- a/src/libraries/Core/Microsoft.Agents.Core/Serialization/Converters/DictionaryOfObjectConverter.cs
+++ b/src/libraries/Core/Microsoft.Agents.Core/Serialization/Converters/DictionaryOfObjectConverter.cs
@@ -308,18 +308,18 @@ namespace Microsoft.Agents.Core.Serialization.Converters
             // Promote homogeneous primitive lists to typed arrays so that
             // round-tripped primitive arrays (e.g. string[], int[], bool[])
             // come back as their original CLR type instead of List<object>.
-            if (objValue is List<object> { Count: > 0 })
+            if (objValue is List<object> list && list.Count > 0)
             {
-                Type elementType = objValue[0]?.GetType();
+                Type elementType = list[0]?.GetType();
                 if (elementType != null
                     && (elementType == typeof(string)
                         || elementType == typeof(int)
                         || elementType == typeof(bool)))
                 {
                     bool allSameType = true;
-                    for (int i = 1; i < objValue.Count; i++)
+                    for (int i = 1; i < list.Count; i++)
                     {
-                        if (objValue[i]?.GetType() != elementType)
+                        if (list[i]?.GetType() != elementType)
                         {
                             allSameType = false;
                             break;
@@ -328,10 +328,10 @@ namespace Microsoft.Agents.Core.Serialization.Converters
 
                     if (allSameType)
                     {
-                        Array typedArray = Array.CreateInstance(elementType, objValue.Count);
-                        for (int i = 0; i < objValue.Count; i++)
+                        Array typedArray = Array.CreateInstance(elementType, list.Count);
+                        for (int i = 0; i < list.Count; i++)
                         {
-                            typedArray.SetValue(objValue[i], i);
+                            typedArray.SetValue(list[i], i);
                         }
                         return typedArray;
                     }

--- a/src/libraries/Core/Microsoft.Agents.Core/Serialization/Converters/DictionaryOfObjectConverter.cs
+++ b/src/libraries/Core/Microsoft.Agents.Core/Serialization/Converters/DictionaryOfObjectConverter.cs
@@ -311,7 +311,10 @@ namespace Microsoft.Agents.Core.Serialization.Converters
             if (objValue is List<object> { Count: > 0 })
             {
                 Type elementType = objValue[0]?.GetType();
-                if (elementType != null)
+                if (elementType != null
+                    && (elementType == typeof(string)
+                        || elementType == typeof(int)
+                        || elementType == typeof(bool)))
                 {
                     bool allSameType = true;
                     for (int i = 1; i < objValue.Count; i++)

--- a/src/libraries/Core/Microsoft.Agents.Core/Serialization/Converters/DictionaryOfObjectConverter.cs
+++ b/src/libraries/Core/Microsoft.Agents.Core/Serialization/Converters/DictionaryOfObjectConverter.cs
@@ -95,6 +95,18 @@ namespace Microsoft.Agents.Core.Serialization.Converters
                                         dict[child.Key] = valValue.GetBoolean();
 #endif
                                         break;
+
+                                    case JsonValueKind.Array:
+                                        JsonArray childArray = JsonArray.Create(valValue);
+                                        if (childArray != null)
+                                        {
+#if NETSTANDARD
+                                            changes.Add(new KeyValuePair<string, object>(child.Key, DeserializeJsonArray(childArray, options)));
+#else
+                                            dict[child.Key] = DeserializeJsonArray(childArray, options);
+#endif
+                                        }
+                                        break;
                                 }
                             }
                         }
@@ -291,6 +303,36 @@ namespace Microsoft.Agents.Core.Serialization.Converters
                     array.SetValue(objValue[i], i);
                 }
                 return array;
+            }
+
+            // Promote homogeneous primitive lists to typed arrays so that
+            // round-tripped primitive arrays (e.g. string[], int[], bool[])
+            // come back as their original CLR type instead of List<object>.
+            if (objValue is List<object> { Count: > 0 })
+            {
+                Type elementType = objValue[0]?.GetType();
+                if (elementType != null)
+                {
+                    bool allSameType = true;
+                    for (int i = 1; i < objValue.Count; i++)
+                    {
+                        if (objValue[i]?.GetType() != elementType)
+                        {
+                            allSameType = false;
+                            break;
+                        }
+                    }
+
+                    if (allSameType)
+                    {
+                        Array typedArray = Array.CreateInstance(elementType, objValue.Count);
+                        for (int i = 0; i < objValue.Count; i++)
+                        {
+                            typedArray.SetValue(objValue[i], i);
+                        }
+                        return typedArray;
+                    }
+                }
             }
 
             return objValue;

--- a/src/tests/Microsoft.Agents.Model.Tests/DictionaryOfObjectConverterTests.cs
+++ b/src/tests/Microsoft.Agents.Model.Tests/DictionaryOfObjectConverterTests.cs
@@ -577,6 +577,97 @@ namespace Microsoft.Agents.Model.Tests
 
         #endregion
 
+        #region Roundtrip: primitive arrays deserialize to typed CLR arrays (not JsonElement / List<object>)
+
+        [Fact]
+        public void Roundtrip_StringArray_DeserializesToStringArray()
+        {
+            var dictionary = new Dictionary<string, object>
+            {
+                ["parameters"] = new string[] { "AddressNormalizerResponse", "AzureMaps", "{Street}" }
+            };
+
+            var json = JsonSerializer.Serialize<IDictionary<string, object>>(dictionary, SdkOptions);
+            IDictionary<string, object> deserialized = JsonSerializer.Deserialize<IDictionary<string, object>>(json, SdkOptions);
+
+            Assert.IsType<string[]>(deserialized["parameters"]);
+            string[] parameters = (string[])deserialized["parameters"];
+            Assert.Equal(3, parameters.Length);
+            Assert.Equal("AddressNormalizerResponse", parameters[0]);
+            Assert.Equal("AzureMaps", parameters[1]);
+            Assert.Equal("{Street}", parameters[2]);
+        }
+
+        [Fact]
+        public void Roundtrip_IntArray_DeserializesToIntArray()
+        {
+            var dictionary = new Dictionary<string, object>
+            {
+                ["counters"] = new int[] { 10, 20, 30 }
+            };
+
+            var json = JsonSerializer.Serialize<IDictionary<string, object>>(dictionary, SdkOptions);
+            IDictionary<string, object> deserialized = JsonSerializer.Deserialize<IDictionary<string, object>>(json, SdkOptions);
+
+            Assert.IsType<int[]>(deserialized["counters"]);
+            int[] counters = (int[])deserialized["counters"];
+            Assert.Equal(3, counters.Length);
+            Assert.Equal(10, counters[0]);
+            Assert.Equal(20, counters[1]);
+            Assert.Equal(30, counters[2]);
+        }
+
+        [Fact]
+        public void Roundtrip_BoolArray_DeserializesToBoolArray()
+        {
+            var dictionary = new Dictionary<string, object>
+            {
+                ["flags"] = new bool[] { true, false, true }
+            };
+
+            var json = JsonSerializer.Serialize<IDictionary<string, object>>(dictionary, SdkOptions);
+            IDictionary<string, object> deserialized = JsonSerializer.Deserialize<IDictionary<string, object>>(json, SdkOptions);
+
+            Assert.IsType<bool[]>(deserialized["flags"]);
+            bool[] flags = (bool[])deserialized["flags"];
+            Assert.Equal(3, flags.Length);
+            Assert.True(flags[0]);
+            Assert.False(flags[1]);
+            Assert.True(flags[2]);
+        }
+
+        [Fact]
+        public void Roundtrip_WaterfallValues_StringArray_DeserializesToStringArray()
+        {
+            // Simulates the exact WaterfallDialog multi-step pattern:
+            // Step 1 stores string[] in stepContext.Values, state is serialized to storage.
+            // Step 2 loads state from storage, reads stepContext.Values["ApiParameters"].
+            // The value must come back as string[], not JsonElement or List<object>.
+            var waterfallState = new Dictionary<string, object>
+            {
+                ["options"] = (object)null,
+                ["values"] = new Dictionary<string, object>
+                {
+                    ["ApiParameters"] = new string[] { "AddressNormalizerResponse", "AzureMaps", "{Street}" }
+                },
+                ["instanceId"] = "test-id",
+                ["stepIndex"] = 1
+            };
+
+            var json = JsonSerializer.Serialize<IDictionary<string, object>>(waterfallState, SdkOptions);
+            IDictionary<string, object> deserialized = JsonSerializer.Deserialize<IDictionary<string, object>>(json, SdkOptions);
+
+            IDictionary<string, object> values = (IDictionary<string, object>)deserialized["values"];
+            Assert.IsType<string[]>(values["ApiParameters"]);
+            string[] parameters = (string[])values["ApiParameters"];
+            Assert.Equal(3, parameters.Length);
+            Assert.Equal("AddressNormalizerResponse", parameters[0]);
+            Assert.Equal("AzureMaps", parameters[1]);
+            Assert.Equal("{Street}", parameters[2]);
+        }
+
+        #endregion
+
         #region Complex real-world scenarios
 
         [Fact]
@@ -631,15 +722,15 @@ namespace Microsoft.Agents.Model.Tests
 
             Assert.NotNull(deserialized);
             Assert.Equal("test-dialog", deserialized["dialogId"].ToString());
-            
+
             IList options = (IList)deserialized["options"];
             Assert.Equal(3, options.Count);
             Assert.Equal("A", options[0].ToString());
-            
+
             IList scores = (IList)deserialized["scores"];
             Assert.Equal(3, scores.Count);
             Assert.Equal(10, Convert.ToInt32(scores[0]));
-            
+
             IList enabled = (IList)deserialized["enabled"];
             Assert.Equal(2, enabled.Count);
             Assert.True(Convert.ToBoolean(enabled[0]));

--- a/src/tests/Microsoft.Agents.Model.Tests/DictionaryOfObjectConverterTests.cs
+++ b/src/tests/Microsoft.Agents.Model.Tests/DictionaryOfObjectConverterTests.cs
@@ -590,6 +590,7 @@ namespace Microsoft.Agents.Model.Tests
             var json = JsonSerializer.Serialize<IDictionary<string, object>>(dictionary, SdkOptions);
             IDictionary<string, object> deserialized = JsonSerializer.Deserialize<IDictionary<string, object>>(json, SdkOptions);
 
+            Assert.NotNull(deserialized);
             Assert.IsType<string[]>(deserialized["parameters"]);
             string[] parameters = (string[])deserialized["parameters"];
             Assert.Equal(3, parameters.Length);
@@ -609,6 +610,7 @@ namespace Microsoft.Agents.Model.Tests
             var json = JsonSerializer.Serialize<IDictionary<string, object>>(dictionary, SdkOptions);
             IDictionary<string, object> deserialized = JsonSerializer.Deserialize<IDictionary<string, object>>(json, SdkOptions);
 
+            Assert.NotNull(deserialized);
             Assert.IsType<int[]>(deserialized["counters"]);
             int[] counters = (int[])deserialized["counters"];
             Assert.Equal(3, counters.Length);
@@ -628,6 +630,7 @@ namespace Microsoft.Agents.Model.Tests
             var json = JsonSerializer.Serialize<IDictionary<string, object>>(dictionary, SdkOptions);
             IDictionary<string, object> deserialized = JsonSerializer.Deserialize<IDictionary<string, object>>(json, SdkOptions);
 
+            Assert.NotNull(deserialized);
             Assert.IsType<bool[]>(deserialized["flags"]);
             bool[] flags = (bool[])deserialized["flags"];
             Assert.Equal(3, flags.Length);
@@ -657,6 +660,7 @@ namespace Microsoft.Agents.Model.Tests
             var json = JsonSerializer.Serialize<IDictionary<string, object>>(waterfallState, SdkOptions);
             IDictionary<string, object> deserialized = JsonSerializer.Deserialize<IDictionary<string, object>>(json, SdkOptions);
 
+            Assert.NotNull(deserialized);
             IDictionary<string, object> values = (IDictionary<string, object>)deserialized["values"];
             Assert.IsType<string[]>(values["ApiParameters"]);
             string[] parameters = (string[])values["ApiParameters"];


### PR DESCRIPTION
PR #843 fixed the serialization crash for primitive arrays (`string[]`, `int[]`, `bool[]`). However, deserialization still lost the original CLR type: values came back as `List<object>` (top-level) or `JsonElement `(inside typed nested dictionaries), making direct casts like `(string[])stepContext.Values["key"]` fail at runtime.

This PR addresses this with 2 proposed changes:
- `DeserializeJsonArray`: when all elements share the same CLR type, return a typed array (e.g. `string[]`) instead of `List<object>`
- `Read`(typed-dictionary path): add missing `JsonValueKind.Array` case so that arrays inside `$type`-annotated nested dictionaries are materialized instead of being left as raw `JsonElement`

Any multi-step `WaterfallDialog` that stores a primitive array in `stepContext.Values` and reads it back in a subsequent step (after the storage round-trip) now gets the original CLR type instead of an opaque `JsonElement`.