### PR TITLE
Add WindowsHostVersion parameters for disk size and version in PR pip…

### DIFF
--- a/.azdo/OneBranch.PullRequest.yml
+++ b/.azdo/OneBranch.PullRequest.yml
@@ -52,6 +52,9 @@ extends:
   template: v2/OneBranch.NonOfficial.CrossPlat.yml@templates
   parameters:
     featureFlags:
+        WindowsHostVersion:
+          Disk: Large
+          Version: 2022
         networkisolation:
           policy: GitHub,Permissive
     globalSdl:


### PR DESCRIPTION
This pull request makes a small configuration update to the Azure DevOps pipeline YAML file. The main change is the addition of a Windows host configuration under `featureFlags`, specifying a larger disk size and Windows Server 2022 as the host version.

* Pipeline configuration:
  * [`.azdo/OneBranch.PullRequest.yml`](diffhunk://#diff-bef7d46a7ac38544e4d4e253e02f1467523dc0d270b31db82c6fee096d358726R55-R57): Added `WindowsHostVersion` feature flag with `Disk: Large` and `Version: 2022` to improve the build environment for Windows jobs.…eline