### PR TITLE
Support for custom Activity types and deserialization

### DIFF
--- a/src/libraries/Builder/Microsoft.Agents.Builder/App/FeedbackLoopHandler.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/App/FeedbackLoopHandler.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Microsoft.Agents.Builder.State;
+using Microsoft.Agents.Core.Models;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -16,4 +17,16 @@ namespace Microsoft.Agents.Builder.App
     /// <param name="cancellationToken">A cancellation token that can be used by other objects
     /// or threads to receive notice of cancellation.</param>
     public delegate Task FeedbackLoopHandler(ITurnContext turnContext, ITurnState turnState, FeedbackData feedbackData, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Function for feedback loop activities
+    /// </summary>
+    /// <typeparam name="T">The type of activity.</typeparam>
+    /// <param name="turnContext">A strongly-typed context object for this turn.</param>
+    /// <param name="turnState">The turn state object that stores arbitrary data for this turn.</param>
+    /// <param name="feedbackData">The feedback loop data.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects
+    /// or threads to receive notice of cancellation.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    public delegate Task FeedbackLoopHandler<T>(ITurnContext<T> turnContext, ITurnState turnState, FeedbackData feedbackData, CancellationToken cancellationToken) where T : IActivity;
 }

--- a/src/libraries/Builder/Microsoft.Agents.Builder/App/Route.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/App/Route.cs
@@ -28,6 +28,17 @@ namespace Microsoft.Agents.Builder.App
     /// <returns></returns>
     public delegate Task RouteHandler(ITurnContext turnContext, ITurnState turnState, CancellationToken cancellationToken);
 
+    /// <summary>
+    /// Represents a route that can be used to handle incoming requests.
+    /// </summary>
+    /// <typeparam name="T">The type of activity that this route handler can process.</typeparam>
+    /// <param name="turnContext">A strongly-typed context object for this turn.</param>
+    /// <param name="turnState">The turn state object that stores arbitrary data for this turn.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used by other objects
+    /// or threads to receive notice of cancellation.</param>
+    /// <returns></returns>
+    public delegate Task TypedRouteHandler<T>(ITurnContext<T> turnContext, ITurnState turnState, CancellationToken cancellationToken) where T : IActivity;
+
     public enum RouteFlags
     {
         None = 0,

--- a/src/libraries/Builder/Microsoft.Agents.Builder/TypedTurnContext.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/TypedTurnContext.cs
@@ -1,0 +1,245 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Agents.Core.Models;
+using System.Runtime.CompilerServices;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Agents.Builder
+{
+    /// <summary>
+    /// A TurnContext with a strongly typed Activity property that wraps an untyped inner TurnContext.
+    /// </summary>
+    /// <typeparam name="T">An IActivity derived type, that is one of IMessageActivity, IConversationUpdateActivity etc.</typeparam>
+    public class TypedTurnContext<T> : ITurnContext<T>
+        where T : IActivity
+    {
+        private readonly ITurnContext _innerTurnContext;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TypedTurnContext{T}"/> class.
+        /// </summary>
+        /// <param name="innerTurnContext">The inner turn context.</param>
+        public TypedTurnContext(ITurnContext innerTurnContext)
+        {
+            _innerTurnContext = innerTurnContext;
+        }
+
+        /// <summary>
+        /// Gets the inner  context's activity, cast to the type parameter of this <see cref="TypedTurnContext{T}"/>.
+        /// </summary>
+        /// <value>The inner context's activity.</value>
+        T ITurnContext<T>.Activity => (T)_innerTurnContext.Activity;
+
+        /// <summary>
+        /// Gets the bot adapter that created this context object.
+        /// </summary>
+        /// <value>The bot adapter that created this context object.</value>
+        public IChannelAdapter Adapter => _innerTurnContext.Adapter;
+
+        /// <summary>
+        /// Gets the collection of values cached with the context object for the lifetime of the turn.
+        /// </summary>
+        /// <value>The collection of services registered on this context object.</value>
+        public TurnContextStateCollection StackState => _innerTurnContext.StackState;
+
+        /// <summary>
+        /// Gets the collection of values cached with the context object for the lifetime of the turn.
+        /// </summary>
+        /// <value>The collection of services registered on this context object.</value>
+        public TurnContextStateCollection Services => _innerTurnContext.Services;
+
+        /// <summary>
+        /// Gets the activity for this turn of the bot.
+        /// </summary>
+        /// <value>The activity for this turn of the bot.</value>
+        public IActivity Activity => _innerTurnContext.Activity;
+
+        /// <summary>
+        /// Gets a value indicating whether at least one response was sent for the current turn.
+        /// </summary>
+        /// <value><c>true</c> if at least one response was sent for the current turn; otherwise, <c>false</c>.</value>
+        /// <seealso cref="SendActivityAsync(IActivity, CancellationToken)"/>
+        public bool Responded => _innerTurnContext.Responded;
+
+        public IStreamingResponse StreamingResponse => _innerTurnContext.StreamingResponse;
+
+        public ClaimsIdentity Identity => _innerTurnContext.Identity;
+
+        /// <summary>
+        /// Deletes an existing activity.
+        /// </summary>
+        /// <param name="activityId">The ID of the activity to delete.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        /// <para>Not all channels support this operation. For channels that don\'t, this call may throw an exception.</para>
+        /// <seealso cref="OnDeleteActivity(DeleteActivityHandler)"/>
+        /// <seealso cref="DeleteActivityAsync(ConversationReference, CancellationToken)"/>
+        /// <seealso cref="SendActivitiesAsync(IActivity[], CancellationToken)"/>
+        /// <seealso cref="UpdateActivityAsync(IActivity, CancellationToken)"/>
+        public Task DeleteActivityAsync(string activityId, CancellationToken cancellationToken = default(CancellationToken))
+            => _innerTurnContext.DeleteActivityAsync(activityId, cancellationToken);
+
+        /// <summary>
+        /// Deletes an existing activity.
+        /// </summary>
+        /// <param name="conversationReference">The conversation containing the activity to delete.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        /// <remarks>The conversation reference's <see cref="ConversationReference.ActivityId"/>
+        /// indicates the activity in the conversation to delete.
+        /// <para>Not all channels support this operation. For channels that don't, this call may throw an exception.</para></remarks>
+        /// <seealso cref="OnDeleteActivity(DeleteActivityHandler)"/>
+        /// <seealso cref="DeleteActivityAsync(string, CancellationToken)"/>
+        /// <seealso cref="SendActivitiesAsync(IActivity[], CancellationToken)"/>
+        /// <seealso cref="UpdateActivityAsync(IActivity, CancellationToken)"/>
+        public Task DeleteActivityAsync(ConversationReference conversationReference, CancellationToken cancellationToken = default(CancellationToken))
+            => _innerTurnContext.DeleteActivityAsync(conversationReference, cancellationToken);
+
+        /// <summary>
+        /// Adds a response handler for delete activity operations.
+        /// </summary>
+        /// <param name="handler">The handler to add to the context object.</param>
+        /// <returns>The updated context object.</returns>
+        /// <remarks>When the context's <see cref="DeleteActivityAsync(string, CancellationToken)"/> is called,
+        /// the adapter calls the registered handlers in the order in which they were
+        /// added to the context object.
+        /// </remarks>
+        /// <seealso cref="DeleteActivityAsync(ConversationReference, CancellationToken)"/>
+        /// <seealso cref="DeleteActivityAsync(string, CancellationToken)"/>
+        /// <seealso cref="DeleteActivityHandler"/>
+        /// <seealso cref="OnSendActivities(SendActivitiesHandler)"/>
+        /// <seealso cref="OnUpdateActivity(UpdateActivityHandler)"/>
+        public ITurnContext OnDeleteActivity(DeleteActivityHandler handler)
+            => _innerTurnContext.OnDeleteActivity(handler);
+
+        /// <summary>
+        /// Adds a response handler for send activity operations.
+        /// </summary>
+        /// <param name="handler">The handler to add to the context object.</param>
+        /// <returns>The updated context object.</returns>
+        /// <remarks>When the context's <see cref="SendActivityAsync(IActivity, CancellationToken)"/>
+        /// or <see cref="SendActivitiesAsync(IActivity[], CancellationToken)"/> method is called,
+        /// the adapter calls the registered handlers in the order in which they were
+        /// added to the context object.
+        /// </remarks>
+        /// <seealso cref="SendActivityAsync(string, string, string, CancellationToken)"/>
+        /// <seealso cref="SendActivityAsync(IActivity, CancellationToken)"/>
+        /// <seealso cref="SendActivitiesAsync(IActivity[], CancellationToken)"/>
+        /// <seealso cref="SendActivitiesHandler"/>
+        /// <seealso cref="OnUpdateActivity(UpdateActivityHandler)"/>
+        /// <seealso cref="OnDeleteActivity(DeleteActivityHandler)"/>
+        public ITurnContext OnSendActivities(SendActivitiesHandler handler)
+            => _innerTurnContext.OnSendActivities(handler);
+
+        /// <summary>
+        /// Adds a response handler for update activity operations.
+        /// </summary>
+        /// <param name="handler">The handler to add to the context object.</param>
+        /// <returns>The updated context object.</returns>
+        /// <remarks>When the context's <see cref="UpdateActivityAsync(IActivity, CancellationToken)"/> is called,
+        /// the adapter calls the registered handlers in the order in which they were
+        /// added to the context object.
+        /// </remarks>
+        /// <seealso cref="UpdateActivityAsync(IActivity, CancellationToken)"/>
+        /// <seealso cref="UpdateActivityHandler"/>
+        /// <seealso cref="OnSendActivities(SendActivitiesHandler)"/>
+        /// <seealso cref="OnDeleteActivity(DeleteActivityHandler)"/>
+        public ITurnContext OnUpdateActivity(UpdateActivityHandler handler)
+            => _innerTurnContext.OnUpdateActivity(handler);
+
+        /// <summary>
+        /// Sends a set of activities to the sender of the incoming activity.
+        /// </summary>
+        /// <param name="activities">The activities to send.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        /// <remarks>If the activities are successfully sent, the task result contains
+        /// an array of <see cref="ResourceResponse"/> objects containing the IDs that
+        /// the receiving channel assigned to the activities.</remarks>
+        /// <seealso cref="OnSendActivities(SendActivitiesHandler)"/>
+        /// <seealso cref="SendActivityAsync(string, string, string, CancellationToken)"/>
+        /// <seealso cref="SendActivityAsync(IActivity, CancellationToken)"/>
+        /// <seealso cref="UpdateActivityAsync(IActivity, CancellationToken)"/>
+        /// <seealso cref="DeleteActivityAsync(ConversationReference, CancellationToken)"/>
+        public Task<ResourceResponse[]> SendActivitiesAsync(IActivity[] activities, CancellationToken cancellationToken = default(CancellationToken))
+            => _innerTurnContext.SendActivitiesAsync(activities, cancellationToken);
+
+        /// <summary>
+        /// Sends a message activity to the sender of the incoming activity.
+        /// </summary>
+        /// <param name="textReplyToSend">The text of the message to send.</param>
+        /// <param name="speak">Optional, text to be spoken by your bot on a speech-enabled
+        /// channel.</param>
+        /// <param name="inputHint">Optional, indicates whether your bot is accepting,
+        /// expecting, or ignoring user input after the message is delivered to the client.
+        /// <see cref="InputHints"/> defines the possible values.
+        /// Default is <see cref="InputHints.AcceptingInput"/>.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        /// <remarks>If the activity is successfully sent, the task result contains
+        /// a <see cref="ResourceResponse"/> object that contains the ID that the receiving
+        /// channel assigned to the activity.
+        /// <para>See the channel's documentation for limits imposed upon the contents of
+        /// <paramref name="textReplyToSend"/>.</para>
+        /// <para>To control various characteristics of your bot's speech such as voice,
+        /// rate, volume, pronunciation, and pitch, specify <paramref name="speak"/> in
+        /// Speech Synthesis Markup Language (SSML) format.</para>
+        /// </remarks>
+        /// <seealso cref="OnSendActivities(SendActivitiesHandler)"/>
+        /// <seealso cref="SendActivityAsync(IActivity, CancellationToken)"/>
+        /// <seealso cref="SendActivitiesAsync(IActivity[], CancellationToken)"/>
+        /// <seealso cref="UpdateActivityAsync(IActivity, CancellationToken)"/>
+        /// <seealso cref="DeleteActivityAsync(ConversationReference, CancellationToken)"/>
+        public Task<ResourceResponse> SendActivityAsync(string textReplyToSend, string speak = null, string inputHint = InputHints.AcceptingInput, CancellationToken cancellationToken = default(CancellationToken))
+            => _innerTurnContext.SendActivityAsync(textReplyToSend, speak, inputHint, cancellationToken);
+
+        /// <summary>
+        /// Sends an activity to the sender of the incoming activity.
+        /// </summary>
+        /// <param name="activity">The activity to send.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        /// <remarks>If the activity is successfully sent, the task result contains
+        /// a <see cref="ResourceResponse"/> object containing the ID that the receiving
+        /// channel assigned to the activity.</remarks>
+        /// <seealso cref="OnSendActivities(SendActivitiesHandler)"/>
+        /// <seealso cref="SendActivityAsync(string, string, string, CancellationToken)"/>
+        /// <seealso cref="SendActivitiesAsync(IActivity[], CancellationToken)"/>
+        /// <seealso cref="UpdateActivityAsync(IActivity, CancellationToken)"/>
+        /// <seealso cref="DeleteActivityAsync(ConversationReference, CancellationToken)"/>
+        public Task<ResourceResponse> SendActivityAsync(IActivity activity, CancellationToken cancellationToken = default(CancellationToken))
+            => _innerTurnContext.SendActivityAsync(activity, cancellationToken);
+
+        /// <summary>
+        /// Replaces an existing activity.
+        /// </summary>
+        /// <param name="activity">New replacement activity.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects
+        /// or threads to receive notice of cancellation.</param>
+        /// <returns>A task that represents the work queued to execute.</returns>
+        /// <remarks>If the activity is successfully sent, the task result contains
+        /// a <see cref="ResourceResponse"/> object containing the ID that the receiving
+        /// channel assigned to the activity.
+        /// <para>Before calling this, set the ID of the replacement activity to the ID
+        /// of the activity to replace.</para>
+        /// <para>Not all channels support this operation. For channels that don't, this call may throw an exception.</para></remarks>
+        /// <seealso cref="OnUpdateActivity(UpdateActivityHandler)"/>
+        /// <seealso cref="SendActivitiesAsync(IActivity[], CancellationToken)"/>
+        /// <seealso cref="DeleteActivityAsync(ConversationReference, CancellationToken)"/>
+        public Task<ResourceResponse> UpdateActivityAsync(IActivity activity, CancellationToken cancellationToken = default(CancellationToken))
+            => _innerTurnContext.UpdateActivityAsync(activity, cancellationToken);
+
+        public Task<ResourceResponse> TraceActivityAsync(string name, object value = null, string valueType = null, [CallerMemberName] string label = null, CancellationToken cancellationToken = default)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/src/libraries/Builder/Microsoft.Agents.Builder/TypedTurnContext.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/TypedTurnContext.cs
@@ -238,8 +238,6 @@ namespace Microsoft.Agents.Builder
             => _innerTurnContext.UpdateActivityAsync(activity, cancellationToken);
 
         public Task<ResourceResponse> TraceActivityAsync(string name, object value = null, string valueType = null, [CallerMemberName] string label = null, CancellationToken cancellationToken = default)
-        {
-            throw new System.NotImplementedException();
-        }
+            => _innerTurnContext.TraceActivityAsync(name, value, valueType, label, cancellationToken);
     }
 }

--- a/src/libraries/Core/Microsoft.Agents.Core.Analyzers/ActivityTypeInitSourceGenerator.cs
+++ b/src/libraries/Core/Microsoft.Agents.Core.Analyzers/ActivityTypeInitSourceGenerator.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.Agents.Core.Analyzers
+{
+    /// <summary>
+    /// Emits an assembly <c>ActivityTypeInitAssemblyAttribute</c> for every class annotated with
+    /// <c>[ActivityType]</c>, so <c>ProtocolJsonSerializer</c> can auto-register custom Activity
+    /// subclasses at load time without scanning every type in the assembly.
+    /// </summary>
+    [Generator]
+    public class ActivityTypeInitSourceGenerator : IIncrementalGenerator
+    {
+        internal const string ActivityTypeAttributeFullName = "Microsoft.Agents.Core.Serialization.ActivityTypeAttribute";
+        internal const string ActivityTypeInitAssemblyAttributeFullName = "Microsoft.Agents.Core.Serialization.ActivityTypeInitAssemblyAttribute";
+
+        public void Initialize(IncrementalGeneratorInitializationContext context)
+        {
+            IncrementalValueProvider<ImmutableArray<string?>> types =
+                context.SyntaxProvider
+                    .ForAttributeWithMetadataName(
+                        ActivityTypeAttributeFullName,
+                        (node, _) => node is ClassDeclarationSyntax,
+                        (ctx, ct) =>
+                            (ctx.TargetSymbol as INamedTypeSymbol)?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat))
+                    .Where(static x => x is not null)
+                    .Collect();
+
+            context.RegisterSourceOutput(types, static (context, types) =>
+            {
+                if (types.IsDefaultOrEmpty)
+                {
+                    return;
+                }
+
+                var source = string.Join("\r\n", types.Distinct().Select(x =>
+                    $"[assembly: {ActivityTypeInitAssemblyAttributeFullName}(typeof({x}))]"));
+
+                context.AddSource("ActivityTypeInitAssemblyAttributes.g.cs", SourceText.From(source, Encoding.UTF8));
+            });
+        }
+    }
+}

