### PR TITLE
Fix Nuget.config file references at built time to comply with SFI Requirements. 

### DIFF
--- a/.azdo/OneBranch.Nightly.yml
+++ b/.azdo/OneBranch.Nightly.yml
@@ -114,6 +114,25 @@ extends:
           - checkout: tools
             path: s/tools
 
+          - task: PowerShell@2
+            displayName: Replace nuget.config files
+            inputs:
+              targetType: inline
+              script: |
+                $repoRoot = "$(Build.SourcesDirectory)"
+                $sourceConfig = Join-Path $repoRoot ".azdo\nuget.config"
+
+                if (-not (Test-Path $sourceConfig)) {
+                  throw "Source nuget.config not found at $sourceConfig"
+                }
+
+                Get-ChildItem -Path $repoRoot -Filter nuget.config -File -Recurse |
+                  Where-Object { $_.FullName -ne $sourceConfig } |
+                  ForEach-Object {
+                    Copy-Item -Path $sourceConfig -Destination $_.FullName -Force
+                    Write-Host "Replaced $($_.FullName)"
+                  }
+
           - task: NuGetAuthenticate@1
 
           - script: dotnet tool restore --configfile $(Build.SourcesDirectory)/.azdo/nuget.config

--- a/.azdo/OneBranch.PullRequest.yml
+++ b/.azdo/OneBranch.PullRequest.yml
@@ -89,6 +89,25 @@ extends:
           - checkout: tools
             path: s/tools
 
+          - task: PowerShell@2
+            displayName: Replace nuget.config files
+            inputs:
+              targetType: inline
+              script: |
+                $repoRoot = "$(Build.SourcesDirectory)"
+                $sourceConfig = Join-Path $repoRoot ".azdo\nuget.config"
+
+                if (-not (Test-Path $sourceConfig)) {
+                  throw "Source nuget.config not found at $sourceConfig"
+                }
+
+                Get-ChildItem -Path $repoRoot -Filter nuget.config -File -Recurse |
+                  Where-Object { $_.FullName -ne $sourceConfig } |
+                  ForEach-Object {
+                    Copy-Item -Path $sourceConfig -Destination $_.FullName -Force
+                    Write-Host "Replaced $($_.FullName)"
+                  }
+
           - task: NuGetAuthenticate@1
 
           - script: dotnet tool restore --configfile $(Build.SourcesDirectory)/.azdo/nuget.config


### PR DESCRIPTION
This pull request updates the Azure DevOps pipeline YAML files to ensure that all `nuget.config` files in the repository are consistently replaced with the canonical version from `.azdo/nuget.config` before running NuGet-related tasks. This helps avoid issues caused by outdated or inconsistent `nuget.config` files during builds.

**Pipeline improvements:**

* Added a PowerShell task in both `.azdo/OneBranch.Nightly.yml` and `.azdo/OneBranch.PullRequest.yml` to recursively find and replace all `nuget.config` files (except for the source file) with `.azdo/nuget.config`, ensuring consistency across the repository. [[1]](diffhunk://#diff-da8946022fae5014bc6b1d1fc713edee9d12d9700548d8681dc082c3dad985adR117-R135) [[2]](diffhunk://#diff-bef7d46a7ac38544e4d4e253e02f1467523dc0d270b31db82c6fee096d358726R92-R110)