### PR TITLE
Update WindowsContainerImage to use ltsc2022 version

### DIFF
--- a/.azdo/OneBranch.PullRequest.yml
+++ b/.azdo/OneBranch.PullRequest.yml
@@ -34,7 +34,7 @@ variables:
   EnableLocalization: true
   system_accesstoken: $(System.AccessToken)
 
-  WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2019/vse2022:latest' # https://aka.ms/obpipelines/containers
+  WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2022/vse2022:latest' # https://aka.ms/obpipelines/containers
 
 resources:
   repositories:


### PR DESCRIPTION
This pull request updates the build pipeline to use a newer Windows container image. The only change is updating the `WindowsContainerImage` variable in the `.azdo/OneBranch.PullRequest.yml` file to use the `ltsc2022` version instead of `ltsc2019`.