--- a/src/libraries/Core/Microsoft.Agents.Core.Analyzers/PreloadAssembliesSourceGenerator.cs
+++ b/src/libraries/Core/Microsoft.Agents.Core.Analyzers/PreloadAssembliesSourceGenerator.cs
@@ -1,0 +1,151 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Agents.Core.Analyzers.Extensions;
+using Microsoft.Agents.Core.Analyzers.Helpers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+
+namespace Microsoft.Agents.Core.Analyzers
+{
+    /// <summary>
+    /// Forces referenced assemblies that contain custom <c>Microsoft.Agents.Core.Models.Entity</c>
+    /// or <c>Microsoft.Agents.Core.Models.Activity</c> subclasses to load, so their
+    /// <c>[SerializationInit]</c>/<c>[EntityInit]</c> registration runs before any (de)serialization.
+    /// </summary>
+    /// <remarks>
+    /// Extension assemblies register custom Entity subclasses (via <c>EntityInitAssemblyAttribute</c>)
+    /// and custom Activity subclasses (via <c>ActivityTypeInitAssemblyAttribute</c>). That registration
+    /// only happens once the assembly is loaded, and the CLR does not load a referenced assembly until
+    /// one of its types is first used. This generator scans the consuming compilation's referenced
+    /// assemblies for such subclasses and emits a registry that references <c>typeof(...)</c> for each,
+    /// forcing the owning assembly to load so its serialization initialization is triggered.
+    /// </remarks>
+    [Generator]
+    [ExcludeFromCodeCoverage]
+    public class PreloadAssembliesSourceGenerator : IIncrementalGenerator
+    {
+        internal const string EntityTypeFullName = "Microsoft.Agents.Core.Models.Entity";
+        internal const string ActivityTypeFullName = "Microsoft.Agents.Core.Models.Activity";
+        internal const string CoreModelsNamespacePrefix = "global::Microsoft.Agents.Core.Models";
+
+        public void Initialize(IncrementalGeneratorInitializationContext context)
+        {
+            // Scan the referenced assemblies (not the current syntax) for Entity/Activity subclasses.
+            var derivedTypesProvider =
+                context.CompilationProvider
+                    .Select(static (compilation, _) => FindDerivedTypes(compilation))
+#pragma warning disable CS8620 // Argument cannot be used for parameter due to differences in the nullability of reference types.
+                    // Custom comparer expects string?, but we guarantee non-null strings in FindDerivedTypes.
+                    .WithComparer(new ObjectImmutableArraySequenceEqualityComparer<string>());
+#pragma warning restore CS8620
+
+            context.RegisterSourceOutput(
+                derivedTypesProvider,
+                static (spc, derivedTypes) =>
+                {
+                    if (derivedTypes.IsDefaultOrEmpty)
+                    {
+                        return;
+                    }
+
+                    var source = GenerateSource(derivedTypes);
+                    spc.AddSource("PreloadedAssemblies.g.cs", SourceText.From(source, Encoding.UTF8));
+                });
+        }
+
+        private static ImmutableArray<string> FindDerivedTypes(Compilation compilation)
+        {
+            var baseTypes = new[]
+            {
+                compilation.GetTypeByMetadataName(EntityTypeFullName),
+                compilation.GetTypeByMetadataName(ActivityTypeFullName),
+            }.Where(static t => t is not null).ToImmutableArray();
+
+            if (baseTypes.IsDefaultOrEmpty)
+            {
+                return ImmutableArray<string>.Empty;
+            }
+
+            var builder = ImmutableArray.CreateBuilder<string>();
+
+            foreach (var assembly in compilation.References
+                         .Select(compilation.GetAssemblyOrModuleSymbol)
+                         .OfType<IAssemblySymbol>())
+            {
+                CollectDerivedTypes(assembly.GlobalNamespace, baseTypes, builder);
+            }
+
+            return builder.ToImmutable();
+        }
+
+        private static void CollectDerivedTypes(
+            INamespaceSymbol ns,
+            ImmutableArray<INamedTypeSymbol?> baseTypes,
+            ImmutableArray<string>.Builder builder)
+        {
+            foreach (var member in ns.GetMembers())
+            {
+                if (member is INamespaceSymbol childNs)
+                {
+                    CollectDerivedTypes(childNs, baseTypes, builder);
+                }
+                else if (member is INamedTypeSymbol type
+                    && type.TypeKind == TypeKind.Class
+                    && !type.IsAbstract
+                    && baseTypes.Any(baseType => type.InheritsFrom(baseType)))
+                {
+                    var name = type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
+
+                    // The base types and the built-in subclasses live in Microsoft.Agents.Core.Models,
+                    // which is always loaded and already registered — never preload it.
+                    if (!name.StartsWith(CoreModelsNamespacePrefix))
+                    {
+                        builder.Add(name);
+                    }
+                }
+            }
+        }
+
+        private static string GenerateSource(ImmutableArray<string> types)
+        {
+            var typesAsStrings = types.Distinct().Select(static x => $"typeof({x})");
+
+            var sb = new StringBuilder();
+            sb.AppendFormat(/* lang=c#-test */ """
+            // <auto-generated />
+            using System;
+            using Microsoft.Agents.Core.Serialization;
+
+            [assembly: Microsoft.Agents.Core.Serialization.SerializationInitAssemblyAttribute(typeof(global::PreloadTypesRegistry))]
+
+            internal static class PreloadTypesRegistry
+            {{
+                private static readonly Type[] s_preloadedTypes;
+
+                static PreloadTypesRegistry()
+                {{
+                    // Referencing typeof(...) forces each owning assembly to load, triggering its
+                    // serialization initialization (EntityInit / SerializationInit).
+                    s_preloadedTypes = new[]
+                    {{
+                        {0}
+                    }};
+                }}
+
+                public static void Init()
+                {{
+                    _ = s_preloadedTypes.Length;
+                }}
+            }}
+            """,
+            string.Join(",\r\n            ", typesAsStrings));
+
+            return sb.ToString();
+        }
+    }
+}

--- a/src/libraries/Core/Microsoft.Agents.Core/Serialization/ActivityTypeAttribute.cs
+++ b/src/libraries/Core/Microsoft.Agents.Core/Serialization/ActivityTypeAttribute.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Microsoft.Agents.Core.Serialization
+{
+    /// <summary>
+    /// Declares that a custom <see cref="Microsoft.Agents.Core.Models.Activity"/> subclass should be
+    /// deserialized when an inbound Activity matches the specified discriminators.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// At least one discriminator (<see cref="Type"/>, <see cref="ChannelId"/>, or <see cref="Name"/>)
+    /// must be set. Discriminators are combined with AND: an Activity matches only when every set
+    /// discriminator equals the corresponding field on the wire (case-insensitive). Unset
+    /// discriminators are wildcards.
+    /// </para>
+    /// <para>
+    /// A single subclass may be annotated multiple times to match more than one shape. When several
+    /// registrations match, the most specific one (the greatest number of set discriminators) wins.
+    /// Annotated subclasses are auto-registered at assembly load time (a source generator emits an
+    /// <see cref="ActivityTypeInitAssemblyAttribute"/> per annotated class), so no manual registration
+    /// call is needed. For matching logic that these declarative discriminators cannot express, register
+    /// an imperative <see cref="ActivityTypeResolver"/> via
+    /// <see cref="Microsoft.Agents.Core.Serialization.ProtocolJsonSerializer.RegisterActivityTypeResolver"/>.
+    /// </para>
+    /// <example>
+    /// <code>
+    /// // Any activity on the msteams channel deserializes to TeamsActivity:
+    /// [ActivityType(ChannelId = "msteams")]
+    /// public class TeamsActivity : Activity { }
+    ///
+    /// // Only "message" activities on msteams deserialize to TeamsMessageActivity:
+    /// [ActivityType("message", ChannelId = "msteams")]
+    /// public class TeamsMessageActivity : Activity { }
+    ///
+    /// // A brand-new protocol type:
+    /// [ActivityType("x-workflowTrigger")]
+    /// public class WorkflowTriggerActivity : Activity { }
+    /// </code>
+    /// </example>
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+    public sealed class ActivityTypeAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ActivityTypeAttribute"/> class.
+        /// Set at least one of <see cref="Type"/>, <see cref="ChannelId"/>, or <see cref="Name"/>.
+        /// </summary>
+        public ActivityTypeAttribute()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ActivityTypeAttribute"/> class that matches
+        /// the given activity <c>type</c> string.
+        /// </summary>
+        /// <param name="type">The activity type string (e.g., "message", "event", "x-myCustomType").</param>
+        public ActivityTypeAttribute(string type)
+        {
+            Type = type;
+        }
+
+        /// <summary>
+        /// The activity <c>type</c> string to match (e.g., "message", "event", "x-myCustomType").
+        /// When <see langword="null"/>, the type is not considered (matches any type).
+        /// </summary>
+        public string Type { get; set; }
+
+        /// <summary>
+        /// The Activity <c>channelId</c> to match (e.g., "msteams"). When <see langword="null"/>,
+        /// the channel is not considered.
+        /// </summary>
+        public string ChannelId { get; set; }
+
+        /// <summary>
+        /// The Activity <c>name</c> to match (e.g., an invoke name like "task/fetch"). When
+        /// <see langword="null"/>, the name is not considered.
+        /// </summary>
+        public string Name { get; set; }
+    }
+}

--- a/src/libraries/Core/Microsoft.Agents.Core/Serialization/ActivityTypeInitAssemblyAttribute.cs
+++ b/src/libraries/Core/Microsoft.Agents.Core/Serialization/ActivityTypeInitAssemblyAttribute.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Microsoft.Agents.Core.Serialization
+{
+    /// <summary>
+    /// Assembly-level attribute that points at a custom <see cref="Microsoft.Agents.Core.Models.Activity"/>
+    /// subclass annotated with one or more <see cref="ActivityTypeAttribute"/> declarations.
+    /// </summary>
+    /// <remarks>
+    /// One instance is emitted by the <c>ActivityTypeInitSourceGenerator</c> for each <c>[ActivityType]</c>
+    /// class in an assembly. At <see cref="ProtocolJsonSerializer"/> initialization these attributes are
+    /// read off the loaded assemblies and their declarations auto-registered, so extension authors do not
+    /// need to call <see cref="ProtocolJsonSerializer.RegisterActivityTypes"/> manually, and the runtime
+    /// never has to scan every type to find custom Activity subclasses.
+    /// </remarks>
+    /// <param name="type">The annotated custom <see cref="Microsoft.Agents.Core.Models.Activity"/> subclass.</param>
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+    public class ActivityTypeInitAssemblyAttribute(Type type) : Attribute
+    {
+        public readonly Type ActivityType = type;
+
+        internal static void InitSerialization()
+        {
+            // Register handler for new assembly loads. This is needed because
+            // C# doesn't load a package until accessed.
+            AppDomain.CurrentDomain.AssemblyLoad += (s, o) => InitAssembly(o.LoadedAssembly);
+
+            // Register from currently loaded assemblies.
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                InitAssembly(assembly);
+            }
+        }
+
+        internal static void InitAssembly(Assembly assembly)
+        {
+            foreach (var type in GetActivityTypes(assembly))
+            {
+                try
+                {
+                    // RegisterActivityTypes is idempotent, so re-processing an assembly is harmless.
+                    ProtocolJsonSerializer.RegisterActivityTypes(new[] { type });
+                }
+                catch (Exception)
+                {
+                    // Ignore errors (e.g. a misconfigured [ActivityType] that sets no discriminators);
+                    // a bad registration must not break serialization initialization for everything else.
+                    // TODO: log this
+                }
+            }
+        }
+
+        private static IEnumerable<Type> GetActivityTypes(Assembly assembly) =>
+            assembly
+                .GetCustomAttributes(typeof(ActivityTypeInitAssemblyAttribute), false)?
+                .OfType<ActivityTypeInitAssemblyAttribute>()
+                .Select(x => x.ActivityType)
+                ?? Array.Empty<Type>();
+    }
+}

--- a/src/libraries/Core/Microsoft.Agents.Core/Serialization/ActivityTypeRegistration.cs
+++ b/src/libraries/Core/Microsoft.Agents.Core/Serialization/ActivityTypeRegistration.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Microsoft.Agents.Core.Serialization
+{
+    /// <summary>
+    /// A single declarative custom-Activity registration: the CLR subclass plus the discriminators
+    /// (type / channelId / name) an inbound Activity must match. Built from <see cref="ActivityTypeAttribute"/>.
+    /// </summary>
+    internal sealed class ActivityTypeRegistration
+    {
+        public ActivityTypeRegistration(Type clrType, string type, string channelId, string name)
+        {
+            ClrType = clrType;
+            Type = string.IsNullOrWhiteSpace(type) ? null : type;
+            ChannelId = string.IsNullOrWhiteSpace(channelId) ? null : channelId;
+            Name = string.IsNullOrWhiteSpace(name) ? null : name;
+        }
+
+        public Type ClrType { get; }
+
+        public string Type { get; }
+
+        public string ChannelId { get; }
+
+        public string Name { get; }
+
+        /// <summary>The number of set discriminators — higher wins when multiple registrations match.</summary>
+        public int Specificity =>
+            (Type != null ? 1 : 0) + (ChannelId != null ? 1 : 0) + (Name != null ? 1 : 0);
+
+        public bool Matches(in ActivityResolutionContext context)
+        {
+            return (Type == null || string.Equals(Type, context.Type, StringComparison.OrdinalIgnoreCase))
+                && (ChannelId == null || string.Equals(ChannelId, context.ChannelId, StringComparison.OrdinalIgnoreCase))
+                && (Name == null || string.Equals(Name, context.Name, StringComparison.OrdinalIgnoreCase));
+        }
+    }
+}

