### PR TITLE
Wrapper for ITurnContext instances

### DIFF
--- a/src/libraries/Builder/Microsoft.Agents.Builder/TurnContextWrapper.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/TurnContextWrapper.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Agents.Builder;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Agents.Builder;
 using Microsoft.Agents.Core.Models;
 using System;
 using System.Runtime.CompilerServices;
@@ -6,7 +9,7 @@ using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Microsoft.Agents.Extensions.Teams
+namespace Microsoft.Agents.Builder
 {
     /// <summary>
     /// Provides a base wrapper around an <see cref="ITurnContext"/> instance.
@@ -90,64 +93,64 @@ namespace Microsoft.Agents.Extensions.Teams
         }
 
         /// <inheritdoc/>
-        public Task<ResourceResponse> SendActivityAsync(string text, string speak = null, string inputHint = "acceptingInput", CancellationToken cancellationToken = default)
+        public virtual Task<ResourceResponse> SendActivityAsync(string text, string speak = null, string inputHint = "acceptingInput", CancellationToken cancellationToken = default)
         {
             return _turnContext.SendActivityAsync(text, speak, inputHint, cancellationToken);
         }
 
         /// <inheritdoc/>
-        public Task<ResourceResponse> SendActivityAsync(IActivity activity, CancellationToken cancellationToken = default)
+        public virtual Task<ResourceResponse> SendActivityAsync(IActivity activity, CancellationToken cancellationToken = default)
         {
             return _turnContext.SendActivityAsync(activity, cancellationToken);
         }
 
         /// <inheritdoc/>
-        public Task<ResourceResponse[]> SendActivitiesAsync(IActivity[] activities, CancellationToken cancellationToken = default)
+        public virtual Task<ResourceResponse[]> SendActivitiesAsync(IActivity[] activities, CancellationToken cancellationToken = default)
         {
             return _turnContext.SendActivitiesAsync(activities, cancellationToken);
         }
 
         /// <inheritdoc/>
-        public Task<ResourceResponse> UpdateActivityAsync(IActivity activity, CancellationToken cancellationToken = default)
+        public virtual Task<ResourceResponse> UpdateActivityAsync(IActivity activity, CancellationToken cancellationToken = default)
         {
             return _turnContext.UpdateActivityAsync(activity, cancellationToken);
         }
 
         /// <inheritdoc/>
-        public Task DeleteActivityAsync(string activityId, CancellationToken cancellationToken = default)
+        public virtual Task DeleteActivityAsync(string activityId, CancellationToken cancellationToken = default)
         {
             return _turnContext.DeleteActivityAsync(activityId, cancellationToken);
         }
 
         /// <inheritdoc/>
-        public Task DeleteActivityAsync(ConversationReference conversationReference, CancellationToken cancellationToken = default)
+        public virtual Task DeleteActivityAsync(ConversationReference conversationReference, CancellationToken cancellationToken = default)
         {
             return _turnContext.DeleteActivityAsync(conversationReference, cancellationToken);
         }
 
         /// <inheritdoc/>
-        public ITurnContext OnSendActivities(SendActivitiesHandler handler)
+        public virtual ITurnContext OnSendActivities(SendActivitiesHandler handler)
         {
             _turnContext.OnSendActivities(handler);
             return this;
         }
 
         /// <inheritdoc/>
-        public ITurnContext OnUpdateActivity(UpdateActivityHandler handler)
+        public virtual ITurnContext OnUpdateActivity(UpdateActivityHandler handler)
         {
             _turnContext.OnUpdateActivity(handler);
             return this;
         }
 
         /// <inheritdoc/>
-        public ITurnContext OnDeleteActivity(DeleteActivityHandler handler)
+        public virtual ITurnContext OnDeleteActivity(DeleteActivityHandler handler)
         {
             _turnContext.OnDeleteActivity(handler);
             return this;
         }
 
         /// <inheritdoc/>
