### PR TITLE
Harden NamedPipeProtocolCancelTests against thread-pool starvation flake

### DIFF
--- a/src/tests/Microsoft.Agents.Hosting.DirectLine.NamedPipes/NamedPipeProtocolCancelTests.cs
+++ b/src/tests/Microsoft.Agents.Hosting.DirectLine.NamedPipes/NamedPipeProtocolCancelTests.cs
@@ -24,6 +24,17 @@ namespace Microsoft.Agents.Hosting.DirectLine.NamedPipes.Tests
     /// </summary>
     public class NamedPipeProtocolCancelTests
     {
+        // Deadline for observing an event (handler start, cancellation propagation, frame emit).
+        // The protocol's read loop and handler continuations resume on the thread pool, so under
+        // heavy parallel CI load the actual propagation can lag well past a few hundred ms even
+        // though it is functionally near-instant. This ceiling stays generous enough to absorb
+        // thread-pool starvation while still failing fast on a genuine hang.
+        private static readonly TimeSpan ObserveTimeout = TimeSpan.FromSeconds(30);
+
+        // How long a dispatched handler blocks when it is NOT cancelled. Must exceed ObserveTimeout
+        // so an uncancelled handler can never spuriously complete before the observation deadline.
+        private static readonly TimeSpan HandlerHangDuration = TimeSpan.FromSeconds(60);
+
         // ----- Outbound emit semantics -----
 
         [Fact]
@@ -85,7 +96,7 @@ namespace Microsoft.Agents.Hosting.DirectLine.NamedPipes.Tests
 
             // Cancel marks the stream "complete", which unblocks the pending dispatch with no body
             // bytes (TakeStreamBody returns null when nothing was ever buffered for the stream).
-            var req = await received.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            var req = await received.Task.WaitAsync(ObserveTimeout);
             Assert.True(req.Body == null || req.Body.Length == 0);
 
             // Drain the outbound 200 OK so dispose doesn't deadlock.
@@ -105,7 +116,7 @@ namespace Microsoft.Agents.Hosting.DirectLine.NamedPipes.Tests
                 handlerStarted.TrySetResult(true);
                 try
                 {
-                    await Task.Delay(TimeSpan.FromSeconds(30), ct);
+                    await Task.Delay(HandlerHangDuration, ct);
                 }
                 catch (OperationCanceledException)
                 {
@@ -125,12 +136,12 @@ namespace Microsoft.Agents.Hosting.DirectLine.NamedPipes.Tests
             });
             await harness.WriteInboundFrameAsync(PayloadTypes.Request, requestId, requestJson, end: true);
 
-            await handlerStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await handlerStarted.Task.WaitAsync(ObserveTimeout);
 
             // CancelStream against the request id must cancel the in-flight handler.
             await harness.WriteInboundFrameAsync(PayloadTypes.CancelStream, requestId, payload: null, end: true);
 
-            var cancelled = await handlerCancelled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            var cancelled = await handlerCancelled.Task.WaitAsync(ObserveTimeout);
             Assert.True(cancelled);
         }
 
@@ -157,7 +168,7 @@ namespace Microsoft.Agents.Hosting.DirectLine.NamedPipes.Tests
 
             // The pending outbound request task should now fault with OperationCanceledException.
             await Assert.ThrowsAsync<OperationCanceledException>(
-                async () => await requestTask.WaitAsync(TimeSpan.FromSeconds(5)));
+                async () => await requestTask.WaitAsync(ObserveTimeout));
         }
 
         [Fact]
@@ -172,7 +183,7 @@ namespace Microsoft.Agents.Hosting.DirectLine.NamedPipes.Tests
                 handlerStarted.TrySetResult(true);
                 try
                 {
-                    await Task.Delay(TimeSpan.FromSeconds(30), ct);
+                    await Task.Delay(HandlerHangDuration, ct);
                 }
                 catch (OperationCanceledException)
                 {
@@ -191,11 +202,11 @@ namespace Microsoft.Agents.Hosting.DirectLine.NamedPipes.Tests
             });
             await harness.WriteInboundFrameAsync(PayloadTypes.Request, requestId, requestJson, end: true);
 
