### PR TITLE
Add blank line for improved readability in OneBranch.PullRequest.yml

### DIFF
--- a/.azdo/OneBranch.PullRequest.yml
+++ b/.azdo/OneBranch.PullRequest.yml
@@ -9,7 +9,7 @@
 #                                                                               #
 #################################################################################
 
-# trigger: none # https://aka.ms/obpipelines/triggers - Disable continuous integration builds for this pipeline. PR builds will be triggered by the PR trigger below.
+trigger: none # https://aka.ms/obpipelines/triggers - Disable continuous integration builds for this pipeline. PR builds will be triggered by the PR trigger below.
 
 pr:
   autoCancel: true # https://aka.ms/obpipelines/pr-triggers

--- a/.azdo/OneBranch.PullRequest.yml
+++ b/.azdo/OneBranch.PullRequest.yml
@@ -9,7 +9,7 @@
 #                                                                               #
 #################################################################################
 
-trigger: none # https://aka.ms/obpipelines/triggers - Disable continuous integration builds for this pipeline. PR builds will be triggered by the PR trigger below.
+# trigger: none # https://aka.ms/obpipelines/triggers - Disable continuous integration builds for this pipeline. PR builds will be triggered by the PR trigger below.
 
 pr:
 - main

--- a/.azdo/OneBranch.PullRequest.yml
+++ b/.azdo/OneBranch.PullRequest.yml
@@ -12,8 +12,11 @@
 # trigger: none # https://aka.ms/obpipelines/triggers - Disable continuous integration builds for this pipeline. PR builds will be triggered by the PR trigger below.
 
 pr:
-- main
-- rel/*
+  autoCancel: true # https://aka.ms/obpipelines/pr-triggers
+  branches:
+    include:
+      - main
+      - rel/*
 
 parameters: # parameters are shown up in ADO UI in a build queue time
 - name: 'debug'

--- a/.azdo/OneBranch.PullRequest.yml
+++ b/.azdo/OneBranch.PullRequest.yml
@@ -10,6 +10,7 @@
 #################################################################################
 
 trigger: none # https://aka.ms/obpipelines/triggers - Disable continuous integration builds for this pipeline. PR builds will be triggered by the PR trigger below.
+
 pr:
 - main
 - rel/*


### PR DESCRIPTION
This pull request makes a small change to the `.azdo/OneBranch.PullRequest.yml` pipeline configuration. The change enables pull request builds to be triggered on the `main` branch and any branch matching `rel/*`.