### PR TITLE
Dispose intermediate MSAL retry responses

### DIFF
--- a/src/libraries/Authentication/Authentication.Msal/MSALHttpRetryHandlerHelper.cs
+++ b/src/libraries/Authentication/Authentication.Msal/MSALHttpRetryHandlerHelper.cs
@@ -46,6 +46,13 @@ namespace Microsoft.Agents.Authentication.Msal
                     }
                     else
                     {
+                        // The caller owns the response returned by this handler. Dispose only
+                        // intermediate timeout responses that will be replaced by another attempt.
+                        if (i < _maxRetryCount - 1)
+                        {
+                            response.Dispose();
+                        }
+
 #if DEBUG
                         System.Diagnostics.Trace.WriteLine($">>> MSAL RETRY ON TIMEOUT >>> {Environment.CurrentManagedThreadId} - {i}");
 #endif

--- a/src/tests/Microsoft.Agents.Authentication.Msal.Tests/MSALHttpRetryHandlerHelperTests.cs
+++ b/src/tests/Microsoft.Agents.Authentication.Msal.Tests/MSALHttpRetryHandlerHelperTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Options;
 using Moq;
 using Moq.Protected;
 using System;
+using System.IO;
 using System.Net.Http;
 using System.Net;
 using System.Threading;
@@ -72,12 +73,17 @@ namespace Microsoft.Agents.Authentication.Msal.Tests
         [Fact]
         public async Task SendAsync_ShouldReturnSuccessfulResponseAfterRetries()
         {
+            var firstTimeoutContent = new TrackingHttpContent();
+            var secondTimeoutContent = new TrackingHttpContent();
+            var thirdTimeoutContent = new TrackingHttpContent();
+            var successfulContent = new TrackingHttpContent();
+
             _handler.Protected()
                 .SetupSequence<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
-                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.RequestTimeout))
-                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.RequestTimeout))
-                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.RequestTimeout))
-                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.RequestTimeout) { Content = firstTimeoutContent })
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.RequestTimeout) { Content = secondTimeoutContent })
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.RequestTimeout) { Content = thirdTimeoutContent })
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK) { Content = successfulContent });
 
             var retryHandler = new MSALHttpRetryHandlerHelper(_service.Object)
             {
@@ -86,18 +92,24 @@ namespace Microsoft.Agents.Authentication.Msal.Tests
 
             var httpClient = new HttpClient(retryHandler);
 
-            var response = await httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Get, RequestUri));
+            using var response = await httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Get, RequestUri));
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.True(firstTimeoutContent.IsDisposed);
+            Assert.True(secondTimeoutContent.IsDisposed);
+            Assert.True(thirdTimeoutContent.IsDisposed);
+            Assert.False(successfulContent.IsDisposed);
             _handler.Protected().Verify("SendAsync", Times.Exactly(4), ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
         }
 
         [Fact]
         public async Task SendAsync_ShouldReturnResponseOnNonRetryableFailure()
         {
+            var badRequestContent = new TrackingHttpContent();
+
             _handler.Protected()
                 .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
-                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.BadRequest))
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.BadRequest) { Content = badRequestContent })
                 .Verifiable(Times.Once);
 
             var retryHandler = new MSALHttpRetryHandlerHelper(_service.Object)
@@ -110,18 +122,27 @@ namespace Microsoft.Agents.Authentication.Msal.Tests
             var response = await httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Get, RequestUri));
 
             Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+            Assert.False(badRequestContent.IsDisposed);
+
+            response.Dispose();
+            Assert.True(badRequestContent.IsDisposed);
             Mock.Verify(_handler);
         }
 
         [Fact]
         public async Task SendAsync_ShouldReturnResponseAfterExhaustsAllRetries()
         {
+            var firstTimeoutContent = new TrackingHttpContent();
+            var secondTimeoutContent = new TrackingHttpContent();
+            var thirdTimeoutContent = new TrackingHttpContent();
+            var finalTimeoutContent = new TrackingHttpContent();
+
             _handler.Protected()
                 .SetupSequence<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
-                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.RequestTimeout))
-                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.RequestTimeout))
-                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.RequestTimeout))
-                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.RequestTimeout));
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.RequestTimeout) { Content = firstTimeoutContent })
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.RequestTimeout) { Content = secondTimeoutContent })
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.RequestTimeout) { Content = thirdTimeoutContent })
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.RequestTimeout) { Content = finalTimeoutContent });
 
             var retryHandler = new MSALHttpRetryHandlerHelper(_service.Object)
             {
@@ -133,7 +154,36 @@ namespace Microsoft.Agents.Authentication.Msal.Tests
             var response = await httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Get, RequestUri));
 
             Assert.Equal(HttpStatusCode.RequestTimeout, response.StatusCode);
+            Assert.True(firstTimeoutContent.IsDisposed);
+            Assert.True(secondTimeoutContent.IsDisposed);
+            Assert.True(thirdTimeoutContent.IsDisposed);
+            Assert.False(finalTimeoutContent.IsDisposed);
+
+            response.Dispose();
+            Assert.True(finalTimeoutContent.IsDisposed);
             _handler.Protected().Verify("SendAsync", Times.Exactly(4), ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
+        }
+
+        private sealed class TrackingHttpContent : HttpContent
+        {
+            public bool IsDisposed { get; private set; }
+
+            protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)
+            {
+                return Task.CompletedTask;
+            }
+
+            protected override bool TryComputeLength(out long length)
+            {
+                length = 0;
+                return true;
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                IsDisposed = true;
+                base.Dispose(disposing);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- dispose retryable 408 responses before replacing them with another attempt
- preserve ownership of successful, non-retryable, and final exhausted responses for the caller
- add regression coverage for successful retries, non-retryable failures, and retry exhaustion

## Why

`MSALHttpRetryHandlerHelper` previously overwrote intermediate `HttpResponseMessage` instances without disposing them. Their content and underlying HTTP resources could remain retained until garbage collection.

## Validation

- `dotnet test src/tests/Microsoft.Agents.Authentication.Msal.Tests/Microsoft.Agents.Authentication.Msal.Tests.csproj --framework net8.0 --configuration Debug --verbosity minimal` — 71 passed
- `dotnet build src/libraries/Authentication/Authentication.Msal/Microsoft.Agents.Authentication.Msal.csproj --framework netstandard2.0 --configuration Debug --no-restore --verbosity minimal` — succeeded with 0 warnings
- `dotnet build src/libraries/Authentication/Authentication.Msal/Microsoft.Agents.Authentication.Msal.csproj --framework net8.0 --configuration Debug --no-restore --verbosity minimal` — succeeded with 0 warnings

The net4.8 test target was not run locally because the .NET Framework 4.8 targeting pack is unavailable in this environment.
