### PR TITLE
An error during OAuth could result in the OnSigninFailure not getting called

### DIFF
--- a/src/libraries/Builder/Microsoft.Agents.Builder/App/UserAuth/UserAuthorization.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/App/UserAuth/UserAuthorization.cs
@@ -272,7 +272,6 @@ namespace Microsoft.Agents.Builder.App.UserAuth
                                 }
                             }, cancellationToken).ConfigureAwait(false);
                         }
-                        return false;
                     }
 
                     if (_userSignInFailureHandler != null)


### PR DESCRIPTION
Fixes #858 