### PR TITLE
Add Graph client factory helpers to Teams turn context and app-only overloads

### DIFF
--- a/src/libraries/Builder/Microsoft.Agents.Builder/App/AgentApplication.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/App/AgentApplication.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.Agents.Authentication;
 using Microsoft.Agents.Builder.App.AdaptiveCards;
 using Microsoft.Agents.Builder.App.UserAuth;
 using Microsoft.Agents.Builder.Errors;
@@ -763,6 +764,10 @@ namespace Microsoft.Agents.Builder.App
             if (_userAuth != null)
             {
                 turnContext.Services.Set<UserAuthorization>(_userAuth);
+            }
+            if (Options.Connections != null)
+            {
+                turnContext.Services.Set<IConnections>(Options.Connections);
             }
             turnContext.Services.Set<Proactive.Proactive>(Proactive);
             turnContext.Services.Set<AdaptiveCard>(AdaptiveCards);

--- a/src/libraries/Extensions/Microsoft.Agents.Extensions.MSTeams/GraphClientFactory.cs
+++ b/src/libraries/Extensions/Microsoft.Agents.Extensions.MSTeams/GraphClientFactory.cs
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Agents.Builder;
+using Microsoft.Agents.Builder.App.UserAuth;
+using Microsoft.Agents.Core;
+using Microsoft.Graph;
+using Microsoft.Kiota.Abstractions;
+using Microsoft.Kiota.Abstractions.Authentication;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Agents.Extensions.MSTeams;
+
+/// <summary>
+/// Shared factory used by <see cref="TeamsAgentExtension"/> and <see cref="TeamsTurnContext"/> to build
+/// <see cref="GraphServiceClient"/> instances, keeping the token-provider and scope-derivation logic in a single place.
+/// </summary>
+internal static class GraphClientFactory
+{
+    /// <summary>
+    /// Creates a <see cref="GraphServiceClient"/> that acquires a delegated (user) token via
+    /// <see cref="UserAuthorization"/> for the current turn.
+    /// </summary>
+    internal static GraphServiceClient CreateUserGraphClient(UserAuthorization userAuthorization, ITurnContext turnContext, string handlerName, string graphBaseUrl)
+    {
+        AssertionHelpers.ThrowIfNull(userAuthorization, nameof(userAuthorization));
+        AssertionHelpers.ThrowIfNull(turnContext, nameof(turnContext));
+        AssertionHelpers.ThrowIfNullOrEmpty(graphBaseUrl, nameof(graphBaseUrl));
+
+        return new GraphServiceClient(new UserTokenProvider(userAuthorization, turnContext, handlerName), graphBaseUrl);
+    }
+
+    /// <summary>
+    /// Creates a <see cref="GraphServiceClient"/> that acquires an app-only (application) token from the supplied
+    /// token connection.
+    /// </summary>
+    internal static GraphServiceClient CreateAppGraphClient(Microsoft.Agents.Authentication.IAccessTokenProvider tokenProvider, string graphBaseUrl)
+    {
+        AssertionHelpers.ThrowIfNull(tokenProvider, nameof(tokenProvider));
+        AssertionHelpers.ThrowIfNullOrEmpty(graphBaseUrl, nameof(graphBaseUrl));
+
+        // Derive the resource and the app-only ".default" scope from the Graph base URL so national
+        // clouds (e.g. graph.microsoft.us) are honored.
+        var graphUri = new Uri(graphBaseUrl);
+        var resourceUrl = $"{graphUri.Scheme}://{graphUri.Host}";
+        var scopes = new List<string> { $"{resourceUrl}/.default" };
+
+        return new GraphServiceClient(new AppTokenProvider(tokenProvider, resourceUrl, scopes), graphBaseUrl);
+    }
+}
+
+class UserTokenProvider(UserAuthorization userAuthorization, ITurnContext turnContext, string handlerName) : IAuthenticationProvider
+{
+    public async Task AuthenticateRequestAsync(RequestInformation request, Dictionary<string, object>? additionalAuthenticationContext = null, CancellationToken cancellationToken = default)
+    {
+        var token = await userAuthorization.GetTurnTokenAsync(turnContext, handlerName, cancellationToken: cancellationToken).ConfigureAwait(false);
+        if (token != null)
+        {
+            request.Headers["Authorization"] = [$"Bearer {token}"];
+        }
+    }
+}
+
+class AppTokenProvider(Microsoft.Agents.Authentication.IAccessTokenProvider tokenProvider, string resourceUrl, IList<string> scopes) : IAuthenticationProvider
+{
+    public async Task AuthenticateRequestAsync(RequestInformation request, Dictionary<string, object>? additionalAuthenticationContext = null, CancellationToken cancellationToken = default)
+    {
+        var token = await tokenProvider.GetAccessTokenAsync(resourceUrl, scopes).ConfigureAwait(false);
+        if (!string.IsNullOrEmpty(token))
+        {
+            request.Headers["Authorization"] = [$"Bearer {token}"];
+        }
+    }
+}

