### PR TITLE
Add activity name to turn telemetry spans

### DIFF
--- a/src/libraries/Builder/Microsoft.Agents.Builder/Telemetry/App/Scopes/ScopeOnTurn.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/Telemetry/App/Scopes/ScopeOnTurn.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Agents.Builder.Telemetry.App.Scopes
     /// A <see cref="TelemetryScope"/> that traces the full execution of a single agent turn.
     /// </summary>
     /// <remarks>
-    /// Tags the <see cref="System.Diagnostics.Activity"/> with activity metadata (type, channel,
+    /// Tags the <see cref="System.Diagnostics.Activity"/> with activity metadata (type, name, channel,
     /// conversation, activity ID) and authorization outcome. On successful completion, increments
     /// <see cref="Metrics.TurnCount"/> and records <see cref="Metrics.TurnDuration"/>; on error,
     /// increments <see cref="Metrics.TurnErrorCount"/> instead. Call <see cref="Share"/> to supply
@@ -31,6 +31,7 @@ namespace Microsoft.Agents.Builder.Telemetry.App.Scopes
         protected override void Callback(System.Diagnostics.Activity telemetryActivity, double duration, Exception? error)
         {
             telemetryActivity.SetTag(TagNames.ActivityType, _turnContext.Activity.Type);
+            telemetryActivity.SetTag(TagNames.ActivityName, _turnContext.Activity.Name);
             telemetryActivity.SetTag(TagNames.ActivityChannelId, _turnContext.Activity.ChannelId?.ToString());
             telemetryActivity.SetTag(TagNames.ConversationId, _turnContext.Activity.Conversation?.Id);
             telemetryActivity.SetTag(TagNames.ActivityId, _turnContext.Activity.Id);

--- a/src/libraries/Core/Microsoft.Agents.Core/Telemetry/TagNames.cs
+++ b/src/libraries/Core/Microsoft.Agents.Core/Telemetry/TagNames.cs
@@ -23,6 +23,9 @@ namespace Microsoft.Agents.Core.Telemetry
         /// <summary>The unique identifier of the activity.</summary>
         public static readonly string ActivityId = "activity.id";
 
+        /// <summary>The name of the activity.</summary>
+        public static readonly string ActivityName = "activity.name";
+
         /// <summary>The number of activities in a batch operation.</summary>
         public static readonly string ActivityCount = "activities.count";
 

--- a/src/tests/Microsoft.Agents.Builder.Tests/Telemetry/AppScopeTests.cs
+++ b/src/tests/Microsoft.Agents.Builder.Tests/Telemetry/AppScopeTests.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Agents.Builder.Tests.Telemetry
             string channelId = "test-channel",
             string conversationId = "conv-1",
             string activityId = "act-1",
+            string activityName = null,
             int attachmentCount = 0)
         {
             var attachments = new List<Attachment>();
@@ -28,6 +29,7 @@ namespace Microsoft.Agents.Builder.Tests.Telemetry
             return new TurnContext(new NotImplementedAdapter(), new Activity
             {
                 Type = type,
+                Name = activityName,
                 ChannelId = channelId,
                 Id = activityId,
                 Conversation = new ConversationAccount { Id = conversationId },
@@ -52,15 +54,27 @@ namespace Microsoft.Agents.Builder.Tests.Telemetry
         [Fact]
         public void ScopeOnTurn_Callback_SetsActivityMetadataTags()
         {
-            var ctx = CreateTurnContext(type: "message", channelId: "msteams", conversationId: "conv-99", activityId: "act-42");
+            var ctx = CreateTurnContext(type: "event", channelId: "msteams", conversationId: "conv-99", activityId: "act-42", activityName: "application/vnd.contoso.order");
             var scope = new ScopeOnTurn(ctx);
             scope.Dispose();
 
             var stopped = Assert.Single(StoppedActivities);
-            Assert.Equal("message", stopped.GetTagItem(TagNames.ActivityType));
+            Assert.Equal("event", stopped.GetTagItem(TagNames.ActivityType));
+            Assert.Equal("application/vnd.contoso.order", stopped.GetTagItem(TagNames.ActivityName));
             Assert.Equal("msteams", stopped.GetTagItem(TagNames.ActivityChannelId));
             Assert.Equal("conv-99", stopped.GetTagItem(TagNames.ConversationId));
             Assert.Equal("act-42", stopped.GetTagItem(TagNames.ActivityId));
+        }
+
+        [Fact]
+        public void ScopeOnTurn_Callback_LeavesActivityNameTagNull_WhenActivityNameIsNull()
+        {
+            var ctx = CreateTurnContext(activityName: null);
+            var scope = new ScopeOnTurn(ctx);
+            scope.Dispose();
+
+            var stopped = Assert.Single(StoppedActivities);
+            Assert.Null(stopped.GetTagItem(TagNames.ActivityName));
         }
 
         [Fact]


### PR DESCRIPTION
## Summary

- add `activity.name` to the turn-level OpenTelemetry activity
- preserve the existing conversation, channel, and recipient telemetry
- add coverage for both named activities and activities whose name is null
- document the new span tag in `ScopeOnTurn`

## Why

`ScopeOnTurn` creates the turn span but did not expose the incoming activity name. This made it harder to distinguish turn activity types in traces without inspecting application payloads.

The activity name is deliberately added only to the span. It is not introduced as a metric dimension, avoiding unnecessary metric cardinality.

## Validation

```text
dotnet test src/tests/Microsoft.Agents.Builder.Tests/Microsoft.Agents.Builder.Tests.csproj -f net8.0 --filter FullyQualifiedName~AppScopeTests --no-restore --tl:off

Passed: 18
Failed: 0
```

Fixes #879

## Attribution

Original work by @ilia-sokolov in #941. Thank you!
