### PR TITLE
Add tenant ID validation for Entra issuer in claims identity

### DIFF
--- a/src/libraries/Core/Microsoft.Agents.Authentication/AgentClaims.cs
+++ b/src/libraries/Core/Microsoft.Agents.Authentication/AgentClaims.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Security.Claims;
+using System.Text.RegularExpressions;
 
 
 namespace Microsoft.Agents.Authentication
@@ -16,6 +17,18 @@ namespace Microsoft.Agents.Authentication
     /// </summary>
     public static class AgentClaims
     {
+        private const string MappedTenantIdClaim = "http://schemas.microsoft.com/identity/claims/tenantid";
+        private const string TenantGuidPattern = "([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})";
+        private static readonly Regex EntraV1IssuerPattern = new(
+            $"^(?i:https://sts\\.windows\\.net/){TenantGuidPattern}/$",
+            RegexOptions.CultureInvariant);
+        private static readonly Regex EntraV2IssuerPattern = new(
+            $"^(?i:https://login\\.microsoftonline\\.(?:com|us)/){TenantGuidPattern}/v2\\.0$",
+            RegexOptions.CultureInvariant);
+        private static readonly Regex EntraChinaV2IssuerPattern = new(
+            $"^(?i:https://login\\.partner\\.microsoftonline\\.cn/0b4a31a2-c1a0-475d-b363-5f26668660a3/){TenantGuidPattern}/v2\\.0$",
+            RegexOptions.CultureInvariant);
+
         /// <summary>
         /// Determines if a token is exchangeable based on its claims. An exchangeable token is one that is not a user token and has 
         /// an audience claim that contains the appId of the token.
@@ -103,6 +116,62 @@ namespace Microsoft.Agents.Authentication
         public static string GetIncomingAudience(this ClaimsIdentity identity)
         {
             return GetIncomingAudienceClaim(identity);
+        }
+
+        /// <summary>
+        /// Determines whether a token's tenant ID claim matches the tenant embedded in its Entra issuer.
+        /// </summary>
+        /// <remarks>
+        /// The comparison applies only to recognized Entra v1 and v2 issuers containing a tenant GUID
+        /// and only when the token contains a tenant ID claim. Other issuers and tokens without a tenant
+        /// ID claim are left to the existing issuer and signing-key validation pipeline.
+        /// </remarks>
+        /// <param name="identity">The validated claims identity.</param>
+        /// <returns>
+        /// <c>false</c> when a present tenant ID differs from the recognized issuer tenant; otherwise,
+        /// <c>true</c>.
+        /// </returns>
+        public static bool IsTenantIdIssuerValid(this ClaimsIdentity identity)
+        {
+            AssertionHelpers.ThrowIfNull(identity, nameof(identity));
+
+            var issuer = identity.FindFirst(AuthenticationConstants.IssuerClaim)?.Value;
+            if (!TryGetEntraIssuerTenant(issuer, out var issuerTenant))
+            {
+                return true;
+            }
+
+            var tenantIdClaims = identity.Claims.Where(claim =>
+                claim.Type == AuthenticationConstants.TenantIdClaim
+                || claim.Type == MappedTenantIdClaim);
+            if (!tenantIdClaims.Any())
+            {
+                return true;
+            }
+
+            return tenantIdClaims.All(claim =>
+                Guid.TryParse(claim.Value, out var tokenTenant) && tokenTenant == issuerTenant);
+        }
+
+        private static bool TryGetEntraIssuerTenant(string issuer, out Guid tenantId)
+        {
+            tenantId = default;
+            if (issuer == null)
+            {
+                return false;
+            }
+
+            var match = EntraV1IssuerPattern.Match(issuer);
+            if (!match.Success)
+            {
+                match = EntraV2IssuerPattern.Match(issuer);
+            }
+            if (!match.Success)
+            {
+                match = EntraChinaV2IssuerPattern.Match(issuer);
+            }
+
+            return match.Success && Guid.TryParse(match.Groups[1].Value, out tenantId);
         }
 
         /// <summary>

--- a/src/libraries/Core/Microsoft.Agents.Authentication/AgentClaims.cs
+++ b/src/libraries/Core/Microsoft.Agents.Authentication/AgentClaims.cs
@@ -19,15 +19,13 @@ namespace Microsoft.Agents.Authentication
     {
         private const string MappedTenantIdClaim = "http://schemas.microsoft.com/identity/claims/tenantid";
         private const string TenantGuidPattern = "([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})";
-        private static readonly Regex EntraV1IssuerPattern = new(
-            $"^(?i:https://sts\\.windows\\.net/){TenantGuidPattern}/$",
-            RegexOptions.CultureInvariant);
-        private static readonly Regex EntraV2IssuerPattern = new(
-            $"^(?i:https://login\\.microsoftonline\\.(?:com|us)/){TenantGuidPattern}/v2\\.0$",
-            RegexOptions.CultureInvariant);
-        private static readonly Regex EntraChinaV2IssuerPattern = new(
-            $"^(?i:https://login\\.partner\\.microsoftonline\\.cn/0b4a31a2-c1a0-475d-b363-5f26668660a3/){TenantGuidPattern}/v2\\.0$",
-            RegexOptions.CultureInvariant);
+        private static readonly Regex[] EntraIssuerPatterns =
+        [
+            BuildIssuerPattern(AuthenticationConstants.ValidTokenIssuerUrlTemplateV1),
+            BuildIssuerPattern(AuthenticationConstants.ValidTokenIssuerUrlTemplateV2),
+            BuildIssuerPattern(AuthenticationConstants.ValidGovernmentTokenIssuerUrlTemplateV2),
+            BuildIssuerPattern(AuthenticationConstants.ValidChinaTokenIssuerUrlTemplateV2),
+        ];
 
         /// <summary>
         /// Determines if a token is exchangeable based on its claims. An exchangeable token is one that is not a user token and has 
@@ -161,17 +159,26 @@ namespace Microsoft.Agents.Authentication
                 return false;
             }
 
-            var match = EntraV1IssuerPattern.Match(issuer);
-            if (!match.Success)
+            foreach (var pattern in EntraIssuerPatterns)
             {
-                match = EntraV2IssuerPattern.Match(issuer);
-            }
-            if (!match.Success)
-            {
-                match = EntraChinaV2IssuerPattern.Match(issuer);
+                var match = pattern.Match(issuer);
+                if (match.Success && Guid.TryParse(match.Groups[1].Value, out tenantId))
+                {
+                    return true;
+                }
             }
 
-            return match.Success && Guid.TryParse(match.Groups[1].Value, out tenantId);
+            return false;
+        }
+
+        private static Regex BuildIssuerPattern(string template)
+        {
+            var placeholderIndex = template.IndexOf("{0}", StringComparison.Ordinal);
+            var prefix = Regex.Escape(template.Substring(0, placeholderIndex));
+            var suffix = Regex.Escape(template.Substring(placeholderIndex + 3));
+            return new Regex(
+                $"^(?i:{prefix}){TenantGuidPattern}{suffix}$",
+                RegexOptions.CultureInvariant);
         }
 
         /// <summary>

