### PR TITLE
Fix flaky named pipe test disposal (thread-pool starvation)

### DIFF
--- a/src/tests/Microsoft.Agents.Hosting.DirectLine.NamedPipes/NamedPipeMessageHandlerBoundaryTests.cs
+++ b/src/tests/Microsoft.Agents.Hosting.DirectLine.NamedPipes/NamedPipeMessageHandlerBoundaryTests.cs
@@ -192,7 +192,7 @@ namespace Microsoft.Agents.Hosting.DirectLine.NamedPipes.Tests
 
         // ========== Harness ==========
 
-        private sealed class ProtocolHarness : IDisposable
+        private sealed class ProtocolHarness : IAsyncDisposable, IDisposable
         {
             private readonly AnonymousPipeServerStream _inboundServer;
             private readonly AnonymousPipeClientStream _inboundClient;
@@ -270,9 +270,17 @@ namespace Microsoft.Agents.Hosting.DirectLine.NamedPipes.Tests
                 return buf;
             }
 
+            public async ValueTask DisposeAsync()
+            {
+                try { await Protocol.DisposeAsync().ConfigureAwait(false); } catch { }
+                Dispose();
+            }
+
+            // Synchronous dispose intentionally does NOT block on Protocol.DisposeAsync
+            // (sync-over-async starves the thread pool under parallel test load, causing
+            // flaky timeouts). Disposing the pipes tears down the read loop instead.
             public void Dispose()
             {
-                try { Protocol.DisposeAsync().AsTask().GetAwaiter().GetResult(); } catch { }
                 try { _inboundClient.Dispose(); } catch { }
                 try { _inboundServer.Dispose(); } catch { }
                 try { _outboundClient?.Dispose(); } catch { }

--- a/src/tests/Microsoft.Agents.Hosting.DirectLine.NamedPipes/NamedPipeProtocolBoundaryTests.cs
+++ b/src/tests/Microsoft.Agents.Hosting.DirectLine.NamedPipes/NamedPipeProtocolBoundaryTests.cs
@@ -410,7 +410,7 @@ namespace Microsoft.Agents.Hosting.DirectLine.NamedPipes.Tests
 
         // ========== Test Harness ==========
 
-        private sealed class TestHarness : IDisposable
+        private sealed class TestHarness : IAsyncDisposable, IDisposable
         {
             private readonly AnonymousPipeServerStream _inboundServer;
             private AnonymousPipeClientStream _inboundClient;
@@ -511,9 +511,17 @@ namespace Microsoft.Agents.Hosting.DirectLine.NamedPipes.Tests
                 return buf;
             }
 
+            public async ValueTask DisposeAsync()
+            {
+                try { await Protocol.DisposeAsync().ConfigureAwait(false); } catch { }
+                Dispose();
+            }
+
+            // Synchronous dispose intentionally does NOT block on Protocol.DisposeAsync
+            // (sync-over-async starves the thread pool under parallel test load, causing
+            // flaky timeouts). Disposing the pipes tears down the read loop instead.
             public void Dispose()
             {
-                try { Protocol.DisposeAsync().AsTask().GetAwaiter().GetResult(); } catch { }
                 try { _inboundClient?.Dispose(); } catch { }
                 try { _inboundServer.Dispose(); } catch { }
                 try { _outboundClient.Dispose(); } catch { }

--- a/src/tests/Microsoft.Agents.Hosting.DirectLine.NamedPipes/NamedPipeProtocolCancelTests.cs
+++ b/src/tests/Microsoft.Agents.Hosting.DirectLine.NamedPipes/NamedPipeProtocolCancelTests.cs
@@ -230,7 +230,7 @@ namespace Microsoft.Agents.Hosting.DirectLine.NamedPipes.Tests
 
         // ----- Harness -----
 
-        private sealed class FrameInspectorHarness : IDisposable
+        private sealed class FrameInspectorHarness : IAsyncDisposable, IDisposable
         {
             private readonly AnonymousPipeServerStream _inboundServer;
             private readonly AnonymousPipeClientStream _inboundClient;
@@ -325,9 +325,17 @@ namespace Microsoft.Agents.Hosting.DirectLine.NamedPipes.Tests
                 try { _outboundServer.Dispose(); } catch { }
             }
 
+            public async ValueTask DisposeAsync()
+            {
+                try { await Protocol.DisposeAsync().ConfigureAwait(false); } catch { }
+                DisposePipesOnly();
+            }
+
+            // Synchronous dispose intentionally does NOT block on Protocol.DisposeAsync
+            // (sync-over-async starves the thread pool under parallel test load, causing
+            // flaky timeouts). Disposing the pipes tears down the read loop instead.
             public void Dispose()
             {
-                try { Protocol.DisposeAsync().AsTask().GetAwaiter().GetResult(); } catch { }
                 DisposePipesOnly();
             }
         }

--- a/src/tests/Microsoft.Agents.Hosting.DirectLine.NamedPipes/NamedPipeProtocolChunkingTests.cs
+++ b/src/tests/Microsoft.Agents.Hosting.DirectLine.NamedPipes/NamedPipeProtocolChunkingTests.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Agents.Hosting.DirectLine.NamedPipes.Tests
         /// <summary>
         /// Outbound-undrained harness so the test can read each frame written by the protocol.
         /// </summary>
-        private sealed class FrameInspectorHarness : IDisposable
+        private sealed class FrameInspectorHarness : IAsyncDisposable, IDisposable
         {
             private readonly AnonymousPipeServerStream _inboundServer;
             private readonly AnonymousPipeClientStream _inboundClient;
@@ -251,9 +251,17 @@ namespace Microsoft.Agents.Hosting.DirectLine.NamedPipes.Tests
                 await stream.FlushAsync().ConfigureAwait(false);
             }
 
+            public async ValueTask DisposeAsync()
+            {
+                try { await Protocol.DisposeAsync().ConfigureAwait(false); } catch { }
+                Dispose();
+            }
+
+            // Synchronous dispose intentionally does NOT block on Protocol.DisposeAsync
+            // (sync-over-async starves the thread pool under parallel test load, causing
+            // flaky timeouts). Disposing the pipes tears down the read loop instead.
             public void Dispose()
             {
-                try { Protocol.DisposeAsync().AsTask().GetAwaiter().GetResult(); } catch { }
                 try { _inboundClient.Dispose(); } catch { }
                 try { _inboundServer.Dispose(); } catch { }
                 try { _outboundClient.Dispose(); } catch { }

--- a/src/tests/Microsoft.Agents.Hosting.DirectLine.NamedPipes/NamedPipeProtocolContentTypeTests.cs
+++ b/src/tests/Microsoft.Agents.Hosting.DirectLine.NamedPipes/NamedPipeProtocolContentTypeTests.cs
@@ -302,7 +302,7 @@ namespace Microsoft.Agents.Hosting.DirectLine.NamedPipes.Tests
 
         // ---------- Inbound harness (supports primary content type + attachments with types) ----------
 
-        private sealed class InboundHarness : IDisposable
+        private sealed class InboundHarness : IAsyncDisposable, IDisposable
         {
             private readonly AnonymousPipeServerStream _inboundServer;
             private readonly AnonymousPipeClientStream _inboundClient;
@@ -429,9 +429,17 @@ namespace Microsoft.Agents.Hosting.DirectLine.NamedPipes.Tests
                 await _inboundClient.FlushAsync().ConfigureAwait(false);
             }
 
+            public async ValueTask DisposeAsync()
+            {
+                try { await Protocol.DisposeAsync().ConfigureAwait(false); } catch { }
+                Dispose();
+            }
+
+            // Synchronous dispose intentionally does NOT block on Protocol.DisposeAsync
+            // (sync-over-async starves the thread pool under parallel test load, causing
+            // flaky timeouts). Disposing the pipes tears down the read loop instead.
             public void Dispose()
             {
-                try { Protocol.DisposeAsync().AsTask().GetAwaiter().GetResult(); } catch { }
                 try { _drainCts.Cancel(); } catch { }
                 try { _inboundClient.Dispose(); } catch { }
                 try { _inboundServer.Dispose(); } catch { }
@@ -443,7 +451,7 @@ namespace Microsoft.Agents.Hosting.DirectLine.NamedPipes.Tests
 
         // ---------- Outbound harness (undrained outbound pipe; reads raw frames) ----------
 
-        private sealed class FrameInspectorHarness : IDisposable
+        private sealed class FrameInspectorHarness : IAsyncDisposable, IDisposable
         {
             private readonly AnonymousPipeServerStream _inboundServer;
             private readonly AnonymousPipeClientStream _inboundClient;
@@ -543,9 +551,17 @@ namespace Microsoft.Agents.Hosting.DirectLine.NamedPipes.Tests
                 await stream.FlushAsync().ConfigureAwait(false);
             }
 
+            public async ValueTask DisposeAsync()
+            {
+                try { await Protocol.DisposeAsync().ConfigureAwait(false); } catch { }
+                Dispose();
+            }
+
+            // Synchronous dispose intentionally does NOT block on Protocol.DisposeAsync
+            // (sync-over-async starves the thread pool under parallel test load, causing
+            // flaky timeouts). Disposing the pipes tears down the read loop instead.
             public void Dispose()
             {
-                try { Protocol.DisposeAsync().AsTask().GetAwaiter().GetResult(); } catch { }
                 try { _inboundClient.Dispose(); } catch { }
                 try { _inboundServer.Dispose(); } catch { }
                 try { _outboundClient.Dispose(); } catch { }

--- a/src/tests/Microsoft.Agents.Hosting.DirectLine.NamedPipes/NamedPipeProtocolStreamingTests.cs
+++ b/src/tests/Microsoft.Agents.Hosting.DirectLine.NamedPipes/NamedPipeProtocolStreamingTests.cs
@@ -466,7 +466,7 @@ namespace Microsoft.Agents.Hosting.DirectLine.NamedPipes.Tests
             Assert.Equal(body, result.Body);
         }
 
-        private sealed class ProtocolHarness : IDisposable
+        private sealed class ProtocolHarness : IAsyncDisposable, IDisposable
         {
             private readonly AnonymousPipeServerStream _inboundServer;
             private readonly AnonymousPipeClientStream _inboundClient;
@@ -606,9 +606,17 @@ namespace Microsoft.Agents.Hosting.DirectLine.NamedPipes.Tests
                 await _inboundClient.FlushAsync().ConfigureAwait(false);
             }
 
+            public async ValueTask DisposeAsync()
+            {
+                try { await Protocol.DisposeAsync().ConfigureAwait(false); } catch { }
+                Dispose();
+            }
+
+            // Synchronous dispose intentionally does NOT block on Protocol.DisposeAsync
+            // (sync-over-async starves the thread pool under parallel test load, causing
+            // flaky timeouts). Disposing the pipes tears down the read loop instead.
             public void Dispose()
             {
-                try { Protocol.DisposeAsync().AsTask().GetAwaiter().GetResult(); } catch { }
                 try { _drainCts.Cancel(); } catch { }
                 try { _inboundClient.Dispose(); } catch { }
                 try { _inboundServer.Dispose(); } catch { }


### PR DESCRIPTION
## Problem

The named-pipe test suite intermittently fails in CI with `System.TimeoutException : The operation has timed out.` on 5s `WaitAsync` guards — for example `NamedPipeProtocolBoundaryTests.ReadLoop_PipeDisconnect_CompletionTaskCompletes` and `NamedPipeProtocolContentTypeTests.PrimaryStream_NoContentType_DefaultsToJson`. The failures are flaky (pass locally, fail under CI load) and unrelated to the code under test.

## Root cause

Every test harness's synchronous `Dispose()` blocked on the protocol shutdown:

```csharp
Protocol.DisposeAsync().AsTask().GetAwaiter().GetResult();
```

Under xUnit's parallel execution on slower CI agents, this sync-over-async call blocks a thread-pool thread while `DisposeAsync`'s own continuations need a pool thread to resume. With many harnesses disposing concurrently, the pool starves and the continuations that complete the `WaitAsync` guards can't be scheduled within 5s → timeout.

## Fix

Convert the harnesses to the non-blocking pattern already used by `NamedPipeProtocolEndFlagTests`: implement `IAsyncDisposable, IDisposable` where the synchronous `Dispose()` tears down **only the pipes** (which ends the read loop via the protocol's outer catch) and `DisposeAsync()` provides graceful shutdown. Test-only change; no production code touched.

## Validation

- Builds clean (0 warnings; `TreatWarningsAsErrors` is enabled).
- All 182 tests pass, stable across 6 consecutive full-suite runs.