### PR TITLE
Updating Windows container image

### DIFF
--- a/.azdo/OneBranch.Nightly.yml
+++ b/.azdo/OneBranch.Nightly.yml
@@ -42,7 +42,7 @@ variables:
   EnableLocalization: true
   system_accesstoken: $(System.AccessToken)  
 
-  WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2019/vse2022:latest' # https://aka.ms/obpipelines/containers
+  WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2022/vse2022:latest' # https://aka.ms/obpipelines/containers
 
 resources:
   repositories: 


### PR DESCRIPTION
This pull request updates the Windows container image used in the `.azdo/OneBranch.Nightly.yml` pipeline. The change switches the build environment from Windows Server 2019 to Windows Server 2022.

Build environment update:
* Updated the `WindowsContainerImage` variable to use the `ltsc2022` tag instead of `ltsc2019`, ensuring the pipeline runs on a more recent version of Windows Server.