--- a/src/samples/Shared/AspNetExtensions.cs
+++ b/src/samples/Shared/AspNetExtensions.cs
@@ -271,6 +271,14 @@ public static class AspNetExtensions
                         && issuer != null && IsBotFrameworkIssuer(issuer);
 
                     if (!isBotFrameworkToken
+                        && context.Principal?.Identity is System.Security.Claims.ClaimsIdentity identity
+                        && !identity.IsTenantIdIssuerValid())
+                    {
+                        context.Fail("Token tenant ID does not match its issuer.");
+                        return Task.CompletedTask;
+                    }
+
+                    if (!isBotFrameworkToken
                         && validationOptions.AllowedCallers != null
                         && validationOptions.AllowedCallers.Count > 0
                         && !validationOptions.AllowedCallers.Any(c => c.Equals("*", StringComparison.Ordinal)))

--- a/src/tests/Microsoft.Agents.Authentication.Tests/AgentClaimsTests.cs
+++ b/src/tests/Microsoft.Agents.Authentication.Tests/AgentClaimsTests.cs
@@ -115,6 +115,138 @@ namespace Microsoft.Agents.Auth.Tests
             Assert.Equal("claim2", identity.GetIncomingAudience());
         }
 
+        [Theory]
+        [InlineData("https://sts.windows.net/11111111-1111-1111-1111-111111111111/")]
+        [InlineData("https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/v2.0")]
+        [InlineData("https://login.microsoftonline.us/11111111-1111-1111-1111-111111111111/v2.0")]
+        [InlineData("https://login.partner.microsoftonline.cn/0b4a31a2-c1a0-475d-b363-5f26668660a3/11111111-1111-1111-1111-111111111111/v2.0")]
+        [InlineData("https://LOGIN.MICROSOFTONLINE.COM/11111111-1111-1111-1111-111111111111/v2.0")]
+        public void IsTenantIdIssuerValid_MatchingTenant_ReturnsTrue(string issuer)
+        {
+            ClaimsIdentity identity = new(
+            [
+                new(AuthenticationConstants.IssuerClaim, issuer),
+                new(AuthenticationConstants.TenantIdClaim, "11111111-1111-1111-1111-111111111111")
+            ]);
+
+            Assert.True(identity.IsTenantIdIssuerValid());
+        }
+
+        [Theory]
+        [InlineData("https://sts.windows.net/11111111-1111-1111-1111-111111111111/")]
+        [InlineData("https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/v2.0")]
+        [InlineData("https://login.microsoftonline.us/11111111-1111-1111-1111-111111111111/v2.0")]
+        [InlineData("https://login.partner.microsoftonline.cn/0b4a31a2-c1a0-475d-b363-5f26668660a3/11111111-1111-1111-1111-111111111111/v2.0")]
+        public void IsTenantIdIssuerValid_MismatchingTenant_ReturnsFalse(string issuer)
+        {
+            ClaimsIdentity identity = new(
+            [
+                new(AuthenticationConstants.IssuerClaim, issuer),
+                new(AuthenticationConstants.TenantIdClaim, "22222222-2222-2222-2222-222222222222")
+            ]);
+
+            Assert.False(identity.IsTenantIdIssuerValid());
+        }
+
+        [Fact]
+        public void IsTenantIdIssuerValid_MappedMismatchingTenant_ReturnsFalse()
+        {
+            ClaimsIdentity identity = new(
+            [
+                new(AuthenticationConstants.IssuerClaim, "https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/v2.0"),
+                new("http://schemas.microsoft.com/identity/claims/tenantid", "22222222-2222-2222-2222-222222222222")
+            ]);
+
+            Assert.False(identity.IsTenantIdIssuerValid());
+        }
+
+        [Fact]
+        public void IsTenantIdIssuerValid_ConflictingRawAndMappedTenantIds_ReturnsFalse()
+        {
+            ClaimsIdentity identity = new(
+            [
+                new(AuthenticationConstants.IssuerClaim, "https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/v2.0"),
+                new(AuthenticationConstants.TenantIdClaim, "11111111-1111-1111-1111-111111111111"),
+                new("http://schemas.microsoft.com/identity/claims/tenantid", "22222222-2222-2222-2222-222222222222")
+            ]);
+
+            Assert.False(identity.IsTenantIdIssuerValid());
+        }
+
+        [Fact]
+        public void IsTenantIdIssuerValid_BlankDuplicateTenantId_ReturnsFalse()
+        {
+            ClaimsIdentity identity = new(
+            [
+                new(AuthenticationConstants.IssuerClaim, "https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/v2.0"),
+                new(AuthenticationConstants.TenantIdClaim, "11111111-1111-1111-1111-111111111111"),
+                new(AuthenticationConstants.TenantIdClaim, "")
+            ]);
+
+            Assert.False(identity.IsTenantIdIssuerValid());
+        }
+
+        [Theory]
+        [InlineData("https://api.botframework.com")]
+        [InlineData("https://api.botframework.us")]
+        [InlineData("https://login.microsoftonline.com/contoso.onmicrosoft.com/v2.0")]
+        [InlineData("https://login.example.com/11111111-1111-1111-1111-111111111111/v2.0")]
+        [InlineData("https://user@sts.windows.net/11111111-1111-1111-1111-111111111111/")]
+        [InlineData("https://sts.windows.net:8443/11111111-1111-1111-1111-111111111111/")]
+        [InlineData("https://sts.windows.net//11111111-1111-1111-1111-111111111111/")]
+        [InlineData("https://sts.windows.net/11111111-1111-1111-1111-111111111111")]
+        [InlineData("https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/v2.0/")]
+        [InlineData("https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/V2.0")]
+        [InlineData("https://login.partner.microsoftonline.cn/0b4a31a2-c1a0-475d-b363-5f26668660a3/11111111-1111-1111-1111-111111111111/V2.0")]
+        [InlineData("not-a-uri")]
+        public void IsTenantIdIssuerValid_UnbindableIssuer_ReturnsTrue(string issuer)
+        {
+            ClaimsIdentity identity = new(
+            [
+                new(AuthenticationConstants.IssuerClaim, issuer),
+                new(AuthenticationConstants.TenantIdClaim, "22222222-2222-2222-2222-222222222222")
+            ]);
+
+            Assert.True(identity.IsTenantIdIssuerValid());
+        }
+
+        [Fact]
+        public void IsTenantIdIssuerValid_MissingTenantId_ReturnsTrue()
+        {
+            ClaimsIdentity identity = new(
+            [
+                new(AuthenticationConstants.IssuerClaim, "https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/v2.0")
+            ]);
+
+            Assert.True(identity.IsTenantIdIssuerValid());
+        }
+
+        [Fact]
+        public void IsTenantIdIssuerValid_InvalidPresentTenantId_ReturnsFalse()
+        {
+            ClaimsIdentity identity = new(
+            [
+                new(AuthenticationConstants.IssuerClaim, "https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/v2.0"),
+                new(AuthenticationConstants.TenantIdClaim, "not-a-guid")
+            ]);
+
+            Assert.False(identity.IsTenantIdIssuerValid());
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void IsTenantIdIssuerValid_BlankPresentTenantId_ReturnsFalse(string tenantId)
+        {
+            ClaimsIdentity identity = new(
+            [
+                new(AuthenticationConstants.IssuerClaim, "https://login.microsoftonline.com/11111111-1111-1111-1111-111111111111/v2.0"),
+                new(AuthenticationConstants.TenantIdClaim, tenantId)
+            ]);
+
+            Assert.False(identity.IsTenantIdIssuerValid());
+        }
+
         [Fact]
         public void GetOutgoingAppId_ThrowIfNull()
         {


### PR DESCRIPTION
Updates to resolve #881 (Add TID→Issuer cross-check in inbound JWT validation).  This pull request introduces a new validation step to ensure that the tenant ID claim in a token matches the tenant embedded in its Entra (Azure AD) issuer claim. This is designed to prevent tokens with mismatched or invalid tenant information from being accepted, improving security in authentication scenarios. The change includes the implementation of the validation logic, integration into the authentication pipeline, and comprehensive unit tests to verify correct behavior.

**Authentication logic enhancements:**

* Added `IsTenantIdIssuerValid` extension method to `ClaimsIdentity` in `AgentClaims.cs`, which checks that the tenant ID claim matches the tenant in recognized Entra v1/v2 issuer URLs. This includes robust regex-based parsing and support for both standard and China-specific endpoints. [[1]](diffhunk://#diff-7ac49c5f61e7fbe13f2bb8567142745f9ced62f6ce4a34fbbad3fd6c274b52bbR20-R31) [[2]](diffhunk://#diff-7ac49c5f61e7fbe13f2bb8567142745f9ced62f6ce4a34fbbad3fd6c274b52bbR121-R176)
* Integrated the new validation into the ASP.NET authentication pipeline in `AspNetExtensions.cs`, causing authentication to fail if the tenant ID and issuer do not match (unless the token is from Bot Framework).

**Testing improvements:**

* Added extensive unit tests in `AgentClaimsTests.cs` to cover matching, mismatching, missing, and malformed tenant IDs and issuers, ensuring the new logic behaves as expected in all scenarios.

**Dependency updates:**

* Added `System.Text.RegularExpressions` import to support regex matching for issuer validation.
