### PR TITLE
docs(ci): reduce sequence-diagram audit churn (anti-reword + canonical terms)

### DIFF
--- a/.github/prompts/verify-sequence-diagrams.prompt.md
+++ b/.github/prompts/verify-sequence-diagrams.prompt.md
@@ -66,7 +66,7 @@ If the answer is no, leave it exactly as-is — even if you would have written i
 
 ## Canonical terminology (use these exact terms; do not reintroduce the alternatives)
 
-- The SSE transport for `DeliveryMode == Stream` is **`DeliveryMode.Stream` SSE**. It is
+- The SSE transport for `DeliveryModes.Stream` (i.e., `IActivity.DeliveryMode == DeliveryModes.Stream`) is **`DeliveryModes.Stream` SSE**. It is
   **not** "A2A" / "Agent-to-Agent" — that is a separate protocol. Never label the streaming
   delivery path as A2A.
 

--- a/.github/prompts/verify-sequence-diagrams.prompt.md
+++ b/.github/prompts/verify-sequence-diagrams.prompt.md
@@ -39,6 +39,37 @@ For each `docs/*sequence-diagram.md` file:
 5. Keep the Mermaid syntax valid. Do not introduce new participants or steps that are not
    grounded in the code.
 
+## What NOT to change (avoid audit churn)
+
+These diagrams were themselves authored by an AI pass. A second AI pass will always find
+*different-but-equally-valid* ways to model the same correct code. Rewriting those is churn,
+not a fix, and it re-opens the same issue every week. **Only edit when the code contradicts a
+stated fact — never merely because you would have phrased or modeled it differently.**
+
+Specifically, do **not**:
+
+- **Reword** prose, notes, or labels that are already accurate (e.g. renaming a participant
+  alias `Class` → `Type`, or a note from "returns true" to "write completes" when both
+  describe the same behavior). A synonym is not a discrepancy.
+- **Re-model at a different granularity** when the existing abstraction is already correct —
+  e.g. splitting one `Assembly` participant into separate `SIA`/`EIA` participants, or
+  collapsing two into one. Only change participant structure if the current one asserts a
+  call/relationship the code does not have.
+- **Swap one valid example for another** (e.g. changing which real converter class is shown in
+  a "usage example") unless the class currently shown **no longer exists** or is no longer
+  valid for that scenario.
+- **Add optional detail** the diagram deliberately omits. A conceptual diagram that abstracts
+  away exact method names is not "wrong" for doing so.
+
+Ask yourself: *"Can I point to a line of code that this diagram states is true but is not?"*
+If the answer is no, leave it exactly as-is — even if you would have written it differently.
+
+## Canonical terminology (use these exact terms; do not reintroduce the alternatives)
+
+- The SSE transport for `DeliveryMode == Stream` is **`DeliveryMode.Stream` SSE**. It is
+  **not** "A2A" / "Agent-to-Agent" — that is a separate protocol. Never label the streaming
+  delivery path as A2A.
+
 ## Domain notes (apply when judging call ordering)
 
 - **`InvokeResponse` timing:** An agent may send an `InvokeResponse` at any point during a


### PR DESCRIPTION
## Why

The weekly `verify-sequence-diagrams` audit keeps re-flagging Mermaid diagrams that are **already correct**. Because the diagrams were originally authored by an AI pass, a second AI audit pass finds *different-but-equally-valid* ways to model the same code and "corrects" them — churn, not fixes (see the interpretation-only edits in #921: `Class`→`Type`, `Assembly` split into `SIA`/`EIA`, swapped-but-valid converter examples, `A2A`↔`SSE` labels).

## Change

Doc/CI-only edit to `.github/prompts/verify-sequence-diagrams.prompt.md`:

- **`What NOT to change (avoid audit churn)`** — forbids rewording accurate labels, re-modeling participant granularity, swapping still-valid examples, and adding deliberately-omitted detail unless the **code contradicts** the diagram. Gated by: *"Can I point to a line the diagram states is true but isn't?"*
- **`Canonical terminology`** — pins `DeliveryMode.Stream` SSE and forbids reintroducing the `A2A` label, so generation and audit passes agree on wording.

## Effect

- **Real drift is still flagged** (e.g. removed `UserSignInFailureHandler`, renamed calls, moved paths).
- **Interpretation churn is suppressed**, so the audit stops re-opening the same non-issues weekly.

