### PR TITLE
Add WindowsHostVersion parameters and disable CI builds for PR pipeline

### DIFF
--- a/.azdo/OneBranch.Nightly.yml
+++ b/.azdo/OneBranch.Nightly.yml
@@ -59,6 +59,9 @@ resources:
 extends:
   template: v2/OneBranch.Official.CrossPlat.yml@templates # https://aka.ms/obpipelines/templates
   parameters:
+    WindowsHostVersion:
+      Disk: Large
+      Version: 2022
     cloudvault: # https://aka.ms/obpipelines/cloudvault
       enabled: false
     globalSdl: # https://aka.ms/obpipelines/sdl

--- a/.azdo/OneBranch.PullRequest.yml
+++ b/.azdo/OneBranch.PullRequest.yml
@@ -9,7 +9,7 @@
 #                                                                               #
 #################################################################################
 
-trigger: none # https://aka.ms/obpipelines/triggers - Disable continue integration builds for this pipeline.  PR builds will be triggered by the PR trigger below.
+trigger: none # https://aka.ms/obpipelines/triggers - Disable continuous integration builds for this pipeline. PR builds will be triggered by the PR trigger below.
 pr:
 - main
 - rel/*

--- a/.azdo/OneBranch.PullRequest.yml
+++ b/.azdo/OneBranch.PullRequest.yml
@@ -9,6 +9,7 @@
 #                                                                               #
 #################################################################################
 
+trigger: none # https://aka.ms/obpipelines/triggers - Disable continue integration builds for this pipeline.  PR builds will be triggered by the PR trigger below.
 pr:
 - main
 - rel/*


### PR DESCRIPTION
This pull request makes configuration improvements to the Azure DevOps pipeline YAML files by updating resource specifications and adjusting pipeline triggers.

Pipeline configuration updates:

* Disabled continuous integration builds in `.azdo/OneBranch.PullRequest.yml` by setting `trigger: none`, ensuring that only pull request builds are triggered.

Resource specification updates:

* Added a `WindowsHostVersion` parameter in `.azdo/OneBranch.Nightly.yml` with `Disk: Large` and `Version: 2022` to explicitly specify the Windows host environment for builds.