### PR TITLE
Add support for attachments in streaming responses

### DIFF
--- a/src/libraries/Builder/Microsoft.Agents.Builder/IStreamingResponse.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/IStreamingResponse.cs
@@ -95,6 +95,12 @@ namespace Microsoft.Agents.Builder
         List<ClientCitation>? Citations { get; }
 
         /// <summary>
+        /// Adds an attachment to the collection of attachments for the final message.
+        /// </summary>
+        /// <param name="attachment">The attachment to add. Must not be <see langword="null"/>.</param>
+        void AddAttachment(Attachment attachment);
+
+        /// <summary>
         /// Adds a citation for the response.
         /// </summary>
         /// <param name="citation"></param>

--- a/src/libraries/Builder/Microsoft.Agents.Builder/StreamingResponse.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/StreamingResponse.cs
@@ -535,6 +535,7 @@ namespace Microsoft.Agents.Builder
                 _userCanceled = false;
                 Message = "";
                 Citations = [];
+                Attachments = [];
                 SensitivityLabel = null;
                 EnableGeneratedByAILabel = false;
             }

--- a/src/libraries/Builder/Microsoft.Agents.Builder/StreamingResponse.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/StreamingResponse.cs
@@ -104,6 +104,11 @@ namespace Microsoft.Agents.Builder
         public SensitivityUsageInfo? SensitivityLabel { get; set; }
 
         /// <summary>
+        /// Attachments to be included in the final message.  This is only used for the final message, and not for intermediate messages.
+        /// </summary>
+        public List<Attachment>? Attachments { get; set; } = [];
+
+        /// <summary>
         /// The interval in milliseconds at which intermediate messages are sent.
         /// </summary>
         /// <remarks>
@@ -169,6 +174,16 @@ namespace Microsoft.Agents.Builder
 
             _context = turnContext;
             SetDefaults(turnContext);
+        }
+
+        /// <summary>
+        /// Adds an attachment to the collection of attachments for the final message.
+        /// </summary>
+        /// <param name="attachment">The attachment to add. Must not be <see langword="null"/>.</param>
+        public void AddAttachment(Attachment attachment)
+        {
+            Attachments ??= [];
+            Attachments.Add(attachment);
         }
 
         /// <summary>
@@ -462,6 +477,12 @@ namespace Microsoft.Agents.Builder
                 }
 
                 activity.Entities.Add(entity);
+            }
+
+            // Add Attachments if there are any
+            if (Attachments != null && Attachments.Count > 0)
+            {
+                activity.Attachments = Attachments;
             }
 
             return activity;

--- a/src/libraries/Builder/Microsoft.Agents.Builder/StreamingResponse.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/StreamingResponse.cs
@@ -482,7 +482,17 @@ namespace Microsoft.Agents.Builder
             // Add Attachments if there are any
             if (Attachments != null && Attachments.Count > 0)
             {
-                activity.Attachments = Attachments;
+                if (activity.Attachments == null)
+                {
+                    activity.Attachments = Attachments;
+                }
+                else if (!ReferenceEquals(activity.Attachments, Attachments))
+                {
+                    foreach (var attachment in Attachments)
+                    {
+                        activity.Attachments.Add(attachment);
+                    }
+                }
             }
 
             return activity;

--- a/src/libraries/Builder/Microsoft.Agents.Builder/StreamingResponse.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/StreamingResponse.cs
@@ -182,6 +182,8 @@ namespace Microsoft.Agents.Builder
         /// <param name="attachment">The attachment to add. Must not be <see langword="null"/>.</param>
         public void AddAttachment(Attachment attachment)
         {
+            AssertionHelpers.ThrowIfNull(attachment, nameof(attachment));
+
             Attachments ??= [];
             Attachments.Add(attachment);
         }
@@ -482,17 +484,28 @@ namespace Microsoft.Agents.Builder
             // Add Attachments if there are any
             if (Attachments != null && Attachments.Count > 0)
             {
-                if (activity.Attachments == null)
-                {
-                    activity.Attachments = Attachments;
-                }
-                else if (!ReferenceEquals(activity.Attachments, Attachments))
-                {
-                    foreach (var attachment in Attachments)
-                    {
-                        activity.Attachments.Add(attachment);
-                    }
-                }
+                if (activity.Attachments == null)
+
+                {
+
+                    activity.Attachments = Attachments;
+
+                }
+
+                else if (!ReferenceEquals(activity.Attachments, Attachments))
+
+                {
+
+                    foreach (var attachment in Attachments)
+
+                    {
+
+                        activity.Attachments.Add(attachment);
+
+                    }
+
+                }
+
             }
 
             return activity;

