### PR TITLE
Definition for OneBranch pipeline

### DIFF
--- a/.azdo/OneBranch.PullRequest.yml
+++ b/.azdo/OneBranch.PullRequest.yml
@@ -1,0 +1,123 @@
+#################################################################################
+#                      OneBranch Pipelines - PR Build                           #
+# This pipeline was created by EasyStart from a sample located at:              #
+#   https://aka.ms/obpipelines/easystart/samples                                #
+# Documentation:  https://aka.ms/obpipelines                                    #
+# Yaml Schema:    https://aka.ms/obpipelines/yaml/schema                        #
+# Retail Tasks:   https://aka.ms/obpipelines/tasks                              #
+# Support:        https://aka.ms/onebranchsup                                   #
+#                                                                               #
+# NOTE: This definition lives in the microsoft/Agents-for-net repo. Because the #
+# shared build template (build-sign-package.yaml) lives in the                  #
+# Microsoft.Botframework.Builds repo, that repo is registered below under       #
+# resources.repositories (alias: builds) and the template is imported via       #
+# '...build-sign-package.yaml@builds' instead of '@self'.                       #
+#################################################################################
+
+trigger: none # https://aka.ms/obpipelines/triggers
+
+parameters: # parameters are shown up in ADO UI in a build queue time
+- name: 'debug'
+  displayName: 'Enable debug output'
+  type: boolean
+  default: false
+
+variables:
+  CDP_DEFINITION_BUILD_COUNT: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
+  MAJOR: 1
+  MINOR: 1
+  BUILD: 0
+  REVISION: $[counter(variables['REVISION'], 20)]
+  system.debug: ${{ parameters.debug }}
+  ENABLE_PRS_DELAYSIGN: 0
+  ROOT: $(Build.SourcesDirectory)
+  REPOROOTDIRECTORY: $(Build.SourcesDirectory)
+  OUTPUTROOT: $(REPOROOTDIRECTORY)\bin
+  NUGET_XMLDOC_MODE: none
+  EnableLocalization: true
+  ProjectFolder : "agnts"
+  system_accesstoken: $(System.AccessToken)
+
+  WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2019/vse2022:latest' # https://aka.ms/obpipelines/containers
+
+resources:
+  repositories:
+    - repository: templates
+      type: git
+      name: OneBranch.Pipelines/GovernedTemplates
+      ref: refs/heads/main
+    # The Microsoft.Botframework.Builds repo hosts the shared build-sign-package.yaml
+    # template. It is hosted on GitHub Enterprise (microsoft.ghe.com/bic), so it is
+    # referenced with type 'githubenterprise'. Update 'endpoint' to the service
+    # connection configured for microsoft.ghe.com if it differs.
+    - repository: builds
+      type: githubenterprise
+      endpoint: MicrosoftGHE # <-- service connection to microsoft.ghe.com (update if named differently)
+      name: bic/Microsoft.Botframework.Builds
+      ref: refs/heads/main
+
+extends:
+  template: v2/OneBranch.NonOfficial.CrossPlat.yml@templates # https://aka.ms/obpipelines/templates
+  parameters:
+    globalSdl: # https://aka.ms/obpipelines/sdl
+      tsa:
+        enabled: false # onebranch publish all sdl results to TSA. If TSA is disabled all SDL tools will forced into 'break' build mode.
+      # credscan:
+      #   suppressionsFile: $(Build.SourcesDirectory)\.config\CredScanSuppressions.json
+      binskim:
+        break: true # always break the build on binskim issues. You can disable it by setting to 'false'
+      policheck:
+        break: true # always break the build on policheck issues. You can disable it by setting to 'false'
+      # suppression:
+      #   suppressionFile: $(Build.SourcesDirectory)\.gdn\global.gdnsuppress
+
+    stages:
+    - stage: Build_Assets
+      jobs:
+      - job: Debug
+        pool:
+          type: windows  # read more about custom job pool types at https://aka.ms/obpipelines/yaml/jobs
+
+        variables: # More settings at https://aka.ms/obpipelines/yaml/jobs
+          ob_outputDirectory: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT' # this directory is uploaded to pipeline artifacts, reddog and cloudvault. More info at https://aka.ms/obpipelines/artifacts
+          ob_sdl_binskim_break: true # https://aka.ms/obpipelines/sdl
+          ob_git_fetchDepth: -1 # https://aka.ms/obpipelines/git
+          # ob_sdl_suppression_suppressionFile: $(Build.SourcesDirectory)\.gdn\build.nonofficial.gdnsuppress
+
+        steps:
+          - checkout: self
+            displayName: 'Checkout self to s/$(ProjectFolder)'
+            path: s/$(ProjectFolder)
+            #env:
+            #  ob_restore_phase: true # # Steps decorated with this env variable will be run with network. All these steps are hoisted to the beginning of the build
+
+          - task: NuGetAuthenticate@1
+
+          - script: dotnet tool restore
+            displayName: Dotnet tools restore
+            env:
+              ob_restore_phase: true # # Steps decorated with this env variable will be run with network. All these steps are hoisted to the beginning of the build
+
+          - template: Agents-dotnet/.pipelines/templates/build-sign-package.yaml@builds
+            parameters:
+              configuration: debug
+              rootProjectFolder: $(ProjectFolder)
+              isOfficialBuild: false
+              OutputDirectoryRoot: '$(OUTPUTROOT)'
+
+          - task: CopyFiles@2
+            displayName: "Copy Files for 'Publish packages (Debug)' publish task"
+            inputs:
+              SourceFolder: '$(ProjectFolder)\bin'
+              Contents: '**/*.nupkg'
+              FlattenFolders : true
+              TargetFolder: $(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT/packagesDebug
+            condition: always()
+
+          - task: CopyFiles@2
+            displayName: "Copy Files for 'Publish diagnostic build logs (Debug)' publish task"
+            inputs:
+              SourceFolder: 'bin\logs'
+              Contents: '**'
+              TargetFolder: $(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT/diagnosticLogs
+            condition: always()


### PR DESCRIPTION
This pull request introduces a new OneBranch pipeline configuration for PR builds by adding a `.azdo/OneBranch.PullRequest.yml` file. The pipeline sets up a non-triggered, parameterized Azure DevOps build process using shared templates and resources, and includes build, packaging, and artifact publishing steps.

The most important changes are:

**Pipeline setup and configuration:**
* Added `.azdo/OneBranch.PullRequest.yml` to define a new OneBranch pipeline for PR builds, including metadata, parameters (such as `debug`), and variables for build versioning and output paths.
* Configured pipeline resources to use governed templates from `OneBranch.Pipelines` and a shared build template from `Microsoft.Botframework.Builds` on GitHub Enterprise.

**Build and artifact stages:**
* Defined the `Build_Assets` stage with a `Debug` job that checks out the repository, restores .NET tools, runs the shared build-sign-package template, and copies build outputs and logs to artifact staging directories.

**Security and compliance:**
* Enabled SDL tools such as BinSkim and PoliCheck to break the build on issues, with TSA publishing disabled for non-official builds.