### PR TITLE
Fixed random failure due to timing in DescriptorLengthMismatch_DoesNotBlockSubsequentRequests

### DIFF
--- a/src/tests/Microsoft.Agents.Hosting.DirectLine.NamedPipes/NamedPipeProtocolStreamingTests.cs
+++ b/src/tests/Microsoft.Agents.Hosting.DirectLine.NamedPipes/NamedPipeProtocolStreamingTests.cs
@@ -271,7 +271,9 @@ namespace Microsoft.Agents.Hosting.DirectLine.NamedPipes.Tests
             // In production, DLFlex has a meaningful gap between operations; in tests with
             // anonymous pipes, data arrives instantly so without this delay the probe would
             // incorrectly consume the next frame's header byte.
-            await Task.Delay(50);
+            // Use 200ms (not 50ms) to account for CancelAfter timer granularity (~15.6ms on
+            // Windows) and thread scheduling jitter on loaded CI machines.
+            await Task.Delay(200);
 
             // --- Second request: must parse correctly immediately ---
             var req2Id = Guid.NewGuid();


### PR DESCRIPTION
Root Cause

The test used Task.Delay(50) to wait for the protocol's 20ms probe timeout to expire before sending a second request. On loaded CI machines, CancellationTokenSource.CancelAfter(20ms) can fire late due to:

 - Windows timer resolution (~15.6ms granularity)
 - Thread pool scheduling delays under load

When the probe's 20ms CTS fires after the 50ms test delay, the probe reads the first byte of the second request's header, interprets it as a "trailing byte", then tries to drain declaredLength - actualLength - 1 bytes from what's actually the second request — corrupting framing and eventually timing out.

Fix

Increased Task.Delay(50) → Task.Delay(200) — 10× the probe timeout, safely beyond any timer jitter.