-        public Task<ResourceResponse> TraceActivityAsync(string name, object value = null, string valueType = null, [CallerMemberName] string label = null, CancellationToken cancellationToken = default)
+        public virtual Task<ResourceResponse> TraceActivityAsync(string name, object value = null, string valueType = null, [CallerMemberName] string label = null, CancellationToken cancellationToken = default)
         {
             return _turnContext.TraceActivityAsync(name, value, valueType, label, cancellationToken);
         }

--- a/src/libraries/Builder/Microsoft.Agents.Builder/TurnContextWrapper.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/TurnContextWrapper.cs
@@ -8,99 +8,145 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Agents.Extensions.Teams
 {
+    /// <summary>
+    /// Provides a base wrapper around an <see cref="ITurnContext"/> instance.
+    /// </summary>
+    /// <remarks>
+    /// This class delegates all <see cref="ITurnContext"/> members to an inner turn context,
+    /// allowing derived types to extend turn-context behavior without reimplementing the
+    /// underlying operations.
+    /// </remarks>
     public abstract class TurnContextWrapper : ITurnContext
     {
 
         protected readonly ITurnContext _turnContext;
 
+        /// <summary>
+        /// Gets the Adapter that created this context object.
+        /// </summary>
+        /// <value>The Adapter that created this context object.</value>
         public IChannelAdapter Adapter
         {
             get { return _turnContext.Adapter; }
         }
 
+        /// <summary>
+        /// Gets the services registered on this context object.
+        /// </summary>
+        /// <value>The services registered on this context object.</value>
         public TurnContextStateCollection Services
         {
             get { return _turnContext.Services; }
         }
 
+        /// <summary>
+        /// Gets the state collection for the turn context.
+        /// </summary>
         public TurnContextStateCollection StackState
         {
             get { return _turnContext.StackState; }
         }
 
+        /// <summary>
+        /// Gets the activity associated with this turn; or <c>null</c> when processing
+        /// a proactive message.
+        /// </summary>
+        /// <value>The activity associated with this turn.</value>
         public IActivity Activity
         {
             get { return _turnContext.Activity; }
         }
 
+        /// <inheritdoc/>
         public IStreamingResponse StreamingResponse
         {
             get { return _turnContext.StreamingResponse; }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether at least one response was sent for the current turn.
+        /// </summary>
+        /// <value><c>true</c> if at least one response was sent for the current turn.</value>
         public bool Responded
         {
             get { return _turnContext.Responded; }
         }
 
+        /// <summary>
+        /// Gets the claims identity associated with this turn context.
+        /// </summary>
         public ClaimsIdentity Identity
         {
             get { return _turnContext.Identity; }
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TurnContextWrapper"/> class.
+        /// </summary>
+        /// <param name="turnContext">The inner turn context to wrap.</param>
         protected TurnContextWrapper(ITurnContext turnContext)
         {
             this._turnContext = turnContext ?? throw new ArgumentNullException(nameof(turnContext));
         }
 
+        /// <inheritdoc/>
         public Task<ResourceResponse> SendActivityAsync(string text, string speak = null, string inputHint = "acceptingInput", CancellationToken cancellationToken = default)
         {
             return _turnContext.SendActivityAsync(text, speak, inputHint, cancellationToken);
         }
 
+        /// <inheritdoc/>
         public Task<ResourceResponse> SendActivityAsync(IActivity activity, CancellationToken cancellationToken = default)
         {
             return _turnContext.SendActivityAsync(activity, cancellationToken);
         }
 
+        /// <inheritdoc/>
         public Task<ResourceResponse[]> SendActivitiesAsync(IActivity[] activities, CancellationToken cancellationToken = default)
         {
             return _turnContext.SendActivitiesAsync(activities, cancellationToken);
         }
 
+        /// <inheritdoc/>
         public Task<ResourceResponse> UpdateActivityAsync(IActivity activity, CancellationToken cancellationToken = default)
         {
             return _turnContext.UpdateActivityAsync(activity, cancellationToken);
         }
 
+        /// <inheritdoc/>
         public Task DeleteActivityAsync(string activityId, CancellationToken cancellationToken = default)
         {
             return _turnContext.DeleteActivityAsync(activityId, cancellationToken);
         }
 
+        /// <inheritdoc/>
         public Task DeleteActivityAsync(ConversationReference conversationReference, CancellationToken cancellationToken = default)
         {
             return _turnContext.DeleteActivityAsync(conversationReference, cancellationToken);
         }
 
+        /// <inheritdoc/>
         public ITurnContext OnSendActivities(SendActivitiesHandler handler)
         {
             _turnContext.OnSendActivities(handler);
             return this;
         }
 
+        /// <inheritdoc/>
         public ITurnContext OnUpdateActivity(UpdateActivityHandler handler)
         {
             _turnContext.OnUpdateActivity(handler);
             return this;
         }
 
+        /// <inheritdoc/>
         public ITurnContext OnDeleteActivity(DeleteActivityHandler handler)
         {
             _turnContext.OnDeleteActivity(handler);
             return this;
         }
 
+        /// <inheritdoc/>
         public Task<ResourceResponse> TraceActivityAsync(string name, object value = null, string valueType = null, [CallerMemberName] string label = null, CancellationToken cancellationToken = default)
         {
             return _turnContext.TraceActivityAsync(name, value, valueType, label, cancellationToken);

--- a/src/libraries/Builder/Microsoft.Agents.Builder/TurnContextWrapper.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/TurnContextWrapper.cs
@@ -1,0 +1,109 @@
+﻿using Microsoft.Agents.Builder;
+using Microsoft.Agents.Core.Models;
+using System;
+using System.Runtime.CompilerServices;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Agents.Extensions.Teams
+{
+    public abstract class TurnContextWrapper : ITurnContext
+    {
+
+        protected readonly ITurnContext _turnContext;
+
+        public IChannelAdapter Adapter
+        {
+            get { return _turnContext.Adapter; }
+        }
+
+        public TurnContextStateCollection Services
+        {
+            get { return _turnContext.Services; }
+        }
+
+        public TurnContextStateCollection StackState
+        {
+            get { return _turnContext.StackState; }
+        }
+
+        public IActivity Activity
+        {
+            get { return _turnContext.Activity; }
+        }
+
+        public IStreamingResponse StreamingResponse
+        {
+            get { return _turnContext.StreamingResponse; }
+        }
+
+        public bool Responded
+        {
+            get { return _turnContext.Responded; }
+        }
+
+        public ClaimsIdentity Identity
+        {
+            get { return _turnContext.Identity; }
+        }
+
+        protected TurnContextWrapper(ITurnContext turnContext)
+        {
+            this._turnContext = turnContext ?? throw new ArgumentNullException(nameof(turnContext));
+        }
+
+        public Task<ResourceResponse> SendActivityAsync(string text, string speak = null, string inputHint = "acceptingInput", CancellationToken cancellationToken = default)
+        {
+            return _turnContext.SendActivityAsync(text, speak, inputHint, cancellationToken);
+        }
+
+        public Task<ResourceResponse> SendActivityAsync(IActivity activity, CancellationToken cancellationToken = default)
+        {
+            return _turnContext.SendActivityAsync(activity, cancellationToken);
+        }
+
+        public Task<ResourceResponse[]> SendActivitiesAsync(IActivity[] activities, CancellationToken cancellationToken = default)
+        {
+            return _turnContext.SendActivitiesAsync(activities, cancellationToken);
+        }
+
+        public Task<ResourceResponse> UpdateActivityAsync(IActivity activity, CancellationToken cancellationToken = default)
+        {
+            return _turnContext.UpdateActivityAsync(activity, cancellationToken);
+        }
+
+        public Task DeleteActivityAsync(string activityId, CancellationToken cancellationToken = default)
+        {
+            return _turnContext.DeleteActivityAsync(activityId, cancellationToken);
+        }
+
+        public Task DeleteActivityAsync(ConversationReference conversationReference, CancellationToken cancellationToken = default)
+        {
+            return _turnContext.DeleteActivityAsync(conversationReference, cancellationToken);
+        }
+
+        public ITurnContext OnSendActivities(SendActivitiesHandler handler)
+        {
+            _turnContext.OnSendActivities(handler);
+            return this;
+        }
+
+        public ITurnContext OnUpdateActivity(UpdateActivityHandler handler)
+        {
+            _turnContext.OnUpdateActivity(handler);
+            return this;
+        }
+
+        public ITurnContext OnDeleteActivity(DeleteActivityHandler handler)
+        {
+            _turnContext.OnDeleteActivity(handler);
+            return this;
+        }
+
+        public Task<ResourceResponse> TraceActivityAsync(string name, object value = null, string valueType = null, [CallerMemberName] string label = null, CancellationToken cancellationToken = default)
+        {
+            return _turnContext.TraceActivityAsync(name, value, valueType, label, cancellationToken);
+        }
+    }
+}

--- a/src/tests/Microsoft.Agents.Builder.Tests/TurnContextWrapperTests.cs
+++ b/src/tests/Microsoft.Agents.Builder.Tests/TurnContextWrapperTests.cs
@@ -1,0 +1,194 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Agents.Core.Models;
+using Microsoft.Agents.Extensions.Teams;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Agents.Builder.Tests
+{
+    public class TurnContextWrapperTests
+    {
+
+        [Fact]
+        public void Constructor_ShouldThrowOnNullTurnContext()
+        {
+            Assert.Throws<ArgumentNullException>(() => new TestTurnContextWrapper((TurnContext)null));
+        }
+
+        [Fact]
+        public void Constructor_ShouldInstantiateCorrectly()
+        {
+            var context = new TestTurnContextWrapper(new TurnContext(new SimpleAdapter(), new Activity()));
+            Assert.NotNull(context);
+        }
+
+        [Fact]
+        public void Wrapper_ShouldExposeInnerTurnContextProperties()
+        {
+            var adapter = new SimpleAdapter();
+            var activity = TestMessage.Message();
+            var innerContext = new TurnContext(adapter, activity);
+            innerContext.StackState.Set("key", "value");
+            innerContext.Services.Set("service", "test-service");
+
+            var context = new TestTurnContextWrapper(innerContext);
+
+            Assert.Same(adapter, context.Adapter);
+            Assert.Same(activity, context.Activity);
+            Assert.Same(innerContext.StackState, context.StackState);
+            Assert.Same(innerContext.Services, context.Services);
+            Assert.Same(innerContext.StreamingResponse, context.StreamingResponse);
+            Assert.False(context.Responded);
+        }
+
+        [Fact]
+        public async Task SendActivityAsync_ShouldSetRespondedAsTrue()
+        {
+            var context = new TestTurnContextWrapper(new TurnContext(new SimpleAdapter(), new Activity()));
+            Assert.False(context.Responded);
+
+            var response = await context.SendActivityAsync(TestMessage.Message("testtest"));
+
+            Assert.True(context.Responded);
+            Assert.Equal("testtest", response.Id);
+        }
+
+        [Fact]
+        public async Task SendActivityAsync_ShouldCallOnSendBeforeDelivery()
+        {
+            var context = new TestTurnContextWrapper(new TurnContext(new SimpleAdapter(), new Activity()));
+
+            var count = 0;
+            var returnedContext = context.OnSendActivities(async (innerContext, activities, next) =>
+            {
+                Assert.NotNull(activities);
+                count = activities.Count;
+                return await next();
+            });
+
+            await context.SendActivityAsync(TestMessage.Message());
+
+            Assert.Same(context, returnedContext);
+            Assert.Equal(1, count);
+        }
+
+        [Fact]
+        public async Task SendActivityAsync_ShouldInterceptAndMutateOnSend()
+        {
+            var foundIt = false;
+
+            void ValidateResponses(IActivity[] activities)
+            {
+                Assert.NotNull(activities);
+                Assert.Single(activities);
+                Assert.Equal("changed", activities[0].Id);
+                foundIt = true;
+            }
+
+            var adapter = new SimpleAdapter(ValidateResponses);
+            var context = new TestTurnContextWrapper(new TurnContext(adapter, new Activity()));
+
+            context.OnSendActivities(async (innerContext, activities, next) =>
+            {
+                Assert.NotNull(activities);
+                Assert.Single(activities);
+                Assert.Equal("1234", activities[0].Id);
+                activities[0].Id = "changed";
+                return await next();
+            });
+
+            await context.SendActivityAsync(TestMessage.Message());
+
+            Assert.True(foundIt);
+        }
+
+        [Fact]
+        public async Task UpdateActivityAsync_ShouldCallOnUpdateBeforeDelivery()
+        {
+            var foundActivity = false;
+
+            void ValidateUpdate(IActivity activity)
+            {
+                Assert.NotNull(activity);
+                Assert.Equal("1234", activity.Id);
+                foundActivity = true;
+            }
+
+            var adapter = new SimpleAdapter(ValidateUpdate);
+            var context = new TestTurnContextWrapper(new TurnContext(adapter, new Activity()));
+
+            var wasCalled = false;
+            var returnedContext = context.OnUpdateActivity(async (innerContext, activity, next) =>
+            {
+                Assert.NotNull(activity);
+                wasCalled = true;
+                return await next();
+            });
+
+            await context.UpdateActivityAsync(TestMessage.Message());
+
+            Assert.Same(context, returnedContext);
+            Assert.True(wasCalled);
+            Assert.True(foundActivity);
+        }
+
+        [Fact]
+        public async Task DeleteActivityAsync_ShouldInterceptAndMutateOnDelete()
+        {
+            var adapterCalled = false;
+
+            void ValidateDelete(ConversationReference reference)
+            {
+                Assert.Equal("mutated", reference.ActivityId);
+                adapterCalled = true;
+            }
+
+            var adapter = new SimpleAdapter(ValidateDelete);
+            var context = new TestTurnContextWrapper(new TurnContext(adapter, new Activity()));
+
+            var returnedContext = context.OnDeleteActivity(async (innerContext, conversationReference, next) =>
+            {
+                Assert.NotNull(conversationReference);
+                Assert.Equal("1234", conversationReference.ActivityId);
+                conversationReference.ActivityId = "mutated";
+                await next();
+            });
+
+            await context.DeleteActivityAsync("1234");
+
+            Assert.Same(context, returnedContext);
+            Assert.True(adapterCalled);
+        }
+
+        [Fact]
+        public async Task TraceActivityAsync_ShouldNotUpdateContextResponded()
+        {
+            var context = new TestTurnContextWrapper(new TurnContext(new SimpleAdapter(), TestMessage.Message()));
+
+            await context.TraceActivityAsync("Message with trace");
+
+            Assert.False(context.Responded);
+        }
+
+        [Fact]
+        public async Task SendActivityAsync_ShouldThrowAfterInnerContextDispose()
+        {
+            var innerContext = new TurnContext(new SimpleAdapter(), new Activity());
+            var context = new TestTurnContextWrapper(innerContext);
+            innerContext.Dispose();
+
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => context.SendActivityAsync("hello"));
+        }
+
+        private sealed class TestTurnContextWrapper : TurnContextWrapper
+        {
+            public TestTurnContextWrapper(ITurnContext turnContext)
+                : base(turnContext)
+            {
+            }
+        }
+    }
+}

--- a/src/tests/Microsoft.Agents.Builder.Tests/TurnContextWrapperTests.cs
+++ b/src/tests/Microsoft.Agents.Builder.Tests/TurnContextWrapperTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using Microsoft.Agents.Core.Models;
-using Microsoft.Agents.Extensions.Teams;
 using System;
 using System.Threading.Tasks;
 using Xunit;


### PR DESCRIPTION
This pull request introduces a new `TurnContextWrapper` abstraction to the `Microsoft.Agents.Extensions.Teams` namespace, providing a base class for wrapping and extending `ITurnContext` functionality. Comprehensive unit tests are also added to ensure the correctness and extensibility of the wrapper. The most important changes are:

### Core Abstraction

* Added the `TurnContextWrapper` abstract class in `TurnContextWrapper.cs`, which delegates all `ITurnContext` methods and properties to an inner `ITurnContext` instance, enabling easy extension and interception of context operations.

### Testing and Validation

* Introduced `TurnContextWrapperTests.cs`, providing thorough unit tests for the wrapper, including constructor validation, property delegation, handler interception, mutation, and proper error handling when the inner context is disposed.