### PR TITLE
Add release category and environment variable for nightly build process

### DIFF
--- a/.azdo/OneBranch.Nightly.yml
+++ b/.azdo/OneBranch.Nightly.yml
@@ -59,9 +59,12 @@ resources:
 extends:
   template: v2/OneBranch.Official.CrossPlat.yml@templates # https://aka.ms/obpipelines/templates
   parameters:
-    WindowsHostVersion:
-      Disk: Large
-      Version: 2022
+    featureFlags:
+        WindowsHostVersion:
+          Disk: Large
+          Version: 2022
+        networkisolation:
+          policy: GitHub,Permissive
     release:
       category: NonAzure      
     cloudvault: # https://aka.ms/obpipelines/cloudvault

--- a/.azdo/OneBranch.Nightly.yml
+++ b/.azdo/OneBranch.Nightly.yml
@@ -62,6 +62,8 @@ extends:
     WindowsHostVersion:
       Disk: Large
       Version: 2022
+    release:
+      category: NonAzure      
     cloudvault: # https://aka.ms/obpipelines/cloudvault
       enabled: false
     globalSdl: # https://aka.ms/obpipelines/sdl
@@ -81,9 +83,10 @@ extends:
         break: true # always break the build on policheck issues. You can disable it by setting to 'false'
       suppression:
          suppressionFile: $(Build.SourcesDirectory)\.gdn\global.gdnsuppress
-
     stages:
     - stage: build
+      variables:
+        ob_release_environment: PPE # Nightly Release process    
       jobs:
       - job: Release
         pool:


### PR DESCRIPTION
This pull request updates the `.azdo/OneBranch.Nightly.yml` pipeline configuration to improve release categorization and environment variable management for nightly builds. The main changes are:

**Release Process Improvements:**

* Added a `release` section under the pipeline host configuration to categorize the release as `NonAzure`.
* Introduced a pipeline variable `ob_release_environment` set to `PPE` to specify the environment for the nightly release process.