--- a/src/libraries/Core/Microsoft.Agents.Core/Serialization/ActivityTypeResolver.cs
+++ b/src/libraries/Core/Microsoft.Agents.Core/Serialization/ActivityTypeResolver.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Agents.Core.Serialization
+{
+    /// <summary>
+    /// The discriminator values peeked from an inbound Activity's JSON, used to resolve which
+    /// custom <see cref="Microsoft.Agents.Core.Models.Activity"/> subclass to deserialize into.
+    /// </summary>
+    /// <remarks>
+    /// Only the well-known top-level discriminators are surfaced (cheap to peek without a full
+    /// parse). <see cref="ChannelId"/> is the channel segment only — any <c>:product</c> sub-channel
+    /// suffix is stripped — so matching against a bare channel id (e.g. "msteams") works regardless
+    /// of the <see cref="ProtocolJsonSerializer.ChannelIdIncludesProduct"/> setting.
+    /// </remarks>
+    public readonly struct ActivityResolutionContext
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ActivityResolutionContext"/> struct.
+        /// </summary>
+        /// <param name="type">The Activity <c>type</c> field, or <see langword="null"/> if absent.</param>
+        /// <param name="channelId">The Activity <c>channelId</c> (channel segment only), or <see langword="null"/> if absent.</param>
+        /// <param name="name">The Activity <c>name</c> field, or <see langword="null"/> if absent.</param>
+        public ActivityResolutionContext(string type, string channelId, string name)
+        {
+            Type = type;
+            ChannelId = channelId;
+            Name = name;
+        }
+
+        /// <summary>The Activity <c>type</c> field (e.g., "message", "invoke", "x-custom").</summary>
+        public string Type { get; }
+
+        /// <summary>The Activity <c>channelId</c> channel segment (e.g., "msteams").</summary>
+        public string ChannelId { get; }
+
+        /// <summary>The Activity <c>name</c> field (e.g., an invoke name like "task/fetch").</summary>
+        public string Name { get; }
+    }
+
+    /// <summary>
+    /// An imperative resolver that maps an inbound Activity to a custom
+    /// <see cref="Microsoft.Agents.Core.Models.Activity"/> subclass to deserialize into.
+    /// </summary>
+    /// <param name="reader">
+    /// A private, forward-only <see cref="System.Text.Json.Utf8JsonReader"/> positioned at the
+    /// Activity's opening <see cref="System.Text.Json.JsonTokenType.StartObject"/> token. This is a
+    /// throwaway copy — reading from it does not affect deserialization, and each resolver receives
+    /// its own copy, so resolvers never interfere with one another. Use it to discriminate on any
+    /// property (including nested ones) that the well-known <paramref name="context"/> discriminators
+    /// don't surface. Resolvers that only need <c>type</c>/<c>channelId</c>/<c>name</c> can ignore it.
+    /// </param>
+    /// <param name="context">
+    /// The well-known top-level discriminators (<c>type</c>/<c>channelId</c>/<c>name</c>) already
+    /// peeked from the Activity JSON, provided for convenience so common cases avoid re-scanning.
+    /// </param>
+    /// <returns>
+    /// The CLR type (must derive from <see cref="Microsoft.Agents.Core.Models.Activity"/>) to
+    /// deserialize into, or <see langword="null"/> to defer to other resolvers / declarative
+    /// registrations / the base <see cref="Microsoft.Agents.Core.Models.Activity"/>.
+    /// </returns>
+    public delegate System.Type ActivityTypeResolver(ref System.Text.Json.Utf8JsonReader reader, in ActivityResolutionContext context);
+}

--- a/src/libraries/Core/Microsoft.Agents.Core/Serialization/Converters/ActivityConverter.cs
+++ b/src/libraries/Core/Microsoft.Agents.Core/Serialization/Converters/ActivityConverter.cs
@@ -11,7 +11,42 @@ namespace Microsoft.Agents.Core.Serialization.Converters
 {
     internal class ActivityConverter : ConnectorConverter<Activity>
     {
+        // Claim Activity subclasses too (e.g. custom types resolved via ActivityTypeResolver). The
+        // base JsonConverter<Activity> only matches typeof(Activity), which is enough for reading
+        // (Read is invoked explicitly with the resolved subclass) but not for top-level writing of a
+        // subclass instance — without this, System.Text.Json falls back to default reflection and
+        // mis-serializes members like ChannelId. value.GetType() drives the actual property set.
+        public override bool CanConvert(Type typeToConvert)
+        {
+            return typeof(Activity).IsAssignableFrom(typeToConvert);
+        }
+
         public override Activity Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            // Fast path: no custom activity resolution registered — existing behavior, zero overhead.
+            if (!ProtocolJsonSerializer.HasActivityTypeRegistrations)
+            {
+                return ReadDefault(ref reader, typeToConvert, options);
+            }
+
+            // Peek the discriminator fields (on a struct copy, leaving the real reader untouched)
+            // to resolve the CLR type to deserialize into.
+            var readerCopy = reader;
+            var context = PeekDiscriminators(ref readerCopy);
+
+            // Resolvers may scan arbitrary properties, so hand resolution a fresh copy positioned at
+            // StartObject (PeekDiscriminators consumed readerCopy). The real reader stays untouched.
+            var resolverReader = reader;
+            var resolvedType = ProtocolJsonSerializer.ResolveActivityType(ref resolverReader, in context);
+            if (resolvedType != null)
+            {
+                return ReadDefault(ref reader, resolvedType, options);
+            }
+
+            return ReadDefault(ref reader, typeToConvert, options);
+        }
+
+        private Activity ReadDefault(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             var activity = base.Read(ref reader, typeToConvert, options);
 
@@ -25,6 +60,86 @@ namespace Microsoft.Agents.Core.Serialization.Converters
             }
 
             return activity;
+        }
+
+        private static ActivityResolutionContext PeekDiscriminators(ref Utf8JsonReader reader)
+        {
+            if (reader.TokenType != JsonTokenType.StartObject)
+            {
+                return default;
+            }
+
+            string type = null;
+            string channelId = null;
+            string name = null;
+
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndObject)
+                {
+                    break;
+                }
+
+                if (reader.TokenType != JsonTokenType.PropertyName || reader.CurrentDepth != 1)
+                {
+                    // Skip stray values / nested content encountered at the top level.
+                    reader.Skip();
+                    continue;
+                }
+
+                var isType = reader.ValueTextEquals("type"u8);
+                var isChannelId = !isType && reader.ValueTextEquals("channelId"u8);
+                var isName = !isType && !isChannelId && reader.ValueTextEquals("name"u8);
+
+                if (!reader.Read())
+                {
+                    break;
+                }
+
+                if (isType || isChannelId || isName)
+                {
+                    var value = reader.TokenType == JsonTokenType.String ? reader.GetString() : null;
+
+                    if (isType)
+                    {
+                        type = value;
+                    }
+                    else if (isChannelId)
+                    {
+                        channelId = ChannelSegment(value);
+                    }
+                    else
+                    {
+                        name = value;
+                    }
+
+                    if (type != null && channelId != null && name != null)
+                    {
+                        break;
+                    }
+                }
+                else
+                {
+                    // Skip the value of an uninteresting property (no-op for scalars,
+                    // skips the whole subtree for objects/arrays).
+                    reader.Skip();
+                }
+            }
+
+            return new ActivityResolutionContext(type, channelId, name);
+        }
+
+        // The channelId can carry a "{channel}:{product}" sub-channel suffix; discriminators match
+        // on the bare channel segment.
+        private static string ChannelSegment(string channelId)
+        {
+            if (channelId == null)
+            {
+                return null;
+            }
+
+            var separator = channelId.IndexOf(':');
+            return separator < 0 ? channelId : channelId.Substring(0, separator);
         }
 
         public override void Write(Utf8JsonWriter writer, Activity value, JsonSerializerOptions options)

--- a/src/libraries/Core/Microsoft.Agents.Core/Serialization/Converters/ConnectorConverter.cs
+++ b/src/libraries/Core/Microsoft.Agents.Core/Serialization/Converters/ConnectorConverter.cs
@@ -329,8 +329,22 @@ namespace Microsoft.Agents.Core.Serialization.Converters
                         ?? namingPolicy?.ConvertName(prop.Name)
                         ?? prop.Name;
 