--- a/src/tests/Microsoft.Agents.Builder.Tests/StreamingResponseTests.cs
+++ b/src/tests/Microsoft.Agents.Builder.Tests/StreamingResponseTests.cs
@@ -424,6 +424,24 @@ namespace Microsoft.Agents.Builder.Tests
         }
 
         [Fact]
+        public async Task AddAttachment_IncludedInFinalMessage()
+        {
+            var responses = new List<IActivity>();
+            var adapter = CreateMockAdapter(responses);
+            var context = new TurnContext(adapter.Object, new Activity() { Type = ActivityTypes.Message, ChannelId = Channels.Test });
+            var attachment = new Attachment { ContentType = "text/plain", Name = "attachment.txt", Content = "hello" };
+
+            context.StreamingResponse.AddAttachment(attachment);
+            context.StreamingResponse.QueueTextChunk("with attachment");
+            await context.StreamingResponse.EndStreamAsync();
+
+            var finalActivity = responses.Last();
+            Assert.NotNull(finalActivity.Attachments);
+            Assert.Single(finalActivity.Attachments);
+            Assert.Same(attachment, finalActivity.Attachments[0]);
+        }
+
+        [Fact]
         public async Task SensitivityLabel_SetOnResponse_IncludedInFinalMessageAIEntity()
         {
             var responses = new List<IActivity>();
@@ -859,6 +877,7 @@ namespace Microsoft.Agents.Builder.Tests
             context.StreamingResponse.EnableGeneratedByAILabel = true;
             context.StreamingResponse.SensitivityLabel = new SensitivityUsageInfo { Name = "Sensitive" };
             context.StreamingResponse.AddCitation(new ClientCitation { Position = 1 });
+            context.StreamingResponse.AddAttachment(new Attachment { ContentType = "text/plain", Name = "attachment.txt", Content = "payload" });
             context.StreamingResponse.QueueTextChunk("some text");
             await context.StreamingResponse.EndStreamAsync();
 
@@ -871,6 +890,11 @@ namespace Microsoft.Agents.Builder.Tests
             Assert.Empty(context.StreamingResponse.Citations);
             Assert.Null(context.StreamingResponse.StreamId);
             Assert.Equal(0, context.StreamingResponse.UpdatesSent());
+
+            context.StreamingResponse.QueueTextChunk("after reset");
+            await context.StreamingResponse.EndStreamAsync();
+            var postResetFinal = responses.Last();
+            Assert.True(postResetFinal.Attachments == null || postResetFinal.Attachments.Count == 0);
         }
 
         [Fact]

--- a/src/tests/Microsoft.Agents.Builder.Tests/StreamingResponseTests.cs
+++ b/src/tests/Microsoft.Agents.Builder.Tests/StreamingResponseTests.cs
@@ -894,7 +894,7 @@ namespace Microsoft.Agents.Builder.Tests
             context.StreamingResponse.QueueTextChunk("after reset");
             await context.StreamingResponse.EndStreamAsync();
             var postResetFinal = responses.Last();
-            Assert.True(postResetFinal.Attachments == null || postResetFinal.Attachments.Count == 0);
+            Assert.True(postResetFinal.Attachments?.Count == 0 ?? true);
         }
 
         [Fact]

--- a/src/tests/Microsoft.Agents.Builder.Tests/StreamingResponseTests.cs
+++ b/src/tests/Microsoft.Agents.Builder.Tests/StreamingResponseTests.cs
@@ -894,7 +894,7 @@ namespace Microsoft.Agents.Builder.Tests
             context.StreamingResponse.QueueTextChunk("after reset");
             await context.StreamingResponse.EndStreamAsync();
             var postResetFinal = responses.Last();
-            Assert.True(postResetFinal.Attachments?.Count == 0 ?? true);
+            Assert.True(postResetFinal.Attachments == null || postResetFinal.Attachments.Count == 0);
         }
 
         [Fact]


### PR DESCRIPTION
Introduced the ability to include attachments in the final message of a streaming response. Added a new `AddAttachment` method to the `IStreamingResponse` interface and implemented it in the `StreamingResponse` class. This method ensures attachments can be added to a collection and included in the final activity.

Added a new `Attachments` property to the `StreamingResponse` class to store the list of attachments. Updated the logic to include these attachments in the `activity` object when present.


This pull request introduces support for adding attachments to the final message in the streaming response workflow. It updates the `IStreamingResponse` interface and its implementation to allow attachments to be added and ensures they are included in the final activity message.

**Attachment support for final messages:**

* Added an `AddAttachment` method to the `IStreamingResponse` interface, allowing attachments to be added to the final message.
* Implemented an `Attachments` property in the `StreamingResponse` class to store attachments for the final message.
* Added the `AddAttachment` method implementation in `StreamingResponse`, ensuring attachments are properly added to the collection.
* Updated the `CreateFinalMessage` method to include any added attachments in the outgoing activity if present.