--- a/src/libraries/Extensions/Microsoft.Agents.Extensions.MSTeams/GraphClientFactory.cs
+++ b/src/libraries/Extensions/Microsoft.Agents.Extensions.MSTeams/GraphClientFactory.cs
@@ -68,7 +68,12 @@ class AppTokenProvider(Microsoft.Agents.Authentication.IAccessTokenProvider toke
 {
     public async Task AuthenticateRequestAsync(RequestInformation request, Dictionary<string, object>? additionalAuthenticationContext = null, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         var token = await tokenProvider.GetAccessTokenAsync(resourceUrl, scopes).ConfigureAwait(false);
+
+        cancellationToken.ThrowIfCancellationRequested();
+
         if (!string.IsNullOrEmpty(token))
         {
             request.Headers["Authorization"] = [$"Bearer {token}"];

--- a/src/libraries/Extensions/Microsoft.Agents.Extensions.MSTeams/ITeamsTurnContext.cs
+++ b/src/libraries/Extensions/Microsoft.Agents.Extensions.MSTeams/ITeamsTurnContext.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Agents.Builder;
 using Microsoft.Agents.Core.Models;
+using Microsoft.Graph;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -37,4 +38,37 @@ public interface ITeamsTurnContext : ITurnContext
     /// <returns>A task that represents the asynchronous send operation. The task result contains an array of
     /// ResourceResponse objects for each sent activity.</returns>
     Task<ResourceResponse[]> SendTargetedActivitiesAsync(IActivity[] activities, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Creates a <see cref="GraphServiceClient"/> authenticated with a delegated (user) token for the signed-in user
+    /// of the current turn.
+    /// </summary>
+    /// <remarks>Requires that user authorization is configured for the agent and the user is signed in. The returned
+    /// client makes requests to Microsoft Graph on behalf of the user.</remarks>
+    /// <param name="handlerName">The name of the sign-in handler to use for token acquisition. If null, the default handler is used.</param>
+    /// <param name="graphBaseUrl">The base URL for the Microsoft Graph API. Defaults to "https://graph.microsoft.com/v1.0".</param>
+    /// <returns>A <see cref="GraphServiceClient"/> authenticated with a delegated user token.</returns>
+    GraphServiceClient GetGraphClient(string handlerName = null, string graphBaseUrl = "https://graph.microsoft.com/v1.0");
+
+    /// <summary>
+    /// Creates a <see cref="GraphServiceClient"/> authenticated with an <b>app-only</b> (application) token, using the
+    /// token connection resolved for the current turn.
+    /// </summary>
+    /// <remarks>Unlike <see cref="GetGraphClient(string, string)"/>, this method uses application permissions, so the
+    /// caller must specify the target resource in the request path (for example <c>client.Users["{userId}"]...</c>).
+    /// No configuration beyond the agent's existing token connection is required.</remarks>
+    /// <param name="graphBaseUrl">The base URL for the Microsoft Graph API. Defaults to "https://graph.microsoft.com/v1.0".</param>
+    /// <returns>A <see cref="GraphServiceClient"/> authenticated with an app-only token.</returns>
+    GraphServiceClient GetAppGraphClient(string graphBaseUrl = "https://graph.microsoft.com/v1.0");
+
+    /// <summary>
+    /// Creates a <see cref="GraphServiceClient"/> authenticated with an <b>app-only</b> (application) token, using the
+    /// named token connection.
+    /// </summary>
+    /// <remarks>The returned client uses application permissions, so the caller must specify the target resource in
+    /// the request path (for example <c>client.Users["{userId}"]...</c>).</remarks>
+    /// <param name="connectionName">The name of the token connection whose credentials acquire the app-only token. Cannot be null or empty.</param>
+    /// <param name="graphBaseUrl">The base URL for the Microsoft Graph API. Defaults to "https://graph.microsoft.com/v1.0".</param>
+    /// <returns>A <see cref="GraphServiceClient"/> authenticated with an app-only token.</returns>
+    GraphServiceClient GetAppGraphClientForConnection(string connectionName, string graphBaseUrl = "https://graph.microsoft.com/v1.0");
 }

--- a/src/libraries/Extensions/Microsoft.Agents.Extensions.MSTeams/TeamsAgentExtension.cs
+++ b/src/libraries/Extensions/Microsoft.Agents.Extensions.MSTeams/TeamsAgentExtension.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Agents.Builder;
 using Microsoft.Agents.Builder.App;
+using Microsoft.Agents.Authentication;
 using Microsoft.Agents.Core;
 using Microsoft.Agents.Core.Models;
 using Microsoft.Agents.Core.Serialization;
@@ -136,7 +137,63 @@ public class TeamsAgentExtension : AgentExtension
     public GraphServiceClient GetGraphClient(ITurnContext turnContext, string handlerName = null, string graphBaseUrl = "https://graph.microsoft.com/v1.0")
     {
         AssertionHelpers.ThrowIfNull(turnContext, nameof(turnContext));
-        return new GraphServiceClient(new TokenProvider(_agentApplication, turnContext, handlerName), graphBaseUrl);
+        return GraphClientFactory.CreateUserGraphClient(_agentApplication.UserAuthorization, turnContext, handlerName, graphBaseUrl);
+    }
+
+    /// <summary>
+    /// Creates a new instance of the GraphServiceClient for accessing Microsoft Graph APIs using an
+    /// <b>app-only</b> (application) token from the agent's configured token connection.
+    /// </summary>
+    /// <remarks>
+    /// Unlike <see cref="GetGraphClient(ITurnContext, string, string)"/>, which acquires a token for the
+    /// signed-in user, this method uses the credentials of the token connection resolved for the current turn
+    /// (via <see cref="IConnections.GetTokenProvider(System.Security.Claims.ClaimsIdentity, IActivity)"/>).
+    /// The returned client is authenticated with application permissions, so the caller must specify the
+    /// target resource in the request path (for example <c>client.Users["{userId}"]...</c>). No additional
+    /// configuration beyond the existing token connection is required.
+    /// </remarks>
+    /// <param name="turnContext">The turn context. Its <see cref="ITurnContext.Identity"/> and
+    /// <see cref="ITurnContext.Activity"/> are used to resolve the connection. Cannot be null.</param>
+    /// <param name="graphBaseUrl">The base URL for the Microsoft Graph API. Defaults to "https://graph.microsoft.com/v1.0".</param>
+    /// <returns>A GraphServiceClient instance authenticated with an app-only token.</returns>
+    public GraphServiceClient GetAppGraphClient(ITurnContext turnContext, string graphBaseUrl = "https://graph.microsoft.com/v1.0")
+    {
+        AssertionHelpers.ThrowIfNull(turnContext, nameof(turnContext));
+        var tokenProvider = GetConnections().GetTokenProvider(turnContext.Identity, turnContext.Activity);
+        return GraphClientFactory.CreateAppGraphClient(tokenProvider, graphBaseUrl);
+    }
+
+    /// <summary>
+    /// Creates a new instance of the GraphServiceClient for accessing Microsoft Graph APIs using an
+    /// <b>app-only</b> (application) token from the named token connection.
+    /// </summary>
+    /// <remarks>
+    /// This overload uses the credentials of the token connection identified by <paramref name="connectionName"/>
+    /// rather than resolving the connection from the current turn, so it does not require a turn context. The
+    /// returned client is authenticated with application permissions, so the caller must specify the target
+    /// resource in the request path (for example <c>client.Users["{userId}"]...</c>). No additional configuration
+    /// beyond the named token connection is required.
+    /// </remarks>
+    /// <param name="connectionName">The name of the token connection whose credentials are used to acquire the app-only token. Cannot be null or empty.</param>
+    /// <param name="graphBaseUrl">The base URL for the Microsoft Graph API. Defaults to "https://graph.microsoft.com/v1.0".</param>
+    /// <returns>A GraphServiceClient instance authenticated with an app-only token.</returns>
+    public GraphServiceClient GetAppGraphClientForConnection(string connectionName, string graphBaseUrl = "https://graph.microsoft.com/v1.0")
+    {
+        AssertionHelpers.ThrowIfNullOrEmpty(connectionName, nameof(connectionName));
+        var tokenProvider = GetConnections().GetConnection(connectionName);
+        return GraphClientFactory.CreateAppGraphClient(tokenProvider, graphBaseUrl);
+    }
+
+    private IConnections GetConnections()
+    {
+        var connections = _agentApplication.Options.Connections;
+        if (connections == null)
+        {
+            throw new System.InvalidOperationException(
+                "IConnections is not configured on the AgentApplication. An app-only Graph client requires a configured token connection.");
+        }
+
+        return connections;
     }
 
     internal static Task SetResponse(ITurnContext context, object result = null, int status = 200)
@@ -148,17 +205,5 @@ public class TeamsAgentExtension : AgentExtension
         }
 
         return Task.CompletedTask;
-    }
-}
-
-class TokenProvider(AgentApplication agentApplication, ITurnContext turnContext, string handlerName) : IAuthenticationProvider
-{
-    public async Task AuthenticateRequestAsync(RequestInformation request, Dictionary<string, object>? additionalAuthenticationContext = null, CancellationToken cancellationToken = default)
-    {
-        var token = await agentApplication.UserAuthorization.GetTurnTokenAsync(turnContext, handlerName, cancellationToken: cancellationToken).ConfigureAwait(false);
-        if (token != null)
-        {
-            request.Headers["Authorization"] = [$"Bearer {token}"];
-        }
     }
 }

--- a/src/libraries/Extensions/Microsoft.Agents.Extensions.MSTeams/TeamsTurnContext.cs
+++ b/src/libraries/Extensions/Microsoft.Agents.Extensions.MSTeams/TeamsTurnContext.cs
@@ -1,8 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.Agents.Authentication;
 using Microsoft.Agents.Builder;
+using Microsoft.Agents.Builder.App.UserAuth;
+using Microsoft.Agents.Core;
 using Microsoft.Agents.Core.Models;
+using Microsoft.Graph;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -34,5 +39,50 @@ public class TeamsTurnContext : TurnContextWrapper, ITeamsTurnContext
         }
 
         return SendActivitiesAsync([.. clonedActivities], cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public GraphServiceClient GetGraphClient(string handlerName = null, string graphBaseUrl = "https://graph.microsoft.com/v1.0")
+    {
+        return GraphClientFactory.CreateUserGraphClient(GetUserAuthorization(), this, handlerName, graphBaseUrl);
+    }
+
+    /// <inheritdoc/>
+    public GraphServiceClient GetAppGraphClient(string graphBaseUrl = "https://graph.microsoft.com/v1.0")
+    {
+        var tokenProvider = GetConnections().GetTokenProvider(Identity, Activity);
+        return GraphClientFactory.CreateAppGraphClient(tokenProvider, graphBaseUrl);
+    }
+
+    /// <inheritdoc/>
+    public GraphServiceClient GetAppGraphClientForConnection(string connectionName, string graphBaseUrl = "https://graph.microsoft.com/v1.0")
+    {
+        AssertionHelpers.ThrowIfNullOrEmpty(connectionName, nameof(connectionName));
+        var tokenProvider = GetConnections().GetConnection(connectionName);
+        return GraphClientFactory.CreateAppGraphClient(tokenProvider, graphBaseUrl);
+    }
+
+    private UserAuthorization GetUserAuthorization()
+    {
+        var userAuthorization = _turnContext.Services.Get<UserAuthorization>();
+        if (userAuthorization == null)
+        {
+            throw new InvalidOperationException(
+                "UserAuthorization is not configured on the AgentApplication. A delegated (user) Graph client requires configured user authorization.");
+        }
+
+        return userAuthorization;
+    }
+
+    private IConnections GetConnections()
+    {
+        var connections = _turnContext.Services.Get<IConnections>();
+        if (connections == null)
+        {
+            throw new InvalidOperationException(
+                "IConnections is not configured on the AgentApplication. An app-only Graph client requires a configured token connection.");
+        }
+
+        return connections;
     }
 }