-                    if (metadata.ContainsKey(resolvedName))
+                    if (metadata.TryGetValue(resolvedName, out var existing))
                     {
+                        // Property shadowing via `new`: the same property name is declared on both a
+                        // base type and a more-derived subclass. Keep the most-derived declaration
+                        // (which carries the stronger typing) rather than treating it as a collision.
+                        if (string.Equals(existing.Item1.Name, prop.Name, StringComparison.Ordinal)
+                            && existing.Item1.DeclaringType != prop.DeclaringType)
+                        {
+                            if (existing.Item1.DeclaringType.IsAssignableFrom(prop.DeclaringType))
+                            {
+                                metadata[resolvedName] = (prop, prop.GetCustomAttribute<JsonIgnoreAttribute>()?.Condition == JsonIgnoreCondition.Always);
+                            }
+
+                            continue;
+                        }
+
                         throw new InvalidOperationException(
                             $"Duplicate JSON property name detected: '{resolvedName}' maps to multiple properties in type '{t.FullName}'."
                         );

--- a/src/libraries/Core/Microsoft.Agents.Core/Serialization/ProtocolJsonSerializer.cs
+++ b/src/libraries/Core/Microsoft.Agents.Core/Serialization/ProtocolJsonSerializer.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
+using System.Reflection;
 using Microsoft.Agents.Core.Models;
 using Microsoft.Agents.Core.Serialization.Converters;
 
@@ -37,12 +38,31 @@ namespace Microsoft.Agents.Core.Serialization
         /// </summary>
         public static ConcurrentDictionary<string, Type> EntityTypes { get; private set; } = CoreEntities();
 
+        /// <summary>
+        /// Maps activity <c>type</c> strings to custom <see cref="Activity"/> subclasses for the
+        /// simple type-only case. Retained for direct inspection; declarative discriminators
+        /// (including channelId/name) are held in the internal registration list. Populated by
+        /// <see cref="RegisterActivityTypes"/>.
+        /// </summary>
+        internal static readonly object _activityResolutionLock = new object();
+        private static ActivityTypeRegistration[] _activityRegistrations = Array.Empty<ActivityTypeRegistration>();
+        private static ActivityTypeResolver[] _activityResolvers = Array.Empty<ActivityTypeResolver>();
+
+        /// <summary>
+        /// True when any custom Activity resolution (declarative registrations or imperative
+        /// resolvers) has been registered. Lets the <c>ActivityConverter</c> keep a zero-overhead
+        /// fast path when no custom Activity types are in play.
+        /// </summary>
+        internal static bool HasActivityTypeRegistrations
+            => _activityRegistrations.Length != 0 || _activityResolvers.Length != 0;
+
         private static readonly object _optionsLock = new object();
 
         static ProtocolJsonSerializer()
         {
             SerializationInitAssemblyAttribute.InitSerialization();
             EntityInitAssemblyAttribute.InitSerialization();
+            ActivityTypeInitAssemblyAttribute.InitSerialization();
         }
 
         private static JsonSerializerOptions InitSerializerOptions()
@@ -152,6 +172,184 @@ namespace Microsoft.Agents.Core.Serialization
         public static void AddEntityType(string entityTypeName, Type entityType)
         {
             EntityTypes[entityTypeName] = entityType;
+        }
+
+        /// <summary>
+        /// Registers custom <see cref="Activity"/> subclasses for polymorphic deserialization.
+        /// Each type must derive from <see cref="Activity"/> and be annotated with one or more
+        /// <see cref="ActivityTypeAttribute"/>. Each attribute declares the discriminators
+        /// (<c>type</c>, and optionally <c>channelId</c> and/or <c>name</c>) that an inbound Activity
+        /// must match for the subclass to be used.
+        /// </summary>
+        /// <remarks>
+        /// Annotated subclasses are normally auto-registered at assembly load time (the
+        /// <c>ActivityTypeInitSourceGenerator</c> emits an <see cref="ActivityTypeInitAssemblyAttribute"/>
+        /// per <c>[ActivityType]</c> class), so calling this directly is rarely needed. It remains public
+        /// for explicit/dynamic registration. Registration is idempotent — registering the same type and
+        /// discriminators more than once is a no-op.
+        /// </remarks>
+        /// <param name="types">The annotated <see cref="Activity"/> subclasses to register.</param>
+        /// <exception cref="ArgumentException">
+        /// A supplied type does not derive from <see cref="Activity"/>, or one of its
+        /// <see cref="ActivityTypeAttribute"/> declarations sets none of Type/ChannelId/Name.
+        /// </exception>
+        public static void RegisterActivityTypes(IEnumerable<Type> types)
+        {
+            if (types == null)
+            {
+                return;
+            }
+
+            var additions = new List<ActivityTypeRegistration>();
+
+            foreach (var type in types)
+            {
+                if (!typeof(Activity).IsAssignableFrom(type))
+                {
+                    throw new ArgumentException($"{type.Name} must derive from {nameof(Activity)}.", nameof(types));
+                }
+
+                foreach (var attr in type.GetCustomAttributes<ActivityTypeAttribute>(false))
+                {
+                    if (string.IsNullOrWhiteSpace(attr.Type)
+                        && string.IsNullOrWhiteSpace(attr.ChannelId)
+                        && string.IsNullOrWhiteSpace(attr.Name))
+                    {
+                        throw new ArgumentException(
+                            $"[{nameof(ActivityTypeAttribute)}] on {type.Name} must set at least one of Type, ChannelId, or Name.",
+                            nameof(types));
+                    }
+
+                    additions.Add(new ActivityTypeRegistration(type, attr.Type, attr.ChannelId, attr.Name));
+                }
+            }
+
+            if (additions.Count == 0)
+            {
+                return;
+            }
+
+            lock (_activityResolutionLock)
+            {
+                var existing = _activityRegistrations;
+
+                // Deduplicate so re-processing (e.g. auto-registration running for an assembly that
+                // is also registered manually, or an assembly seen by both the initial scan and the
+                // AssemblyLoad handler) does not append identical registrations.
+                var toAdd = new List<ActivityTypeRegistration>();
+                foreach (var addition in additions)
+                {
+                    if (!ContainsRegistration(existing, addition) && !ContainsRegistration(toAdd, addition))
+                    {
+                        toAdd.Add(addition);
+                    }
+                }
+
+                if (toAdd.Count == 0)
+                {
+                    return;
+                }
+
+                var updated = new ActivityTypeRegistration[existing.Length + toAdd.Count];
+                Array.Copy(existing, updated, existing.Length);
+                for (var i = 0; i < toAdd.Count; i++)
+                {
+                    updated[existing.Length + i] = toAdd[i];
+                }
+
+                _activityRegistrations = updated;
+            }
+        }
+
+        private static bool ContainsRegistration(IReadOnlyList<ActivityTypeRegistration> list, ActivityTypeRegistration candidate)
+        {
+            for (var i = 0; i < list.Count; i++)
+            {
+                var r = list[i];
+                if (r.ClrType == candidate.ClrType
+                    && string.Equals(r.Type, candidate.Type, StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(r.ChannelId, candidate.ChannelId, StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(r.Name, candidate.Name, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Registers an imperative <see cref="ActivityTypeResolver"/> for custom Activity resolution
+        /// scenarios that the declarative <see cref="ActivityTypeAttribute"/> discriminators cannot
+        /// express. The resolver receives a private <see cref="Utf8JsonReader"/> copy positioned at
+        /// the Activity's <c>StartObject</c> (so it can discriminate on any property, including nested
+        /// ones) plus the well-known peeked discriminators for convenience. Resolvers are consulted
+        /// (in registration order) before declarative registrations; the first resolver to return a
+        /// non-<see langword="null"/> type wins.
+        /// </summary>
+        /// <param name="resolver">The resolver to add.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="resolver"/> is <see langword="null"/>.</exception>
+        public static void RegisterActivityTypeResolver(ActivityTypeResolver resolver)
+        {
+            AssertionHelpers.ThrowIfNull(resolver, nameof(resolver));
+
+            lock (_activityResolutionLock)
+            {
+                var updated = new ActivityTypeResolver[_activityResolvers.Length + 1];
+                Array.Copy(_activityResolvers, updated, _activityResolvers.Length);
+                updated[_activityResolvers.Length] = resolver;
+                _activityResolvers = updated;
+            }
+        }
+
+        /// <summary>
+        /// Resolves the custom <see cref="Activity"/> subclass to deserialize into for the given
+        /// peeked discriminators, or <see langword="null"/> to use the base <see cref="Activity"/>.
+        /// Imperative resolvers are consulted first (in registration order); then the most-specific
+        /// matching declarative registration (greatest number of set discriminators; ties resolved
+        /// by registration order).
+        /// </summary>
+        internal static Type ResolveActivityType(ref Utf8JsonReader reader, in ActivityResolutionContext context)
+        {
+            // Snapshot the copy-on-write arrays for a consistent, lock-free read.
+            var resolvers = _activityResolvers;
+            for (var i = 0; i < resolvers.Length; i++)
+            {
+                // Hand each resolver its own copy of the reader (positioned at StartObject) so its
+                // scanning can't disturb deserialization or the next resolver.
+                var resolverReader = reader;
+                var resolved = resolvers[i](ref resolverReader, in context);
+                if (resolved != null)
+                {
+                    return resolved;
+                }
+            }
+
+            var registrations = _activityRegistrations;
+            ActivityTypeRegistration best = null;
+            for (var i = 0; i < registrations.Length; i++)
+            {
+                var registration = registrations[i];
+                if (registration.Matches(in context)
+                    && (best == null || registration.Specificity > best.Specificity))
+                {
+                    best = registration;
+                }
+            }
+
+            return best?.ClrType;
+        }
+
+        /// <summary>
+        /// Removes all custom Activity type registrations and resolvers. Intended for test isolation.
+        /// </summary>
+        internal static void ClearActivityTypeRegistrations()
+        {
+            lock (_activityResolutionLock)
+            {
+                _activityRegistrations = Array.Empty<ActivityTypeRegistration>();
+                _activityResolvers = Array.Empty<ActivityTypeResolver>();
+            }
         }
 
         private static JsonSerializerOptions ApplyCoreOptions(this JsonSerializerOptions options)

--- a/src/libraries/Extensions/Microsoft.Agents.Extensions.Slack/AgentApplicationAttributes.cs
+++ b/src/libraries/Extensions/Microsoft.Agents.Extensions.Slack/AgentApplicationAttributes.cs
@@ -3,14 +3,10 @@
 
 using Microsoft.Agents.Builder;
 using Microsoft.Agents.Builder.App;
-using Microsoft.Agents.Builder.State;
 using Microsoft.Agents.Core.Models;
 using System;
 using System.Reflection;
-using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Microsoft.Agents.Extensions.Slack;
 
@@ -212,12 +208,25 @@ public class SlackMessageRouteAttribute(string text = null, string textRegex = n
 /// <param name="autoSignInHandlers">A comma/space/semicolon-delimited list of OAuth sign-in handler names, or the name of an instance or static method on the agent class matching <c>Func&lt;ITurnContext, string[]&gt;</c>.</param>
 [AttributeUsage(AttributeTargets.Method, Inherited = true)]
 [RouteHandlerType(typeof(RouteHandler))]
+[RouteHandlerType(typeof(TypedRouteHandler<ISlackActivity>))]
 public class SlackEventRouteAttribute(string name = null, string nameRegex = null, bool isAgenticOnly = false, ushort rank = RouteRank.Unspecified, string autoSignInHandlers = null) : Attribute, IRouteAttribute
 {
     public void AddRoute(AgentApplication app, MethodInfo method)
     {
-        var handler = RouteAttributeHelper.CreateHandlerDelegate<RouteHandler>(app, method);
-        var b = EventRouteBuilder.Create().WithHandler(handler).AsAgentic(isAgenticOnly).WithOrderRank(rank).WithChannelId(Channels.Slack);
+        var handler = RouteAttributeHelper.CreateMatchingHandlerDelegate(app, method, GetType());
+
+        RouteHandler routeHandler;
+        if (handler is TypedRouteHandler<ISlackActivity> typedHandler)
+        {
+            routeHandler = (turnContext, turnState, cancellationToken) =>
+                typedHandler(new TypedTurnContext<ISlackActivity>(turnContext), turnState, cancellationToken);
+        }
+        else
+        {
+            routeHandler = (RouteHandler)handler;
+        }
+
+        var b = EventRouteBuilder.Create().WithHandler(routeHandler).AsAgentic(isAgenticOnly).WithOrderRank(rank).WithChannelId(Channels.Slack);
         RouteAttributeHelper.ApplySignInHandlers(app, autoSignInHandlers, s => b.WithOAuthHandlers(s), f => b.WithOAuthHandlers(f));
 
         if (!string.IsNullOrWhiteSpace(name))
@@ -263,20 +272,33 @@ public class SlackEventRouteAttribute(string name = null, string nameRegex = nul
 /// <param name="autoSignInHandlers">A comma/space/semicolon-delimited list of OAuth sign-in handler names, or the name of an instance or static method on the agent class matching <c>Func&lt;ITurnContext, string[]&gt;</c>.</param>
 [AttributeUsage(AttributeTargets.Method, Inherited = true)]
 [RouteHandlerType(typeof(RouteHandler))]
+[RouteHandlerType(typeof(TypedRouteHandler<ISlackActivity>))]
 public class SlackConversationUpdateRouteAttribute(string eventName = null, bool isAgenticOnly = false, ushort rank = RouteRank.Unspecified, string autoSignInHandlers = null) : Attribute, IRouteAttribute
 {
     public void AddRoute(AgentApplication app, MethodInfo method)
     {
-        var handler = RouteAttributeHelper.CreateHandlerDelegate<RouteHandler>(app, method);
+        var handler = RouteAttributeHelper.CreateMatchingHandlerDelegate(app, method, GetType());
+
+        RouteHandler routeHandler;
+        if (handler is TypedRouteHandler<ISlackActivity> typedHandler)
+        {
+            routeHandler = (turnContext, turnState, cancellationToken) =>
+                typedHandler(new TypedTurnContext<ISlackActivity>(turnContext), turnState, cancellationToken);
+        }
+        else
+        {
+            routeHandler = (RouteHandler)handler;
+        }
+
         if (!string.IsNullOrWhiteSpace(eventName))
         {
-            var b = ConversationUpdateRouteBuilder.Create().WithUpdateEvent(eventName).WithHandler(handler).AsAgentic(isAgenticOnly).WithOrderRank(rank).WithChannelId(Channels.Slack);
+            var b = ConversationUpdateRouteBuilder.Create().WithUpdateEvent(eventName).WithHandler(routeHandler).AsAgentic(isAgenticOnly).WithOrderRank(rank).WithChannelId(Channels.Slack);
             RouteAttributeHelper.ApplySignInHandlers(app, autoSignInHandlers, s => b.WithOAuthHandlers(s), f => b.WithOAuthHandlers(f));
             app.AddRoute(b.Build());
         }
         else
         {
-            var b = TypeRouteBuilder.Create().WithType(ActivityTypes.ConversationUpdate).WithHandler(handler).AsAgentic(isAgenticOnly).WithOrderRank(rank == RouteRank.Unspecified ? RouteRank.Last : rank).WithChannelId(Channels.Slack);
+            var b = TypeRouteBuilder.Create().WithType(ActivityTypes.ConversationUpdate).WithHandler(routeHandler).AsAgentic(isAgenticOnly).WithOrderRank(rank == RouteRank.Unspecified ? RouteRank.Last : rank).WithChannelId(Channels.Slack);
             RouteAttributeHelper.ApplySignInHandlers(app, autoSignInHandlers, s => b.WithOAuthHandlers(s), f => b.WithOAuthHandlers(f));
             app.AddRoute(b.Build());
         }
@@ -308,12 +330,25 @@ public class SlackConversationUpdateRouteAttribute(string eventName = null, bool
 /// <param name="autoSignInHandlers">A comma/space/semicolon-delimited list of OAuth sign-in handler names, or the name of an instance or static method on the agent class matching <c>Func&lt;ITurnContext, string[]&gt;</c>.</param>
 [AttributeUsage(AttributeTargets.Method, Inherited = true)]
 [RouteHandlerType(typeof(RouteHandler))]
+[RouteHandlerType(typeof(TypedRouteHandler<ISlackActivity>))]
 public class SlackMembersAddedRouteAttribute(bool isAgenticOnly = false, ushort rank = RouteRank.Unspecified, string autoSignInHandlers = null) : Attribute, IRouteAttribute
 {
     public void AddRoute(AgentApplication app, MethodInfo method)
     {
-        var handler = RouteAttributeHelper.CreateHandlerDelegate<RouteHandler>(app, method);
-        var builder = ConversationUpdateRouteBuilder.Create().WithUpdateEvent(ConversationUpdateEvents.MembersAdded).WithHandler(handler).AsAgentic(isAgenticOnly).WithOrderRank(rank).WithChannelId(Channels.Slack);
+        var handler = RouteAttributeHelper.CreateMatchingHandlerDelegate(app, method, GetType());
+
+        RouteHandler routeHandler;
+        if (handler is TypedRouteHandler<ISlackActivity> typedHandler)
+        {
+            routeHandler = (turnContext, turnState, cancellationToken) =>
+                typedHandler(new TypedTurnContext<ISlackActivity>(turnContext), turnState, cancellationToken);
+        }
+        else
+        {
+            routeHandler = (RouteHandler)handler;
+        }
+
+        var builder = ConversationUpdateRouteBuilder.Create().WithUpdateEvent(ConversationUpdateEvents.MembersAdded).WithHandler(routeHandler).AsAgentic(isAgenticOnly).WithOrderRank(rank).WithChannelId(Channels.Slack);
         RouteAttributeHelper.ApplySignInHandlers(app, autoSignInHandlers, s => builder.WithOAuthHandlers(s), f => builder.WithOAuthHandlers(f));
         app.AddRoute(builder.Build());
     }
@@ -338,12 +373,25 @@ public class SlackMembersAddedRouteAttribute(bool isAgenticOnly = false, ushort 
 /// <param name="autoSignInHandlers">A comma/space/semicolon-delimited list of OAuth sign-in handler names, or the name of an instance or static method on the agent class matching <c>Func&lt;ITurnContext, string[]&gt;</c>.</param>
 [AttributeUsage(AttributeTargets.Method, Inherited = true)]
 [RouteHandlerType(typeof(RouteHandler))]
+[RouteHandlerType(typeof(TypedRouteHandler<ISlackActivity>))]
 public class SlackMembersRemovedRouteAttribute(bool isAgenticOnly = false, ushort rank = RouteRank.Unspecified, string autoSignInHandlers = null) : Attribute, IRouteAttribute
 {
     public void AddRoute(AgentApplication app, MethodInfo method)
     {
-        var handler = RouteAttributeHelper.CreateHandlerDelegate<RouteHandler>(app, method);
-        var builder = ConversationUpdateRouteBuilder.Create().WithUpdateEvent(ConversationUpdateEvents.MembersRemoved).WithHandler(handler).AsAgentic(isAgenticOnly).WithOrderRank(rank).WithChannelId(Channels.Slack);
+        var handler = RouteAttributeHelper.CreateMatchingHandlerDelegate(app, method, GetType());
+
+        RouteHandler routeHandler;
+        if (handler is TypedRouteHandler<ISlackActivity> typedHandler)
+        {
+            routeHandler = (turnContext, turnState, cancellationToken) =>
+                typedHandler(new TypedTurnContext<ISlackActivity>(turnContext), turnState, cancellationToken);
+        }
+        else
+        {
+            routeHandler = (RouteHandler)handler;
+        }
+
+        var builder = ConversationUpdateRouteBuilder.Create().WithUpdateEvent(ConversationUpdateEvents.MembersRemoved).WithHandler(routeHandler).AsAgentic(isAgenticOnly).WithOrderRank(rank).WithChannelId(Channels.Slack);
         RouteAttributeHelper.ApplySignInHandlers(app, autoSignInHandlers, s => builder.WithOAuthHandlers(s), f => builder.WithOAuthHandlers(f));
         app.AddRoute(builder.Build());
     }
@@ -369,12 +417,25 @@ public class SlackMembersRemovedRouteAttribute(bool isAgenticOnly = false, ushor
 /// <param name="autoSignInHandlers">A comma/space/semicolon-delimited list of OAuth sign-in handler names, or the name of an instance or static method on the agent class matching <c>Func&lt;ITurnContext, string[]&gt;</c>.</param>
 [AttributeUsage(AttributeTargets.Method, Inherited = true)]
 [RouteHandlerType(typeof(FeedbackLoopHandler))]
+[RouteHandlerType(typeof(FeedbackLoopHandler<ISlackActivity>))]
 public class SlackFeedbackLoopRouteAttribute(bool isAgenticOnly = false, ushort rank = RouteRank.Unspecified, string autoSignInHandlers = null) : Attribute, IRouteAttribute
 {
     public void AddRoute(AgentApplication app, MethodInfo method)
     {
-        var handler = RouteAttributeHelper.CreateHandlerDelegate<FeedbackLoopHandler>(app, method);
-        var builder = FeedbackRouteBuilder.Create().WithHandler(handler).AsAgentic(isAgenticOnly).WithOrderRank(rank).WithChannelId(Channels.Slack);
+        var handler = RouteAttributeHelper.CreateMatchingHandlerDelegate(app, method, GetType());
+
+        FeedbackLoopHandler routeHandler;
+        if (handler is FeedbackLoopHandler<ISlackActivity> typedHandler)
+        {
+            routeHandler = (turnContext, turnState, feedbackData, cancellationToken) =>
+                typedHandler(new TypedTurnContext<ISlackActivity>(turnContext), turnState, feedbackData, cancellationToken);
+        }
+        else
+        {
+            routeHandler = (FeedbackLoopHandler)handler;
+        }
+
+        var builder = FeedbackRouteBuilder.Create().WithHandler(routeHandler).AsAgentic(isAgenticOnly).WithOrderRank(rank).WithChannelId(Channels.Slack);
         RouteAttributeHelper.ApplySignInHandlers(app, autoSignInHandlers, s => builder.WithOAuthHandlers(s), f => builder.WithOAuthHandlers(f));
         app.AddRoute(builder.Build());
     }

--- a/src/libraries/Extensions/Microsoft.Agents.Extensions.Slack/AgentApplicationAttributes.cs
+++ b/src/libraries/Extensions/Microsoft.Agents.Extensions.Slack/AgentApplicationAttributes.cs
@@ -1,11 +1,16 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.Agents.Core.Models;
+using Microsoft.Agents.Builder;
 using Microsoft.Agents.Builder.App;
+using Microsoft.Agents.Builder.State;
+using Microsoft.Agents.Core.Models;
 using System;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.Agents.Extensions.Slack;
 
@@ -135,12 +140,25 @@ public class SlackInstallationUpdateRouteAttribute(bool isAgenticOnly = false, u
 /// <param name="autoSignInHandlers">A comma/space/semicolon-delimited list of OAuth sign-in handler names, or the name of an instance or static method on the agent class matching <c>Func&lt;ITurnContext, string[]&gt;</c>.</param>
 [AttributeUsage(AttributeTargets.Method, Inherited = true)]
 [RouteHandlerType(typeof(RouteHandler))]
+[RouteHandlerType(typeof(TypedRouteHandler<ISlackActivity>))]
 public class SlackMessageRouteAttribute(string text = null, string textRegex = null, bool isAgenticOnly = false, ushort rank = RouteRank.Unspecified, string autoSignInHandlers = null) : Attribute, IRouteAttribute
 {
     public void AddRoute(AgentApplication app, MethodInfo method)
     {
-        var handler = RouteAttributeHelper.CreateHandlerDelegate<RouteHandler>(app, method);
-        var b = MessageRouteBuilder.Create().WithHandler(handler).AsAgentic(isAgenticOnly).WithOrderRank(rank).WithChannelId(Channels.Slack);
+        var handler = RouteAttributeHelper.CreateMatchingHandlerDelegate(app, method, GetType());
+
+        RouteHandler routeHandler;
+        if (handler is TypedRouteHandler<ISlackActivity> typedHandler)
+        {
+            routeHandler = (turnContext, turnState, cancellationToken) =>
+                typedHandler(new TypedTurnContext<ISlackActivity>(turnContext), turnState, cancellationToken);
+        }
+        else
+        {
+            routeHandler = (RouteHandler)handler;
+        }
+
+        var b = MessageRouteBuilder.Create().WithHandler(routeHandler).AsAgentic(isAgenticOnly).WithOrderRank(rank).WithChannelId(Channels.Slack);
         RouteAttributeHelper.ApplySignInHandlers(app, autoSignInHandlers, s => b.WithOAuthHandlers(s), f => b.WithOAuthHandlers(f));
 
         if (!string.IsNullOrWhiteSpace(text))

--- a/src/libraries/Extensions/Microsoft.Agents.Extensions.Slack/ISlackActivity.cs
+++ b/src/libraries/Extensions/Microsoft.Agents.Extensions.Slack/ISlackActivity.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Agents.Core.Models;
+using Microsoft.Agents.Extensions.Slack.Api;
+
+namespace Microsoft.Agents.Extensions.Slack
+{
+    /// <summary>
+    /// A Slack-specific <see cref="IActivity"/> that exposes the Slack channel data as a strongly-typed
+    /// <see cref="SlackChannelData"/> instead of the loosely-typed <see cref="IActivity.ChannelData"/>.
+    /// </summary>
+    public interface ISlackActivity : IActivity
+    {
+        /// <summary>
+        /// The Slack channel data (envelope / interactive payload) carried on the Activity.
+        /// </summary>
+        new SlackChannelData ChannelData { get; set; }
+    }
+}

--- a/src/libraries/Extensions/Microsoft.Agents.Extensions.Slack/Serialization/SerializationInit.cs
+++ b/src/libraries/Extensions/Microsoft.Agents.Extensions.Slack/Serialization/SerializationInit.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using Microsoft.Agents.Core.Serialization;

--- a/src/libraries/Extensions/Microsoft.Agents.Extensions.Slack/SlackActivity.cs
+++ b/src/libraries/Extensions/Microsoft.Agents.Extensions.Slack/SlackActivity.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Agents.Core.Models;
+using Microsoft.Agents.Core.Serialization;
+using Microsoft.Agents.Extensions.Slack.Api;
+
+namespace Microsoft.Agents.Extensions.Slack
+{
+    /// <summary>
+    /// A Slack-specific <see cref="Activity"/> that surfaces the Slack channel payload as a
+    /// strongly-typed <see cref="SlackChannelData"/>.
+    /// </summary>
+    /// <remarks>
+    /// The <c>[ActivityType(ChannelId = "slack")]</c> annotation auto-registers this type (via the
+    /// generated <see cref="ActivityTypeInitAssemblyAttribute"/>), so any inbound Activity whose
+    /// <see cref="Activity.ChannelId"/> is <c>"slack"</c> deserializes to <see cref="SlackActivity"/>.
+    /// The typed <see cref="ChannelData"/> shadow reads through the base <see cref="Activity.ChannelData"/>
+    /// (which the deserializer populates as raw JSON), so both the base and typed views stay in sync.
+    /// </remarks>
+    [ActivityType(ChannelId = Channels.Slack)]
+    public class SlackActivity : Activity, ISlackActivity
+    {
+        /// <summary>
+        /// The Slack channel data (envelope / interactive payload) carried on the Activity.
+        /// </summary>
+        public new SlackChannelData ChannelData
+        {
+            get => this.GetChannelData<SlackChannelData>();
+            set => base.ChannelData = value;
+        }
+    }
+}

--- a/src/samples/SlackAgent/MyAgent.cs
+++ b/src/samples/SlackAgent/MyAgent.cs
@@ -46,7 +46,8 @@ public partial class MyAgent : AgentApplication
         var message = $$"""
         {
             "channel": "{{channelData.Channel}}",
-            "text": "You said: {{turnContext.Activity.Text}}"
+            "text": "You said: {{turnContext.Activity.Text}}",
+            "thread_ts": "{{channelData.ThreadTs}}"
         }
         """;
 

--- a/src/samples/SlackAgent/MyAgent.cs
+++ b/src/samples/SlackAgent/MyAgent.cs
@@ -32,9 +32,9 @@ public partial class MyAgent(AgentApplicationOptions options) : AgentApplication
     // Demonstrates using the Slack API to reply to a message with the text "You said: {message text}" instead of
     // the typical ITurnContext.SendActivityAsync response.
     [SlackMessageRoute]
-    public async Task OnSlackMessageAsync(ITurnContext turnContext, ITurnState turnState, CancellationToken cancellationToken)
+    public async Task OnSlackMessageAsync(ITurnContext<ISlackActivity> turnContext, ITurnState turnState, CancellationToken cancellationToken)
     {
-        var channelData = turnContext.Activity.GetChannelData<SlackChannelData>();
+        var channelData = turnContext.Activity.ChannelData;
 
         var message = $$"""
         {

--- a/src/tests/Microsoft.Agents.Core.Analyzers.Tests/ActivityTypeInitSourceGeneratorTests.cs
+++ b/src/tests/Microsoft.Agents.Core.Analyzers.Tests/ActivityTypeInitSourceGeneratorTests.cs
@@ -1,0 +1,189 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Microsoft.Agents.Core.Analyzers.Tests
+{
+    public class ActivityTypeInitSourceGeneratorTests
+    {
+        /// <summary>
+        /// BCL platform references plus Microsoft.Agents.Core so tests can compile source that
+        /// references <c>Microsoft.Agents.Core.Serialization.ActivityTypeAttribute</c>.
+        /// </summary>
+        private static IEnumerable<MetadataReference> GetReferences()
+        {
+            var trusted = (string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES");
+            if (trusted != null)
+                foreach (var path in trusted.Split(Path.PathSeparator))
+                    if (File.Exists(path))
+                        yield return MetadataReference.CreateFromFile(path);
+
+            yield return MetadataReference.CreateFromFile(
+                typeof(Microsoft.Agents.Core.Serialization.ActivityTypeAttribute).Assembly.Location);
+        }
+
+        private static CSharpGeneratorDriver RunGenerator(string source)
+        {
+            var compilation = CSharpCompilation.Create(
+                "TestAssembly",
+                new[] { CSharpSyntaxTree.ParseText(source) },
+                GetReferences(),
+                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+            var generator = new ActivityTypeInitSourceGenerator();
+            var driver = CSharpGeneratorDriver.Create(generator);
+            return (CSharpGeneratorDriver)driver.RunGenerators(compilation);
+        }
+
+        [Fact]
+        public void NoActivityTypeAttribute_ProducesNoOutput()
+        {
+            var source = """
+                namespace MyApp
+                {
+                    public class NotAnnotated : Microsoft.Agents.Core.Models.Activity { }
+                    public class AlsoNot { }
+                }
+                """;
+
+            var result = RunGenerator(source).GetRunResult();
+
+            Assert.Empty(result.Results.Single().GeneratedSources);
+        }
+
+        [Fact]
+        public void OneAnnotatedClass_GeneratesOneAssemblyAttribute()
+        {
+            var source = """
+                namespace MyApp
+                {
+                    [Microsoft.Agents.Core.Serialization.ActivityType("x-workflowTrigger")]
+                    public class WorkflowTriggerActivity : Microsoft.Agents.Core.Models.Activity { }
+                }
+                """;
+
+            var text = Assert.Single(RunGenerator(source).GetRunResult().Results.Single().GeneratedSources)
+                .SourceText.ToString();
+
+            Assert.Contains(
+                "[assembly: Microsoft.Agents.Core.Serialization.ActivityTypeInitAssemblyAttribute(typeof(global::MyApp.WorkflowTriggerActivity))]",
+                text);
+        }
+
+        [Fact]
+        public void ChannelIdOnlyAttribute_IsPickedUp()
+        {
+            var source = """
+                namespace MyApp
+                {
+                    [Microsoft.Agents.Core.Serialization.ActivityType(ChannelId = "slack")]
+                    public class SlackActivity : Microsoft.Agents.Core.Models.Activity { }
+                }
+                """;
+
+            var text = Assert.Single(RunGenerator(source).GetRunResult().Results.Single().GeneratedSources)
+                .SourceText.ToString();
+
+            Assert.Contains("typeof(global::MyApp.SlackActivity)", text);
+        }
+
+        [Fact]
+        public void MultipleAnnotatedClasses_GenerateAllAttributes()
+        {
+            var source = """
+                namespace MyApp
+                {
+                    [Microsoft.Agents.Core.Serialization.ActivityType("a")]
+                    public class ActivityA : Microsoft.Agents.Core.Models.Activity { }
+
+                    [Microsoft.Agents.Core.Serialization.ActivityType("b")]
+                    public class ActivityB : Microsoft.Agents.Core.Models.Activity { }
+                }
+                """;
+
+            var text = Assert.Single(RunGenerator(source).GetRunResult().Results.Single().GeneratedSources)
+                .SourceText.ToString();
+
+            Assert.Contains("global::MyApp.ActivityA", text);
+            Assert.Contains("global::MyApp.ActivityB", text);
+        }
+
+        [Fact]
+        public void ClassWithMultipleAttributes_EmitsSingleTypeReference()
+        {
+            var source = """
+                namespace MyApp
+                {
+                    [Microsoft.Agents.Core.Serialization.ActivityType("a")]
+                    [Microsoft.Agents.Core.Serialization.ActivityType("b")]
+                    public class MultiActivity : Microsoft.Agents.Core.Models.Activity { }
+                }
+                """;
+
+            var text = Assert.Single(RunGenerator(source).GetRunResult().Results.Single().GeneratedSources)
+                .SourceText.ToString();
+
+            // The assembly attribute references the class once; the individual discriminators are read
+            // off the [ActivityType] attributes at registration time.
+            var occurrences = text.Split(new[] { "typeof(global::MyApp.MultiActivity)" }, StringSplitOptions.None).Length - 1;
+            Assert.Equal(1, occurrences);
+        }
+
+        [Fact]
+        public void UnannotatedClass_IsNotIncluded()
+        {
+            var source = """
+                namespace MyApp
+                {
+                    public class Plain : Microsoft.Agents.Core.Models.Activity { }
+
+                    [Microsoft.Agents.Core.Serialization.ActivityType("x-custom")]
+                    public class Annotated : Microsoft.Agents.Core.Models.Activity { }
+                }
+                """;
+
+            var text = Assert.Single(RunGenerator(source).GetRunResult().Results.Single().GeneratedSources)
+                .SourceText.ToString();
+
+            Assert.DoesNotContain("Plain", text);
+            Assert.Contains("global::MyApp.Annotated", text);
+        }
+
+        [Fact]
+        public void GeneratedFile_HasExpectedHintName()
+        {
+            var source = """
+                namespace MyApp
+                {
+                    [Microsoft.Agents.Core.Serialization.ActivityType("x-custom")]
+                    public class MyActivity : Microsoft.Agents.Core.Models.Activity { }
+                }
+                """;
+
+            var generated = Assert.Single(RunGenerator(source).GetRunResult().Results.Single().GeneratedSources);
+
+            Assert.Equal("ActivityTypeInitAssemblyAttributes.g.cs", generated.HintName);
+        }
+
+        [Fact]
+        public void Generator_ProducesNoDiagnostics()
+        {
+            var source = """
+                namespace MyApp
+                {
+                    [Microsoft.Agents.Core.Serialization.ActivityType("x-custom")]
+                    public class MyActivity : Microsoft.Agents.Core.Models.Activity { }
+                }
+                """;
+
+            Assert.Empty(RunGenerator(source).GetRunResult().Diagnostics);
+        }
+    }
+}

--- a/src/tests/Microsoft.Agents.Core.Analyzers.Tests/PreloadAssembliesSourceGeneratorTests.cs
+++ b/src/tests/Microsoft.Agents.Core.Analyzers.Tests/PreloadAssembliesSourceGeneratorTests.cs
@@ -1,0 +1,229 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Microsoft.Agents.Core.Analyzers.Tests
+{
+    public class PreloadAssembliesSourceGeneratorTests
+    {
+        // ---------------------------------------------------------------------------
+        // Helpers
+        // ---------------------------------------------------------------------------
+
+        /// <summary>
+        /// Returns BCL platform references plus Microsoft.Agents.Core so tests can compile
+        /// source that references <c>Microsoft.Agents.Core.Models.Entity</c>/<c>Activity</c>.
+        /// </summary>
+        private static IEnumerable<MetadataReference> GetReferences()
+        {
+            var trusted = (string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES");
+            if (trusted != null)
+                foreach (var path in trusted.Split(Path.PathSeparator))
+                    if (File.Exists(path))
+                        yield return MetadataReference.CreateFromFile(path);
+
+            yield return MetadataReference.CreateFromFile(
+                typeof(Microsoft.Agents.Core.Models.Entity).Assembly.Location);
+        }
+
+        /// <summary>
+        /// Compiles <paramref name="source"/> into a referenced assembly so the generator can
+        /// discover derived types the way it would in a real referenced extension assembly.
+        /// </summary>
+        private static MetadataReference CreateReferencedAssembly(string assemblyName, string source)
+        {
+            var compilation = CSharpCompilation.Create(
+                assemblyName,
+                new[] { CSharpSyntaxTree.ParseText(source) },
+                GetReferences(),
+                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+            return compilation.ToMetadataReference();
+        }
+
+        private static GeneratorDriverRunResult RunGenerator(params MetadataReference[] extraReferences)
+        {
+            var compilation = CSharpCompilation.Create(
+                "TestAssembly",
+                new[] { CSharpSyntaxTree.ParseText("namespace App { internal class Program { } }") },
+                GetReferences().Concat(extraReferences),
+                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+            var generator = new PreloadAssembliesSourceGenerator();
+            var driver = CSharpGeneratorDriver.Create(generator);
+            return ((CSharpGeneratorDriver)driver.RunGenerators(compilation)).GetRunResult();
+        }
+
+        private static string GeneratedText(GeneratorDriverRunResult result) =>
+            result.Results.Single().GeneratedSources.Single().SourceText.ToString();
+
+        // ---------------------------------------------------------------------------
+        // Tests
+        // ---------------------------------------------------------------------------
+
+        [Fact]
+        public void ActivitySubclassInReferencedAssembly_IsPreloaded()
+        {
+            // The key new capability: custom Activity subclasses are discovered for preloading.
+            var reference = CreateReferencedAssembly("Ext.Activities", """
+                namespace Ext.Activities
+                {
+                    [Microsoft.Agents.Core.Serialization.ActivityType("x-custom")]
+                    public class CustomActivity : Microsoft.Agents.Core.Models.Activity
+                    {
+                    }
+                }
+                """);
+
+            var text = GeneratedText(RunGenerator(reference));
+
+            Assert.Contains("typeof(global::Ext.Activities.CustomActivity)", text);
+        }
+
+        [Fact]
+        public void EntitySubclassInReferencedAssembly_IsPreloaded()
+        {
+            var reference = CreateReferencedAssembly("Ext.Entities", """
+                namespace Ext.Entities
+                {
+                    public class CustomEntity : Microsoft.Agents.Core.Models.Entity
+                    {
+                        public CustomEntity() : base("customEntity") { }
+                    }
+                }
+                """);
+
+            var text = GeneratedText(RunGenerator(reference));
+
+            Assert.Contains("typeof(global::Ext.Entities.CustomEntity)", text);
+        }
+
+        [Fact]
+        public void BothEntityAndActivitySubclasses_ArePreloaded()
+        {
+            var reference = CreateReferencedAssembly("Ext.Mixed", """
+                namespace Ext.Mixed
+                {
+                    public class MixedActivity : Microsoft.Agents.Core.Models.Activity { }
+
+                    public class MixedEntity : Microsoft.Agents.Core.Models.Entity
+                    {
+                        public MixedEntity() : base("mixedEntity") { }
+                    }
+                }
+                """);
+
+            var text = GeneratedText(RunGenerator(reference));
+
+            Assert.Contains("typeof(global::Ext.Mixed.MixedActivity)", text);
+            Assert.Contains("typeof(global::Ext.Mixed.MixedEntity)", text);
+        }
+
+        [Fact]
+        public void IndirectActivitySubclass_IsPreloaded()
+        {
+            var reference = CreateReferencedAssembly("Ext.Indirect", """
+                namespace Ext.Indirect
+                {
+                    public class BaseCustom : Microsoft.Agents.Core.Models.Activity { }
+                    public class DerivedCustom : BaseCustom { }
+                }
+                """);
+
+            var text = GeneratedText(RunGenerator(reference));
+
+            Assert.Contains("typeof(global::Ext.Indirect.BaseCustom)", text);
+            Assert.Contains("typeof(global::Ext.Indirect.DerivedCustom)", text);
+        }
+
+        [Fact]
+        public void NonDerivedTypeInReferencedAssembly_IsNotPreloaded()
+        {
+            var reference = CreateReferencedAssembly("Ext.Plain", """
+                namespace Ext.Plain
+                {
+                    public class NotDerived { }
+                    public class AlsoNot : System.Exception { }
+                }
+                """);
+
+            var result = RunGenerator(reference);
+
+            // No derived types anywhere -> no generated output at all.
+            Assert.Empty(result.Results.Single().GeneratedSources);
+        }
+
+        [Fact]
+        public void CoreModelsSubclasses_AreExcluded()
+        {
+            // Microsoft.Agents.Core (which defines Activity/Entity and their built-in subclasses)
+            // is always referenced, but its Models-namespace types must never be preloaded.
+            var reference = CreateReferencedAssembly("Ext.Activities2", """
+                namespace Ext.Activities2
+                {
+                    public class AnotherActivity : Microsoft.Agents.Core.Models.Activity { }
+                }
+                """);
+
+            var text = GeneratedText(RunGenerator(reference));
+
+            Assert.DoesNotContain("global::Microsoft.Agents.Core.Models", text);
+            Assert.Contains("typeof(global::Ext.Activities2.AnotherActivity)", text);
+        }
+
+        [Fact]
+        public void Generated_RegistersSerializationInitAssemblyAttribute()
+        {
+            var reference = CreateReferencedAssembly("Ext.Reg", """
+                namespace Ext.Reg
+                {
+                    public class RegActivity : Microsoft.Agents.Core.Models.Activity { }
+                }
+                """);
+
+            var text = GeneratedText(RunGenerator(reference));
+
+            Assert.Contains(
+                "[assembly: Microsoft.Agents.Core.Serialization.SerializationInitAssemblyAttribute(typeof(global::PreloadTypesRegistry))]",
+                text);
+            Assert.Contains("internal static class PreloadTypesRegistry", text);
+        }
+
+        [Fact]
+        public void GeneratedFile_HasExpectedHintName()
+        {
+            var reference = CreateReferencedAssembly("Ext.Hint", """
+                namespace Ext.Hint
+                {
+                    public class HintActivity : Microsoft.Agents.Core.Models.Activity { }
+                }
+                """);
+
+            var generated = RunGenerator(reference).Results.Single().GeneratedSources.Single();
+
+            Assert.Equal("PreloadedAssemblies.g.cs", generated.HintName);
+        }
+
+        [Fact]
+        public void Generator_ProducesNoDiagnostics()
+        {
+            var reference = CreateReferencedAssembly("Ext.Diag", """
+                namespace Ext.Diag
+                {
+                    public class DiagActivity : Microsoft.Agents.Core.Models.Activity { }
+                }
+                """);
+
+            var result = RunGenerator(reference);
+
+            Assert.Empty(result.Diagnostics);
+        }
+    }
+}

--- a/src/tests/Microsoft.Agents.Extensions.Slack.Tests/SlackActivityTests.cs
+++ b/src/tests/Microsoft.Agents.Extensions.Slack.Tests/SlackActivityTests.cs
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Agents.Core.Models;
+using Microsoft.Agents.Core.Serialization;
+using Xunit;
+
+namespace Microsoft.Agents.Extensions.Slack.Tests;
+
+/// <summary>
+/// Tests for the polymorphic resolution of inbound Activities to <see cref="SlackActivity"/>.
+/// The resolver (registered in <c>Serialization.SerializationInit.Init</c>) maps any Activity whose
+/// channelId is "slack" to <see cref="SlackActivity"/>, exposing a strongly-typed
+/// <see cref="Api.SlackChannelData"/> via the <see cref="SlackActivity.ChannelData"/> shadow.
+/// </summary>
+public class SlackActivityTests
+{
+    private const string SlackMessageJson = """
+        {
+          "type": "message",
+          "channelId": "slack",
+          "channelData": {
+            "SlackMessage": {
+              "event": {
+                "type": "message",
+                "channel": "C0AT123",
+                "text": "hello",
+                "ts": "1776271070.726439"
+              }
+            },
+            "ApiToken": "xoxb-token"
+          }
+        }
+        """;
+
+    [Fact]
+    public void SlackChannelId_ResolvesToSlackActivity()
+    {
+        var activity = ProtocolJsonSerializer.ToObject<Activity>(SlackMessageJson);
+
+        var slack = Assert.IsType<SlackActivity>(activity);
+        Assert.Equal(Channels.Slack, slack.ChannelId.Channel);
+    }
+
+    [Fact]
+    public void SlackActivity_ExposesTypedChannelData()
+    {
+        var slack = Assert.IsType<SlackActivity>(ProtocolJsonSerializer.ToObject<Activity>(SlackMessageJson));
+
+        var channelData = slack.ChannelData;
+        Assert.NotNull(channelData);
+        Assert.Equal("C0AT123", channelData.Channel);
+        Assert.Equal("xoxb-token", channelData.ApiToken);
+        Assert.Equal("hello", channelData.Envelope.Get<string>("event.text"));
+    }
+
+    [Fact]
+    public void TypedChannelData_StaysInSyncWithBaseChannelData()
+    {
+        var slack = Assert.IsType<SlackActivity>(ProtocolJsonSerializer.ToObject<Activity>(SlackMessageJson));
+
+        // The typed shadow reads through the base (loosely-typed) ChannelData that the deserializer
+        // populated, so the base view and the GetChannelData<T>() extension agree.
+        var viaExtension = ((IActivity)slack).GetChannelData<Api.SlackChannelData>();
+        Assert.Equal(slack.ChannelData.Channel, viaExtension.Channel);
+    }
+
+    [Fact]
+    public void NonSlackChannelId_ResolvesToBaseActivity()
+    {
+        var activity = ProtocolJsonSerializer.ToObject<Activity>(
+            """{"type":"message","channelId":"test","text":"hi"}""");
+
+        Assert.Equal(typeof(Activity), activity.GetType());
+    }
+
+    [Fact]
+    public void SlackActivity_RoundTripsChannelData()
+    {
+        var slack = Assert.IsType<SlackActivity>(ProtocolJsonSerializer.ToObject<Activity>(SlackMessageJson));
+
+        var json = ProtocolJsonSerializer.ToJson(slack);
+        var roundTripped = Assert.IsType<SlackActivity>(ProtocolJsonSerializer.ToObject<Activity>(json));
+
+        Assert.Equal("C0AT123", roundTripped.ChannelData.Channel);
+        Assert.Equal("xoxb-token", roundTripped.ChannelData.ApiToken);
+    }
+}

--- a/src/tests/Microsoft.Agents.Extensions.Slack.Tests/SlackActivityTests.cs
+++ b/src/tests/Microsoft.Agents.Extensions.Slack.Tests/SlackActivityTests.cs
@@ -9,9 +9,12 @@ namespace Microsoft.Agents.Extensions.Slack.Tests;
 
 /// <summary>
 /// Tests for the polymorphic resolution of inbound Activities to <see cref="SlackActivity"/>.
-/// The resolver (registered in <c>Serialization.SerializationInit.Init</c>) maps any Activity whose
-/// channelId is "slack" to <see cref="SlackActivity"/>, exposing a strongly-typed
-/// <see cref="Api.SlackChannelData"/> via the <see cref="SlackActivity.ChannelData"/> shadow.
+/// Resolution is driven by the <c>[ActivityType(ChannelId = "slack")]</c> annotation on
+/// <see cref="SlackActivity"/>, which the source generator turns into an assembly-level
+/// <see cref="ActivityTypeInitAssemblyAttribute"/> that auto-registers the type at load time.
+/// Any Activity whose channelId is "slack" therefore deserializes to <see cref="SlackActivity"/>,
+/// exposing a strongly-typed <see cref="Api.SlackChannelData"/> via the
+/// <see cref="SlackActivity.ChannelData"/> shadow.
 /// </summary>
 public class SlackActivityTests
 {

--- a/src/tests/Microsoft.Agents.Model.Tests/CustomActivityTypeTests.cs
+++ b/src/tests/Microsoft.Agents.Model.Tests/CustomActivityTypeTests.cs
@@ -1,0 +1,434 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using Microsoft.Agents.Core.Models;
+using Microsoft.Agents.Core.Serialization;
+using Xunit;
+
+namespace Microsoft.Agents.Model.Tests
+{
+    public class CustomActivityTypeTests
+    {
+        // Register custom activity types/resolvers, always clearing afterward to keep the global
+        // ProtocolJsonSerializer resolution state from leaking into other tests. Only "x-*" types and
+        // fake channel ids are used so concurrent deserialization of real Activities never matches.
+        private static IDisposable Register(params Type[] types)
+        {
+            ProtocolJsonSerializer.RegisterActivityTypes(types);
+            return new Cleanup();
+        }
+
+        [Fact]
+        public void CustomActivityType_ResolvesSubclass()
+        {
+            using var _ = Register(typeof(WorkflowTriggerActivity));
+
+            var json = """
+                {
+                  "type": "x-workflowTrigger",
+                  "id": "act-1",
+                  "workflowId": "wf-42",
+                  "correlationId": "corr-9",
+                  "parameters": { "region": "west", "count": 3 }
+                }
+                """;
+
+            var result = ProtocolJsonSerializer.ToObject<Activity>(json);
+
+            var trigger = Assert.IsType<WorkflowTriggerActivity>(result);
+            Assert.Equal("x-workflowTrigger", trigger.Type);
+            Assert.Equal("act-1", trigger.Id);
+            Assert.Equal("wf-42", trigger.WorkflowId);
+            Assert.Equal("corr-9", trigger.CorrelationId);
+            Assert.NotNull(trigger.Parameters);
+            Assert.Equal(2, trigger.Parameters.Count);
+        }
+
+        [Fact]
+        public void UnregisteredType_FallsBackToActivity()
+        {
+            // Registry is non-empty, but "message" is never registered -> base Activity.
+            using var _ = Register(typeof(WorkflowTriggerActivity));
+
+            var json = """{"type":"message","text":"hello","id":"m-1"}""";
+
+            var result = ProtocolJsonSerializer.ToObject<Activity>(json);
+
+            Assert.Equal(typeof(Activity), result.GetType());
+            Assert.Equal("message", result.Type);
+            Assert.Equal("hello", result.Text);
+        }
+
+        [Fact]
+        public void IActivity_AlsoResolvesSubclass()
+        {
+            using var _ = Register(typeof(WorkflowTriggerActivity));
+
+            var json = """{"type":"x-workflowTrigger","workflowId":"wf-1"}""";
+
+            var result = ProtocolJsonSerializer.ToObject<IActivity>(json);
+
+            var trigger = Assert.IsType<WorkflowTriggerActivity>(result);
+            Assert.Equal("wf-1", trigger.WorkflowId);
+        }
+
+        [Fact]
+        public void MultipleAttributes_RegisterAllTypeStrings()
+        {
+            using var _ = Register(typeof(MultiTypeActivity));
+
+            var a = ProtocolJsonSerializer.ToObject<Activity>("""{"type":"x-alpha"}""");
+            var b = ProtocolJsonSerializer.ToObject<Activity>("""{"type":"x-beta"}""");
+
+            Assert.IsType<MultiTypeActivity>(a);
+            Assert.IsType<MultiTypeActivity>(b);
+        }
+
+        [Fact]
+        public void ShadowedProperty_Deserializes()
+        {
+            using var _ = Register(typeof(ShadowActivity));
+
+            var json = """{"type":"x-shadow","speak":"strengthened"}""";
+
+            var result = ProtocolJsonSerializer.ToObject<Activity>(json);
+
+            var shadow = Assert.IsType<ShadowActivity>(result);
+            Assert.Equal("strengthened", shadow.Speak);
+        }
+
+        [Fact]
+        public void CustomActivity_RoundTrips()
+        {
+            using var _ = Register(typeof(WorkflowTriggerActivity));
+
+            var original = new WorkflowTriggerActivity
+            {
+                Type = "x-workflowTrigger",
+                Id = "rt-1",
+                WorkflowId = "wf-77",
+                CorrelationId = "corr-2",
+                Parameters = new Dictionary<string, object> { ["k"] = "v" }
+            };
+
+            var json = ProtocolJsonSerializer.ToJson(original);
+            var result = ProtocolJsonSerializer.ToObject<Activity>(json);
+
+            var trigger = Assert.IsType<WorkflowTriggerActivity>(result);
+            Assert.Equal("wf-77", trigger.WorkflowId);
+            Assert.Equal("corr-2", trigger.CorrelationId);
+            Assert.NotNull(trigger.Parameters);
+            Assert.Single(trigger.Parameters);
+        }
+
+        [Fact]
+        public void CustomActivityType_ResolvesWhenTypeNotFirst()
+        {
+            // "type" appears after a nested object — exercises the peek's skip-over-nested logic.
+            using var _ = Register(typeof(WorkflowTriggerActivity));
+
+            var json = """
+                {
+                  "id": "act-2",
+                  "parameters": { "region": "east", "nested": { "deep": true } },
+                  "channelData": { "foo": "bar" },
+                  "type": "x-workflowTrigger",
+                  "workflowId": "wf-99"
+                }
+                """;
+
+            var result = ProtocolJsonSerializer.ToObject<Activity>(json);
+
+            var trigger = Assert.IsType<WorkflowTriggerActivity>(result);
+            Assert.Equal("act-2", trigger.Id);
+            Assert.Equal("wf-99", trigger.WorkflowId);
+            Assert.NotNull(trigger.Parameters);
+        }
+
+        [Fact]
+        public void ChannelIdDiscriminator_ResolvesSubclass()
+        {
+            // "message" activities on the fake teams channel resolve to the Teams subclass...
+            using var __ = Register(typeof(TeamsChannelMessageActivity));
+
+            var teams = ProtocolJsonSerializer.ToObject<Activity>(
+                """{"type":"message","channelId":"x-teams-test","text":"hi"}""");
+            Assert.IsType<TeamsChannelMessageActivity>(teams);
+
+            // ...but the same type on a different channel falls back to the base Activity.
+            var other = ProtocolJsonSerializer.ToObject<Activity>(
+                """{"type":"message","channelId":"x-other-test","text":"hi"}""");
+            Assert.Equal(typeof(Activity), other.GetType());
+        }
+
+        [Fact]
+        public void ChannelIdOnly_MatchesAnyType()
+        {
+            // No Type discriminator -> any activity on the channel resolves.
+            using var __ = Register(typeof(AnyTeamsChannelActivity));
+
+            var message = ProtocolJsonSerializer.ToObject<Activity>(
+                """{"type":"message","channelId":"x-anyteams-test"}""");
+            var invoke = ProtocolJsonSerializer.ToObject<Activity>(
+                """{"type":"invoke","channelId":"x-anyteams-test"}""");
+
+            Assert.IsType<AnyTeamsChannelActivity>(message);
+            Assert.IsType<AnyTeamsChannelActivity>(invoke);
+        }
+
+        [Fact]
+        public void ChannelIdDiscriminator_IgnoresProductSubChannelSuffix()
+        {
+            // channelId may carry a "{channel}:{product}" suffix; matching is on the channel segment.
+            using var __ = Register(typeof(TeamsChannelMessageActivity));
+
+            var result = ProtocolJsonSerializer.ToObject<Activity>(
+                """{"type":"message","channelId":"x-teams-test:someProduct","text":"hi"}""");
+
+            Assert.IsType<TeamsChannelMessageActivity>(result);
+        }
+
+        [Fact]
+        public void NameDiscriminator_ResolvesSubclass()
+        {
+            // Second-level discrimination on invoke name.
+            using var __ = Register(typeof(TaskFetchInvokeActivity));
+
+            var match = ProtocolJsonSerializer.ToObject<Activity>(
+                """{"type":"x-invoke","name":"task/fetch"}""");
+            var noMatch = ProtocolJsonSerializer.ToObject<Activity>(
+                """{"type":"x-invoke","name":"task/submit"}""");
+
+            Assert.IsType<TaskFetchInvokeActivity>(match);
+            Assert.Equal(typeof(Activity), noMatch.GetType());
+        }
+
+        [Fact]
+        public void MostSpecificRegistration_Wins()
+        {
+            // A channel-only (specificity 1) and a type+channel (specificity 2) registration both
+            // target the same channel. The more specific one wins regardless of registration order.
+            using var __ = Register(typeof(SpecChannelActivity), typeof(SpecTypeChannelActivity));
+
+            var message = ProtocolJsonSerializer.ToObject<Activity>(
+                """{"type":"message","channelId":"x-spec-test"}""");
+            var invoke = ProtocolJsonSerializer.ToObject<Activity>(
+                """{"type":"invoke","channelId":"x-spec-test"}""");
+
+            // message matches both -> the 2-discriminator registration wins.
+            Assert.IsType<SpecTypeChannelActivity>(message);
+            // invoke matches only the channel-only registration.
+            Assert.IsType<SpecChannelActivity>(invoke);
+        }
+
+        [Fact]
+        public void CustomResolver_ResolvesSubclass()
+        {
+            // Fully imperative resolution for logic the attributes can't express.
+            ProtocolJsonSerializer.RegisterActivityTypeResolver(
+                (ref Utf8JsonReader reader, in ActivityResolutionContext ctx) =>
+                    ctx.ChannelId == "x-resolver-test" ? typeof(ResolverActivity) : null);
+
+            try
+            {
+                var match = ProtocolJsonSerializer.ToObject<Activity>(
+                    """{"type":"message","channelId":"x-resolver-test"}""");
+                var noMatch = ProtocolJsonSerializer.ToObject<Activity>(
+                    """{"type":"message","channelId":"x-elsewhere"}""");
+
+                Assert.IsType<ResolverActivity>(match);
+                Assert.Equal(typeof(Activity), noMatch.GetType());
+            }
+            finally
+            {
+                ProtocolJsonSerializer.ClearActivityTypeRegistrations();
+            }
+        }
+
+        [Fact]
+        public void CustomResolver_TakesPriorityOverDeclarative()
+        {
+            using var __ = Register(typeof(TeamsChannelMessageActivity));
+            ProtocolJsonSerializer.RegisterActivityTypeResolver(
+                (ref Utf8JsonReader reader, in ActivityResolutionContext ctx) =>
+                    ctx.ChannelId == "x-teams-test" ? typeof(ResolverActivity) : null);
+
+            var result = ProtocolJsonSerializer.ToObject<Activity>(
+                """{"type":"message","channelId":"x-teams-test"}""");
+
+            // Resolver runs before declarative registrations.
+            Assert.IsType<ResolverActivity>(result);
+        }
+
+        [Fact]
+        public void CustomResolver_CanDiscriminateOnNestedProperty()
+        {
+            // The reader gives resolvers access to ANY property, including nested ones the
+            // well-known discriminators (type/channelId/name) don't surface.
+            ProtocolJsonSerializer.RegisterActivityTypeResolver(
+                (ref Utf8JsonReader reader, in ActivityResolutionContext ctx) =>
+                {
+                    if (JsonDocument.TryParseValue(ref reader, out var doc))
+                    {
+                        using (doc)
+                        {
+                            if (doc.RootElement.TryGetProperty("value", out var value)
+                                && value.TryGetProperty("action", out var action)
+                                && action.GetString() == "escalate")
+                            {
+                                return typeof(EscalatedActivity);
+                            }
+                        }
+                    }
+
+                    return null;
+                });
+
+            try
+            {
+                var match = ProtocolJsonSerializer.ToObject<Activity>(
+                    """{"type":"invoke","value":{"action":"escalate","ticket":"T-9"}}""");
+                var noMatch = ProtocolJsonSerializer.ToObject<Activity>(
+                    """{"type":"invoke","value":{"action":"acknowledge"}}""");
+
+                Assert.IsType<EscalatedActivity>(match);
+                Assert.Equal(typeof(Activity), noMatch.GetType());
+            }
+            finally
+            {
+                ProtocolJsonSerializer.ClearActivityTypeRegistrations();
+            }
+        }
+
+        [Fact]
+        public void CustomResolver_ReaderCopyDoesNotDisturbDeserialization()
+        {
+            // A resolver that fully consumes its reader copy must not corrupt the actual
+            // deserialization of the Activity.
+            ProtocolJsonSerializer.RegisterActivityTypeResolver(
+                (ref Utf8JsonReader reader, in ActivityResolutionContext ctx) =>
+                {
+                    // Drain the copy entirely.
+                    while (reader.Read())
+                    {
+                    }
+
+                    return null;
+                });
+
+            try
+            {
+                var result = ProtocolJsonSerializer.ToObject<Activity>(
+                    """{"type":"message","text":"hello","id":"m-1"}""");
+
+                Assert.Equal(typeof(Activity), result.GetType());
+                Assert.Equal("message", result.Type);
+                Assert.Equal("hello", result.Text);
+                Assert.Equal("m-1", result.Id);
+            }
+            finally
+            {
+                ProtocolJsonSerializer.ClearActivityTypeRegistrations();
+            }
+        }
+
+        [Fact]
+        public void RegisterActivityTypeResolver_Null_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                ProtocolJsonSerializer.RegisterActivityTypeResolver(null));
+        }
+
+        [Fact]
+        public void RegisterActivityTypes_NoDiscriminator_Throws()
+        {
+            Assert.Throws<ArgumentException>(() =>
+                ProtocolJsonSerializer.RegisterActivityTypes(new[] { typeof(NoDiscriminatorActivity) }));
+        }
+
+        [Fact]
+        public void RegisterActivityTypes_NonActivityType_Throws()
+        {
+            Assert.Throws<ArgumentException>(() =>
+                ProtocolJsonSerializer.RegisterActivityTypes(new[] { typeof(NotAnActivity) }));
+        }
+
+        [Fact]
+        public void RegisterActivityTypes_Null_DoesNotThrow()
+        {
+            ProtocolJsonSerializer.RegisterActivityTypes(null);
+        }
+
+        private sealed class Cleanup : IDisposable
+        {
+            public void Dispose() => ProtocolJsonSerializer.ClearActivityTypeRegistrations();
+        }
+
+        [ActivityType("x-workflowTrigger")]
+        private class WorkflowTriggerActivity : Activity
+        {
+            public string WorkflowId { get; set; }
+
+            public Dictionary<string, object> Parameters { get; set; }
+
+            public string CorrelationId { get; set; }
+        }
+
+        [ActivityType("x-alpha")]
+        [ActivityType("x-beta")]
+        private class MultiTypeActivity : Activity
+        {
+        }
+
+        [ActivityType("x-shadow")]
+        private class ShadowActivity : Activity
+        {
+            public new string Speak { get; set; }
+        }
+
+        [ActivityType("message", ChannelId = "x-teams-test")]
+        private class TeamsChannelMessageActivity : Activity
+        {
+        }
+
+        [ActivityType(ChannelId = "x-anyteams-test")]
+        private class AnyTeamsChannelActivity : Activity
+        {
+        }
+
+        [ActivityType("x-invoke", Name = "task/fetch")]
+        private class TaskFetchInvokeActivity : Activity
+        {
+        }
+
+        [ActivityType(ChannelId = "x-spec-test")]
+        private class SpecChannelActivity : Activity
+        {
+        }
+
+        [ActivityType("message", ChannelId = "x-spec-test")]
+        private class SpecTypeChannelActivity : Activity
+        {
+        }
+
+        private class ResolverActivity : Activity
+        {
+        }
+
+        private class EscalatedActivity : Activity
+        {
+        }
+
+        [ActivityType]
+        private class NoDiscriminatorActivity : Activity
+        {
+        }
+
+        private class NotAnActivity
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Custom Activity Types

Enables extensions and channels to define strongly-typed `Activity` subclasses that are deserialized directly from the wire format, based on discriminators peeked from the inbound JSON — no more stuffing everything into untyped `Value` / `ChannelData`.

### Key features
- **Declarative registration** — annotate a subclass with `[ActivityType]`, matching on any combination of `type`, `channelId`, and/or `name` (AND semantics, unset = wildcard). Most-specific registration wins.
- **Imperative escape hatch** — `ActivityTypeResolver` receives a private `Utf8JsonReader` to discriminate on *any* property (including nested), for cases the attribute can't express.
- **Zero-ceremony auto-registration** — a source generator emits an assembly attribute per `[ActivityType]` class; types register at load time (mirrors the `EntityInit` pattern). No DI wiring, no per-extension `SerializationInit` call.
- **Type-safe handlers** — `TypedRouteHandler<T>` + `TypedTurnContext<T>` deliver the resolved subclass to handlers as `ITurnContext<T>`, no manual casting.
- **Slack reference implementation** — `SlackActivity` / `ISlackActivity` with a strongly-typed `ChannelData`, matched by `[ActivityType(ChannelId = "slack")]`, validating the full path end-to-end.

### Benefits
- **Non-breaking & opt-in** — existing `Activity` / `IActivity` code is unaffected; a zero-overhead fast path runs when no custom types are registered.
- **Correct round-tripping** — an `ActivityConverter.CanConvert` override makes the converter own the whole `Activity` hierarchy for both read and write.
- **Extension-driven** — each extension owns its own types; no central enum or factory to modify.

### Design doc
The full design addendum is attached below.

<details>
<summary><b>2026-06-15-custom-activity-types-addendum.md</b></summary>


# Custom Activity Types Design

## Addendum to: Non-Breaking Multi-Adapter Extension Design (2026-06-10)

### Status: Implemented

This document describes support for **custom activity types** — enabling extensions and
channels to define strongly-typed `Activity` subclasses that are deserialized directly
from the wire format based on discriminators peeked from the inbound JSON. This is
independent of (and can ship before or after) the multi-adapter registry work.

> **Note (reconciliation):** This addendum was originally a proposal. It has been updated
> to describe **where the implementation actually landed** on branch
> `users/tracyboehrer/custom-activity`. The shipped design generalized the original
> `type`-only lookup into a multi-discriminator (`type` / `channelId` / `name`) match plus
> an imperative resolver hook, and it auto-registers annotated types via a source generator
> (mirroring the `EntityInit` pattern) rather than via per-extension `SerializationInit`
> calls. The validating example is the **Slack** extension.

---

## Problem

Today, all inbound Activities deserialize into the single `Activity` class regardless
of their `type` field. The handler then discriminates using string comparison:

```csharp
OnActivity(ActivityTypes.Message, HandleMessageAsync);
OnActivity(ActivityTypes.ConversationUpdate, HandleConversationUpdateAsync);
```

The `Activity` class already implements typed marker interfaces (`IMessageActivity`,
`IConversationUpdateActivity`, etc.), but these are **compile-time aids only** — the
same runtime instance services all of them. This means:

1. **No custom properties per type/channel.** A `commandResult` activity carries a `Result`
   payload, but you access it via `Activity.Value` (untyped `object`). Channel-specific
   activities (Teams task/fetch, Copilot Studio events, Slack interactive payloads) stuff
   everything into `ChannelData`.

2. **No extensibility point for new types.** The Activity Protocol spec explicitly
   allows custom activity types (`x-*` prefix). Today these deserialize into a generic
   `Activity` with only `Type` and `Value` populated — there's no mechanism to
   deserialize into a developer-defined type with strongly-typed properties.

3. **Route handlers receive `IActivity` always.** Even when the route already proved
   `Type == "message"`, the handler works with the full union type.

---

## Design Goals

1. **Register custom Activity subclasses** annotated with the discriminators
   (`type`, and/or `channelId`, and/or `name`) they apply to — not just a single type
   string. This lets an extension supply a custom Activity for an *existing* type on a
   specific channel (e.g. any `channelId == "slack"` → `SlackActivity`).
2. **Automatic polymorphic deserialization** — the `ActivityConverter` peeks the inbound
   JSON, resolves the correct CLR type, and deserializes into it before handing the
   Activity to the pipeline.
3. **An imperative escape hatch** — an `ActivityTypeResolver` delegate receives a private
   `Utf8JsonReader` so it can discriminate on *any* property (including nested ones) that
   the declarative discriminators can't express.
4. **Type-safe handlers** — extensions can register route handlers that receive the
   specific subclass via `ITurnContext<TActivity>` (using `TypedRouteHandler<T>` +
   `TypedTurnContext<T>`), no manual casting.
5. **Non-breaking** — existing code that uses `Activity` / `IActivity` continues
   to work. Custom types are opt-in per-registration and there is a zero-overhead fast
   path when none are registered.
6. **Extension-driven & zero-ceremony** — each extension annotates its own types with
   `[ActivityType]`; a source generator auto-registers them at assembly load. No central
   enum, factory, or DI wiring, and no per-extension `SerializationInit` call is required.

---

## Core Components

### ActivityTypeAttribute

Annotates a custom Activity subclass with the discriminators an inbound Activity must
match. Discriminators are combined with **AND**; an unset discriminator is a wildcard.
At least one of `Type` / `ChannelId` / `Name` must be set. The attribute is
`AllowMultiple = true`, so one class can match more than one shape.

```csharp
[AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
public sealed class ActivityTypeAttribute : Attribute
{
    public ActivityTypeAttribute() { }
    public ActivityTypeAttribute(string type) { Type = type; }

    /// <summary>The activity <c>type</c> string (e.g., "message", "event", "x-myCustomType").</summary>
    public string Type { get; set; }

    /// <summary>The Activity <c>channelId</c> to match (e.g., "msteams", "slack").</summary>
    public string ChannelId { get; set; }

    /// <summary>The Activity <c>name</c> to match (e.g., an invoke name like "task/fetch").</summary>
    public string Name { get; set; }
}
```

Usage:

```csharp
// Any activity on the slack channel deserializes to SlackActivity:
[ActivityType(ChannelId = "slack")]
public class SlackActivity : Activity { /* typed ChannelData */ }

// Only "message" activities on msteams deserialize to TeamsMessageActivity:
[ActivityType("message", ChannelId = "msteams")]
public class TeamsMessageActivity : Activity { }

// A compound (type + name) discriminator for an invoke sub-shape:
[ActivityType("invoke", Name = "task/fetch")]
public class TaskFetchActivity : Activity { }

// A brand-new protocol type:
[ActivityType("x-workflowTrigger")]
public class WorkflowTriggerActivity : Activity { }
```

When several registrations match a given Activity, the **most specific** one wins — the
registration with the greatest number of set discriminators (ties resolved by
registration order). So `[ActivityType("message", ChannelId = "msteams")]` beats
`[ActivityType(ChannelId = "msteams")]` for an msteams message.

### ActivityResolutionContext & ActivityTypeResolver

For discrimination the declarative attribute can't express (arbitrary or nested
properties), register an imperative resolver. The resolver receives:

- a **private, forward-only `Utf8JsonReader`** copy positioned at the Activity's opening
  `StartObject` — a throwaway (each resolver gets its own copy, so reading from it never
  disturbs deserialization or other resolvers); and
- an `ActivityResolutionContext` carrying the well-known discriminators already peeked
  (`Type` / `ChannelId` / `Name`), for convenience.

```csharp
public readonly struct ActivityResolutionContext
{
    public ActivityResolutionContext(string type, string channelId, string name);
    public string Type { get; }        // the "type" field
    public string ChannelId { get; }   // channel segment only ("{channel}:{product}" suffix stripped)
    public string Name { get; }        // the "name" field
}

/// Returns the Activity subclass to deserialize into, or null to defer.
public delegate System.Type ActivityTypeResolver(
    ref System.Text.Json.Utf8JsonReader reader,
    in ActivityResolutionContext context);
```

`ChannelId` is the channel segment only (any `:product` sub-channel suffix is stripped),
so matching a bare channel id works regardless of the
`ProtocolJsonSerializer.ChannelIdIncludesProduct` setting.

### ProtocolJsonSerializer: registration & resolution

Registrations and resolvers are held in copy-on-write arrays behind a lock (lock-free
reads on the hot path). The type-only `type → subclass` case is the common one, but the
same list carries `channelId` / `name` discriminators.

```csharp
public static class ProtocolJsonSerializer
{
    // Idempotent. Rarely called directly — auto-registration (below) normally handles this.
    // Throws if a type doesn't derive from Activity, or a [ActivityType] sets no discriminator.
    public static void RegisterActivityTypes(IEnumerable<Type> types);

    // Imperative escape hatch. Resolvers are consulted (in registration order) BEFORE
    // declarative registrations; the first to return non-null wins.
    public static void RegisterActivityTypeResolver(ActivityTypeResolver resolver);

    // True when any registration or resolver exists — gates the converter's fast path.
    internal static bool HasActivityTypeRegistrations { get; }

    // Resolvers first (registration order), then the most-specific matching declarative
    // registration. Returns null to use the base Activity.
    internal static Type ResolveActivityType(ref Utf8JsonReader reader, in ActivityResolutionContext context);

    // Test isolation: wipes all registrations AND resolvers.
    internal static void ClearActivityTypeRegistrations();
}
```

`RegisterActivityTypes` deduplicates on `(ClrType, Type, ChannelId, Name)`
(case-insensitive), so re-processing the same assembly — e.g. the initial scan plus the
`AssemblyLoad` handler — is harmless.

### ActivityConverter enhancement

Two changes to the existing `ActivityConverter` (a `ConnectorConverter<Activity>`):

```csharp
internal class ActivityConverter : ConnectorConverter<Activity>
{
    // Critical: a JsonConverter<Activity> otherwise only claims typeof(Activity), so
    // *writing* a top-level subclass instance would fall back to STJ reflection and
    // mis-serialize (e.g. channelId as an object). This override makes the converter own
    // the whole Activity hierarchy for both read and write.
    public override bool CanConvert(Type typeToConvert)
        => typeof(Activity).IsAssignableFrom(typeToConvert);

    public override Activity Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
    {
        // Fast path: no custom resolution registered — existing behavior, zero overhead
        // (not even a peek).
        if (!ProtocolJsonSerializer.HasActivityTypeRegistrations)
            return ReadDefault(ref reader, typeToConvert, options);

        // Peek the well-known discriminators from a throwaway copy.
        var readerCopy = reader;
        var context = PeekDiscriminators(ref readerCopy);

        // Resolvers may scan arbitrary properties, so hand resolution a fresh copy
        // positioned at StartObject. The real reader stays untouched.
        var resolverReader = reader;
        var resolvedType = ProtocolJsonSerializer.ResolveActivityType(ref resolverReader, in context);
        if (resolvedType != null)
            return ReadDefault(ref reader, resolvedType, options);

        return ReadDefault(ref reader, typeToConvert, options);
    }
}
```

**Performance note:** `PeekDiscriminators` scans only the top-level `type` / `channelId` /
`name` string properties and skips over nested values. When `HasActivityTypeRegistrations`
is false, the existing code path runs with zero overhead — not even the peek.

---

## Auto-Registration (source generator + assembly attribute)

Rather than requiring each extension's `SerializationInit` to call `RegisterActivityTypes`,
`[ActivityType]` classes are discovered at compile time and registered at load time,
**mirroring the `EntityInit` pattern** (not the converter/`SerializationInit` pattern).

1. **`ActivityTypeInitSourceGenerator`** (in `Microsoft.Agents.Core.Analyzers`) uses
   `ForAttributeWithMetadataName("Microsoft.Agents.Core.Serialization.ActivityTypeAttribute", …)`
   to find every annotated class and emits one assembly attribute per class into
   `ActivityTypeInitAssemblyAttributes.g.cs`:

   ```csharp
   [assembly: Microsoft.Agents.Core.Serialization.ActivityTypeInitAssemblyAttribute(typeof(global::MyNs.MyActivity))]
   ```

2. **`ActivityTypeInitAssemblyAttribute`** (in `Microsoft.Agents.Core`) reads those
   attributes at initialization. Its `InitSerialization()` is called from the
   `ProtocolJsonSerializer` static constructor (alongside `SerializationInitAssemblyAttribute`
   and `EntityInitAssemblyAttribute`). It hooks `AppDomain.AssemblyLoad` and scans
   already-loaded assemblies, reading each assembly's `ActivityTypeInitAssemblyAttribute`s
   and calling `RegisterActivityTypes` (in a try/catch that swallows a single bad
   registration so it can't break serialization init for everything else):

   ```csharp
   [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
   public class ActivityTypeInitAssemblyAttribute(Type type) : Attribute
   {
       public readonly Type ActivityType = type;
       internal static void InitSerialization() { /* hook AssemblyLoad + scan loaded assemblies */ }
   }
   ```

This avoids scanning every type in every assembly at runtime — the generator did the
discovery at build time, and the assembly attribute is the cheap runtime hand-off. The CLR
doesn't load a referenced assembly until one of its types is used, which is where the
preload generator comes in (next).

### PreloadAssembliesSourceGenerator integration

The `PreloadAssembliesSourceGenerator` scans the consuming compilation's **referenced**
assemblies for both custom `Entity` subclasses (registered via `EntityInitAssemblyAttribute`)
and custom `Activity` subclasses, and emits a registry that references `typeof(...)` for
each — forcing the owning assembly to load so its serialization initialization (including
the `ActivityTypeInitAssemblyAttribute` scan) runs even if the app never otherwise touches
a type from that assembly.

### No DI required

Unlike an earlier sketch (`AddActivityTypeResolver`, `AddTeamsActivityTypes`), this
requires **no DI registration and no per-extension `SerializationInit` call**. Annotate the
subclass with `[ActivityType]` and reference the extension — the generator and assembly
attribute do the rest. `RegisterActivityTypes` / `RegisterActivityTypeResolver` remain
public for explicit or dynamic registration.

---

## Type-Safe Handlers

The SDK ships generic primitives for typed handlers (no per-extension builder subclass
needed):

- **`TypedRouteHandler<T>`** (in `Microsoft.Agents.Builder.App`):

  ```csharp
  public delegate Task TypedRouteHandler<T>(ITurnContext<T> turnContext, ITurnState turnState, CancellationToken cancellationToken)
      where T : IActivity;
  ```

- **`TypedTurnContext<T>`** (in `Microsoft.Agents.Builder`): wraps an inner `ITurnContext`
  and exposes `Activity` as `T`.

A route attribute declares the typed handler as an accepted signature via
`[RouteHandlerType]` and, in `AddRoute`, wraps the turn context. This is how Slack's
`[SlackMessageRoute]` supports both the plain `RouteHandler` and a typed
`TypedRouteHandler<ISlackActivity>` on the same attribute:

```csharp
[RouteHandlerType(typeof(RouteHandler))]
[RouteHandlerType(typeof(TypedRouteHandler<ISlackActivity>))]
public class SlackMessageRouteAttribute(...) : Attribute, IRouteAttribute
{
    public void AddRoute(AgentApplication app, MethodInfo method)
    {
        var handler = RouteAttributeHelper.CreateMatchingHandlerDelegate(app, method, GetType());

        RouteHandler routeHandler;
        if (handler is TypedRouteHandler<ISlackActivity> typedHandler)
        {
            routeHandler = (ctx, state, ct) =>
                typedHandler(new TypedTurnContext<ISlackActivity>(ctx), state, ct);
        }
        else
        {
            routeHandler = (RouteHandler)handler;
        }

        var b = MessageRouteBuilder.Create().WithHandler(routeHandler)
            .WithChannelId(Channels.Slack) /* … */;
        app.AddRoute(b.Build());
    }
}
```

A handler can therefore be written against the typed context and receive the resolved
subclass directly:

```csharp
[SlackMessageRoute]
public Task OnSlackMessage(ITurnContext<ISlackActivity> ctx, ITurnState state, CancellationToken ct)
{
    SlackChannelData data = ctx.Activity.ChannelData; // strongly typed
    return Task.CompletedTask;
}
```

Alternatively, a plain `OnActivity` handler can `is`-check the runtime type
(`ctx.Activity is ISlackActivity slack`) — useful for multi-protocol agents with a mostly
shared code path.

---

## Custom Activity Subclass Design

### Rules

1. **Must derive from `Activity`** (directly or transitively).
2. **Must have a public parameterless constructor** (for deserialization).
3. **May shadow base properties with `new`** to provide stronger typing.
4. **May add new properties** — deserialized via the standard `ConnectorConverter`
   property-mapping logic.
5. **May carry multiple `[ActivityType]`** attributes to match several shapes; most
   specific wins at resolution time.

### The typed-`ChannelData` shadow gotcha

When shadowing `ChannelData` with a stronger type, make it a **computed** property that
reads through the base — do **not** make it an auto-property and do **not** put
`[JsonIgnore]` on it:

```csharp
[ActivityType(ChannelId = Channels.Slack)]
public class SlackActivity : Activity, ISlackActivity
{
    public new SlackChannelData ChannelData
    {
        get => this.GetChannelData<SlackChannelData>();
        set => base.ChannelData = value;
    }
}
```

Why: `ActivityConverter` intercepts the `"channelData"` property and writes the **base**
`Activity.ChannelData` (raw JSON). A shadowed *auto*-property would never be populated on
read. And `[JsonIgnore]` on the shadow would drop `channelData` from output entirely
(`ConnectorConverter` keeps the most-derived shadowed property), breaking round-trip. A
computed shadow that delegates to the base keeps both views in sync.

---

## Discrimination Beyond `type`

Because a registration can set any combination of `type` / `channelId` / `name`, common
"second-level" discrimination is now first-class (no route-selector gymnastics required):

**By channel** — a custom Activity for an *existing* type on one channel:

```csharp
[ActivityType(ChannelId = "slack")]   // any activity on slack
public class SlackActivity : Activity { }
```

**Compound (type + name)** — e.g. Teams invoke sub-shapes, most-specific-wins picks the
narrowest:

```csharp
[ActivityType("invoke")]                              // fallback for all invokes
public class InvokeActivity : Activity { }

[ActivityType("invoke", Name = "task/fetch")]         // wins for task/fetch
public class TaskFetchActivity : Activity { }
```

**Arbitrary / nested properties** — register an imperative resolver:

```csharp
ProtocolJsonSerializer.RegisterActivityTypeResolver((ref Utf8JsonReader reader, in ActivityResolutionContext ctx) =>
{
    if (ctx.Type == "event" && JsonDocument.TryParseValue(ref reader, out var doc))
    {
        using (doc)
        {
            if (doc.RootElement.TryGetProperty("value", out var v)
                && v.TryGetProperty("schema", out var s)
                && s.GetString() == "workflow/v2")
            {
                return typeof(WorkflowV2Activity);
            }
        }
    }
    return null; // defer
});
```

---

## Backward Compatibility

| Scenario | Behavior |
|----------|----------|
| No custom activity types/resolvers registered | Existing behavior — always returns `Activity`, zero overhead (no peek) |
| Registration matches peeked discriminators | Returns the registered subclass (most specific match) |
| Resolver returns a type | Returns that type (resolvers run before declarative registrations) |
| Registered but no match | Returns base `Activity` (fallback) |
| Code using `IActivity` / `Activity` | Subclass IS-A `Activity`, so all existing code works |
| `activity.IsType("message")` | Works — `Type` property still set |
| Writing a subclass instance | Correct, thanks to the `CanConvert` override |

---

## Example: Slack Extension (the validating end-to-end case)

The Slack extension is the reference implementation that exercises the whole path —
`[ActivityType]` → generated assembly attribute → load-time auto-registration → converter
resolution → typed handler.

```csharp
// ISlackActivity.cs
public interface ISlackActivity : IActivity
{
    new SlackChannelData ChannelData { get; set; }
}

// SlackActivity.cs — auto-registered via the generated ActivityTypeInitAssemblyAttribute
[ActivityType(ChannelId = Channels.Slack)]   // Channels.Slack == "slack"
public class SlackActivity : Activity, ISlackActivity
{
    public new SlackChannelData ChannelData
    {
        get => this.GetChannelData<SlackChannelData>();
        set => base.ChannelData = value;
    }
}
```

No `SerializationInit` change and no DI wiring — the Slack extension references
`Microsoft.Agents.Core.Analyzers` as an analyzer, so the generator emits
`[assembly: ActivityTypeInitAssemblyAttribute(typeof(SlackActivity))]` into `Slack.dll`,
and any inbound Activity with `channelId == "slack"` deserializes to `SlackActivity`.

---

## Example: Custom Protocol Activity

```csharp
[ActivityType("x-workflowTrigger")]
public class WorkflowTriggerActivity : Activity
{
    public string WorkflowId { get; set; }
    public Dictionary<string, object> Parameters { get; set; }
    public string CorrelationId { get; set; }
}

AddRoute(RouteBuilder.Create()
    .WithSelector((ctx, ct) => Task.FromResult(ctx.Activity is WorkflowTriggerActivity))
    .WithHandler(async (ctx, ts, ct) =>
    {
        var trigger = (WorkflowTriggerActivity)ctx.Activity;
        await ExecuteWorkflowAsync(trigger.WorkflowId, trigger.Parameters, ct);
    })
    .Build());
```

---

## Changes Landed

| Component | Change | Breaking? |
|-----------|--------|-----------|
| `ActivityTypeAttribute` | New attribute — `Type` / `ChannelId` / `Name` discriminators, `AllowMultiple` | No (additive) |
| `ActivityResolutionContext` / `ActivityTypeResolver` | New struct + delegate for imperative resolution (with `Utf8JsonReader`) | No (additive) |
| `ActivityTypeRegistration` | Internal: a declarative registration + `Specificity` + `Matches` | No (internal) |
| `ProtocolJsonSerializer` | `RegisterActivityTypes`, `RegisterActivityTypeResolver`, `ResolveActivityType`, `HasActivityTypeRegistrations`, `ClearActivityTypeRegistrations`; dedup | No (additive) |
| `ActivityConverter` | `CanConvert` override (owns the hierarchy) + `Read` peek/resolve | No (fast-path fallback when none registered) |
| `ActivityTypeInitAssemblyAttribute` | New assembly attribute + load-time registration (mirrors `EntityInit`) | No (additive) |
| `ActivityTypeInitSourceGenerator` | New generator emits the assembly attribute per `[ActivityType]` class | No (additive) |
| `PreloadAssembliesSourceGenerator` | Extended to also discover `Activity` subclasses (not just `Entity`) | No (additive) |
| `TypedRouteHandler<T>` / `TypedTurnContext<T>` | Generic typed-handler primitives | No (additive) |
| Slack extension | `ISlackActivity` / `SlackActivity` + `[SlackMessageRoute]` typed-handler support | No (new code) |

---

## Implementation Order (as built)

1. `ActivityTypeAttribute` — multi-discriminator attribute.
2. `ActivityTypeRegistration` + `ProtocolJsonSerializer.RegisterActivityTypes` (+ dedup) and
   `ResolveActivityType`.
3. `ActivityResolutionContext` + `ActivityTypeResolver` + `RegisterActivityTypeResolver`.
4. `ActivityConverter` — `CanConvert` override, peek discriminators, resolve, deserialize.
5. `ActivityTypeInitAssemblyAttribute` + `ActivityTypeInitSourceGenerator` + static-ctor
   wiring; extend `PreloadAssembliesSourceGenerator` to scan `Activity` subclasses.
6. `TypedRouteHandler<T>` / `TypedTurnContext<T>` typed-handler primitives.
7. Validate end-to-end with the Slack extension (`SlackActivity`, `[SlackMessageRoute]`).

---

## Relationship to Multi-Adapter

This design is **orthogonal** to multi-adapter — it enhances the Activity Protocol
experience regardless of how many adapters are registered. However, it composes well:

- **Before multi-adapter:** Custom activity types improve the single-adapter AP
  experience. Extensions like Slack/Teams benefit immediately.
- **With multi-adapter:** Each adapter deserializes using its own resolver (or shares
  a global one). Non-AP adapters (A2A) don't use `ActivityConverter` at all — they
  have their own wire format. The resolver is AP-specific.
- **With custom `ITurnContext`:** The typed context (`ITurnContext<TActivity>` via
  `TypedTurnContext<T>`) exposes the resolved subtype — eliminating the cast in handlers.

---

## Relationship to Other Documents

- **[Non-Breaking Multi-Adapter Extension Design](2026-06-10-non-breaking-multi-adapter-addendum.md)** —
  overview of the incremental approach.
- **[Custom ITurnContext via RouteBuilders](2026-06-15-custom-context-routebuilder-addendum.md)** —
  the custom context pattern; `TypedTurnContext<T>` is its realized form here.
- **[Multi-Adapter Registry & Dispatch](2026-06-15-multi-adapter-registry-addendum.md)** —
  orthogonal; adapter registry is AP-endpoint-agnostic.


</details>