-            await handlerStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            await handlerStarted.Task.WaitAsync(ObserveTimeout);
 
             await harness.WriteInboundFrameAsync(PayloadTypes.CancelAll, Guid.Empty, payload: null, end: true);
 
-            var cancelled = await handlerCancelled.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            var cancelled = await handlerCancelled.Task.WaitAsync(ObserveTimeout);
             Assert.True(cancelled);
         }
 
@@ -210,10 +221,10 @@ namespace Microsoft.Agents.Hosting.DirectLine.NamedPipes.Tests
             var disposeTask = Task.Run(async () => await harness.Protocol.DisposeAsync());
 
             // First frame written by DisposeAsync should be CancelAll.
-            var frame = await harness.ReadFrameAsync().WaitAsync(TimeSpan.FromSeconds(5));
+            var frame = await harness.ReadFrameAsync().WaitAsync(ObserveTimeout);
             Assert.Equal(PayloadTypes.CancelAll, frame.Header.Type);
 
-            await disposeTask.WaitAsync(TimeSpan.FromSeconds(5));
+            await disposeTask.WaitAsync(ObserveTimeout);
             harness.DisposePipesOnly();
         }
 


### PR DESCRIPTION
## Summary

Fixes an intermittent CI failure in `NamedPipeProtocolCancelTests.InboundCancelAll_CancelsInflightInboundDispatch` (observed in [run 30385663500](https://github.com/microsoft/Agents-for-net/actions/runs/30385663500/job/90364211476)).

## Root cause — flaky test, not a product bug

`NamedPipeProtocol.HandleCancelAllFrame` is correct: it cancels every in-flight inbound dispatch CTS and faults all pending outbound requests. The failure is a timing/scheduling flake:

- `NamedPipeProtocol.Start()` runs `ReadLoopAsync` as a plain async task. After its first `await`, every continuation that reads/processes an inbound frame resumes on the **thread pool** (`ConfigureAwait(false)`). The dispatched handler's post-cancellation continuation is likewise thread-pool bound.
- The test sends a `CancelAll` frame and asserts the in-flight handler is cancelled **within 5 seconds**. That deadline depends on the read loop being scheduled to process the frame *and* the handler continuation running — both subject to thread-pool availability.
- On the CI runner the whole assembly ran under heavy parallelism (48s vs ~31s locally). Under that pressure the 5s window is occasionally exceeded and `Task.WaitAsync` throws `TimeoutException` at `NamedPipeProtocolCancelTests.cs:194`.

### Evidence
- Passed **20/20** in isolation and **5/5** in the full suite locally.
- Artificially capping worker threads (`DOTNET_ThreadPool_ForceMaxWorkerThreads=2`) made even the 7 cancel tests run for minutes — confirming these tests impose real-time deadlines that starvation blows past.

The 5s assertion conflates **correctness** (does cancellation propagate?) with **speed** (how fast?), which is environment-dependent.

## Fix (test-only)

- Introduce two bounded constants in `NamedPipeProtocolCancelTests`:
  - `ObserveTimeout = 30s` — deadline for observing an event (handler start, cancellation propagation, frame emit).
  - `HandlerHangDuration = 60s` — how long a dispatched handler blocks when **not** cancelled. Kept `> ObserveTimeout` so an uncancelled handler can never spuriously complete before the observation deadline.
- Replace all hard-coded `TimeSpan.FromSeconds(5)` waits and `Task.Delay(30s)` handler hangs with these constants.

This preserves the correctness assertion (a genuine hang still fails, and fails fast relative to a real deadlock) while tolerating CI scheduling jitter. No production code changed.

## Testing

- `dotnet build` — clean (0 warnings, 0 errors).
- `NamedPipeProtocolCancelTests` — 7/7 passing in 84 ms (the generous ceilings do not affect the happy path).