### PR DESCRIPTION
## Summary

Adds Microsoft Graph client factory helpers so agents can obtain a `GraphServiceClient` for both delegated (user) and **app-only** (application) tokens without manually wiring up token providers or scopes.

## Changes

- **New `GraphClientFactory`** — shared by `TeamsAgentExtension` and `TeamsTurnContext`, centralizing the token-provider and `.default` scope-derivation logic (no duplication). Scope/resource is derived from the Graph base URL so national clouds (e.g. `graph.microsoft.us`) are honored.
- **App-only Graph client overloads:**
  - `GetAppGraphClient(...)` — connection resolved from the current turn (`ITurnContext.Identity` + `Activity`) via `IConnections.GetTokenProvider`.
  - `GetAppGraphClientForConnection(connectionName, ...)` — named token connection. No extra `appsettings` required beyond the existing token connection.
- **Turn-context surface** — `GetGraphClient` / `GetAppGraphClient` / `GetAppGraphClientForConnection` are now exposed on `ITeamsTurnContext` / `TeamsTurnContext`, resolving `UserAuthorization` and `IConnections` from `ITurnContext.Services` (clear `InvalidOperationException` if unconfigured).
- **`AgentApplication.SetTurnContextServices`** now registers `IConnections` in turn services so the turn-context helpers can resolve it.

## Notes

- The named-connection variant is `GetAppGraphClientForConnection` (not an overload of `GetAppGraphClient`) to avoid a silent single-`string` overload collision with `GetAppGraphClient(graphBaseUrl)`.
- App-only clients use application permissions, so callers specify the target resource in the request path (e.g. `client.Users["{userId}"]...`).

## Testing

- `dotnet build src\libraries\Extensions\Microsoft.Agents.Extensions.MSTeams\Microsoft.Agents.Extensions.MSTeams.csproj` → **0 warnings / 0 errors**.
