### PR TITLE
Fix LockRecursionException on duplicate StopAsync in hosted services (#304)

### DIFF
--- a/src/libraries/Hosting/AspNetCore/BackgroundQueue/HostedActivityService.cs
+++ b/src/libraries/Hosting/AspNetCore/BackgroundQueue/HostedActivityService.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Agents.Hosting.AspNetCore.BackgroundQueue
         private readonly IActivityTaskQueue _activityQueue;
         private readonly int _shutdownTimeoutSeconds;
         private readonly IServiceProvider _serviceProvider;
+        private int _stopping;
 
         /// <summary>
         /// Create a <see cref="Microsoft.Agents.Hosting.AspNetCore.BackgroundQueue.HostedActivityService"/> instance for processing Activities
@@ -64,6 +65,16 @@ namespace Microsoft.Agents.Hosting.AspNetCore.BackgroundQueue
         /// <returns>The Task to be executed asynchronously.</returns>
         public override async Task StopAsync(CancellationToken stoppingToken)
         {
+            // Some hosts (notably WebApplicationFactory/TestServer teardown, see
+            // https://github.com/dotnet/aspnetcore/issues/40271) can call StopAsync more than once.
+            // Guard against re-entering the write lock on the same thread, which throws
+            // LockRecursionException since ReaderWriterLockSlim defaults to NoRecursion.
+            if (Interlocked.Exchange(ref _stopping, 1) == 1)
+            {
+                await base.StopAsync(stoppingToken).ConfigureAwait(false);
+                return;
+            }
+
             _logger.LogInformation("Queued Hosted Service is stopping.");
 
             _activityQueue.Stop();

--- a/src/libraries/Hosting/AspNetCore/BackgroundQueue/HostedTaskService.cs
+++ b/src/libraries/Hosting/AspNetCore/BackgroundQueue/HostedTaskService.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Agents.Hosting.AspNetCore.BackgroundQueue
         private readonly ConcurrentDictionary<Func<CancellationToken,Task>, Task> _tasks = new();
         private readonly IBackgroundTaskQueue _taskQueue;
         private readonly int _shutdownTimeoutSeconds;
+        private int _stopping;
 
         /// <summary>
         /// Create a <see cref="Microsoft.Agents.Hosting.AspNetCore.BackgroundQueue.HostedTaskService"/> instance for processing work on a background thread.
@@ -49,6 +50,16 @@ namespace Microsoft.Agents.Hosting.AspNetCore.BackgroundQueue
         /// <returns>The Task to be executed asynchronously.</returns>
         public override async Task StopAsync(CancellationToken stoppingToken)
         {
+            // Some hosts (notably WebApplicationFactory/TestServer teardown, see
+            // https://github.com/dotnet/aspnetcore/issues/40271) can call StopAsync more than once.
+            // Guard against re-entering the write lock on the same thread, which throws
+            // LockRecursionException since ReaderWriterLockSlim defaults to NoRecursion.
+            if (Interlocked.Exchange(ref _stopping, 1) == 1)
+            {
+                await base.StopAsync(stoppingToken).ConfigureAwait(false);
+                return;
+            }
+
             _logger.LogInformation("Queued Hosted Service is stopping.");
 
             // Obtain a write lock and do not release it, preventing new tasks from starting

--- a/src/tests/Microsoft.Agents.Hosting.AspNetCore/BackgroundActivityService/HostedActivityServiceTests.cs
+++ b/src/tests/Microsoft.Agents.Hosting.AspNetCore/BackgroundActivityService/HostedActivityServiceTests.cs
@@ -139,6 +139,18 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
             record.VerifyMocks();
         }
 
+        [Fact]
+        public async Task StopAsync_ShouldBeIdempotent()
+        {
+            var record = UseRecord();
+            var token = CancellationToken.None;
+
+            // Calling StopAsync more than once (as WebApplicationFactory/TestServer teardown can do)
+            // must not throw LockRecursionException. See https://github.com/dotnet/aspnetcore/issues/40271.
+            await record.Service.StopAsync(token);
+            await record.Service.StopAsync(token);
+        }
+
         private static Record UseRecord(IAgent agent = null)
         {
             var config = new ConfigurationBuilder().Build();

--- a/src/tests/Microsoft.Agents.Hosting.AspNetCore/BackgroundTaskService/HostedTaskServiceTests.cs
+++ b/src/tests/Microsoft.Agents.Hosting.AspNetCore/BackgroundTaskService/HostedTaskServiceTests.cs
@@ -110,6 +110,18 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests.BackgroundTaskService
             record.VerifyMocks();
         }
 
+        [Fact]
+        public async Task StopAsync_ShouldBeIdempotent()
+        {
+            var record = UseRecord();
+            var token = CancellationToken.None;
+
+            // Calling StopAsync more than once (as WebApplicationFactory/TestServer teardown can do)
+            // must not throw LockRecursionException. See https://github.com/dotnet/aspnetcore/issues/40271.
+            await record.Service.StopAsync(token);
+            await record.Service.StopAsync(token);
+        }
+
         private static Record UseRecord()
         {
             var config = new ConfigurationBuilder().Build();


### PR DESCRIPTION
Fixes #304.

## Root cause
`WebApplicationFactory`/`TestServer` teardown can invoke a hosted service's `StopAsync` more than once on the same thread (dotnet/aspnetcore#40271). `HostedTaskService` and `HostedActivityService` unconditionally re-entered a `ReaderWriterLockSlim` write lock created with the default `NoRecursion` policy. A second `StopAsync` on the thread already holding the write lock throws `LockRecursionException` (rather than returning `false`), which surfaced during integration-test disposal. This also contributed to the intermittent ~120s shutdown hangs.

## Fix
Guard `StopAsync` in both hosted services with an `Interlocked.Exchange` flag so a second invocation delegates straight to `base.StopAsync` without re-entering the lock. Behavior for the normal single-call shutdown path is unchanged, and there is no public API change (`_stopping` is a private field).

## Tests
Added `StopAsync_ShouldBeIdempotent` regression tests to `HostedTaskServiceTests` and `HostedActivityServiceTests` that call `StopAsync` twice and assert no exception. All 14 tests in `Microsoft.Agents.Hosting.AspNetCore.Tests` pass.