### PR TITLE
Validate AgentApplication configuration at startup

### DIFF
--- a/src/libraries/Builder/Microsoft.Agents.Builder/App/AgentApplicationConfigurationValidator.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/App/AgentApplicationConfigurationValidator.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Agents.Builder.Errors;
+using Microsoft.Agents.Core;
+using Microsoft.Agents.Core.Errors;
+using Microsoft.Extensions.Configuration;
+using System;
+using System.Linq;
+
+namespace Microsoft.Agents.Builder.App
+{
+    /// <summary>
+    /// Validates the configuration <see cref="AgentApplicationOptions"/> is created from.
+    /// </summary>
+    /// <remarks>
+    /// <para>DI creates <see cref="AgentApplicationOptions"/> on first use, which for an Agent is the first inbound
+    /// Activity.  Configuration mistakes, such as a <c>DefaultHandlerName</c> that doesn't name a defined handler,
+    /// are otherwise not reported until a user sends a message.  A host can call this during startup to report them
+    /// while the Agent is starting instead.</para>
+    /// <para>Only configuration is inspected.  Nothing is instantiated, so this has no side effects and doesn't
+    /// require the rest of the Agent to be resolvable.  The exceptions thrown are the same ones the Agent would
+    /// throw on the first Activity.</para>
+    /// </remarks>
+    internal static class AgentApplicationConfigurationValidator
+    {
+        private const string UserAuthorizationKey = "UserAuthorization";
+        private const string HandlersKey = "Handlers";
+        private const string DefaultHandlerNameKey = "DefaultHandlerName";
+
+        /// <summary>
+        /// Validates the AgentApplication configuration section.
+        /// </summary>
+        /// <param name="configuration">The configuration <see cref="AgentApplicationOptions"/> is created from.</param>
+        /// <param name="configKey">The AgentApplication config section name.</param>
+        /// <exception cref="InvalidOperationException">User authorization is configured without handlers.</exception>
+        /// <exception cref="IndexOutOfRangeException"><c>DefaultHandlerName</c> doesn't name a defined handler.</exception>
+        public static void Validate(IConfiguration configuration, string configKey = "AgentApplication")
+        {
+            AssertionHelpers.ThrowIfNull(configuration, nameof(configuration));
+
+            var section = configuration.GetSection(configKey);
+            if (!section.Exists())
+            {
+                // This is to compensate for IConfiguration containing the class name as the section name.
+                section = configuration.GetSection(nameof(AgentApplicationOptions));
+                if (!section.Exists())
+                {
+                    // Nothing is configured.  The Agent will use AgentApplicationOptions defaults.
+                    return;
+                }
+            }
+
+            ValidateUserAuthorization(section.GetSection(UserAuthorizationKey));
+        }
+
+        private static void ValidateUserAuthorization(IConfigurationSection section)
+        {
+            if (!section.Exists())
+            {
+                // User authorization is optional.
+                return;
+            }
+
+            var handlerNames = section.GetSection(HandlersKey).GetChildren().Select(handler => handler.Key).ToList();
+            if (handlerNames.Count == 0)
+            {
+                throw ExceptionHelper.GenerateException<InvalidOperationException>(ErrorHelper.NoUserAuthorizationHandlers, null);
+            }
+
+            var defaultHandlerName = section.GetValue<string>(DefaultHandlerNameKey);
+            if (string.IsNullOrWhiteSpace(defaultHandlerName))
+            {
+                // The first handler defined is used when a default isn't specified.
+                return;
+            }
+
+            // Matches how UserAuthorizationDispatcher looks up a handler name.
+            if (!handlerNames.Any(handlerName => string.Equals(handlerName, defaultHandlerName.Trim(), StringComparison.OrdinalIgnoreCase)))
+            {
+                throw ExceptionHelper.GenerateException<IndexOutOfRangeException>(ErrorHelper.UserAuthorizationDefaultHandlerNotFound, null, defaultHandlerName);
+            }
+        }
+    }
+}

--- a/src/libraries/Builder/Microsoft.Agents.Builder/UserAuth/UserAuthorizationDispatcher.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/UserAuth/UserAuthorizationDispatcher.cs
@@ -93,7 +93,11 @@ namespace Microsoft.Agents.Builder.UserAuth
             _connections = sp.GetService<IConnections>();
 
             var configDict = configuration.GetSection(configKey).Get<Dictionary<string, UserAuthorizationDefinition>>();
-            _userAuthHandlers = new(configDict, StringComparer.OrdinalIgnoreCase);
+
+            // A missing Handlers section binds to null.  Handled below as "no handlers defined".
+            _userAuthHandlers = configDict == null
+                ? new(StringComparer.OrdinalIgnoreCase)
+                : new(configDict, StringComparer.OrdinalIgnoreCase);
 
             if (_userAuthHandlers.Count == 0)
             {

--- a/src/libraries/Hosting/AspNetCore/AgentApplicationConfigurationStartupFilter.cs
+++ b/src/libraries/Hosting/AspNetCore/AgentApplicationConfigurationStartupFilter.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Agents.Builder.App;
+using Microsoft.Agents.Builder.App.UserAuth;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+
+namespace Microsoft.Agents.Hosting.AspNetCore
+{
+    /// <summary>
+    /// Validates the AgentApplication configuration while the host is starting.
+    /// </summary>
+    /// <remarks>
+    /// <para><see cref="AgentApplicationOptions"/> is registered as a singleton and DI doesn't create it until the
+    /// Agent handles its first Activity.  Configuration errors, such as a <c>DefaultHandlerName</c> that doesn't name
+    /// a defined handler, would therefore first appear as a failed conversation.  This runs the same validation
+    /// before the server starts accepting requests, so the host fails to start instead.</para>
+    /// <para>An <see cref="IStartupFilter"/> is used rather than an <see cref="Microsoft.Extensions.Hosting.IHostedService"/>
+    /// because startup filters run while the request pipeline is being built, which is before the server is listening.</para>
+    /// </remarks>
+    internal sealed class AgentApplicationConfigurationStartupFilter : IStartupFilter
+    {
+        private readonly IConfiguration _configuration;
+        private readonly IServiceProviderIsService _serviceProviderIsService;
+
+        public AgentApplicationConfigurationStartupFilter(IConfiguration configuration, IServiceProviderIsService serviceProviderIsService)
+        {
+            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+            _serviceProviderIsService = serviceProviderIsService ?? throw new ArgumentNullException(nameof(serviceProviderIsService));
+        }
+
+        public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
+        {
+            // AgentApplicationOptions prefers a DI'd UserAuthorizationOptions over the configuration section, and
+            // the registered instance isn't created here to check it.  Config validation is skipped in that case.
+            if (!_serviceProviderIsService.IsService(typeof(UserAuthorizationOptions)))
+            {
+                AgentApplicationConfigurationValidator.Validate(_configuration);
+            }
+
+            return next;
+        }
+    }
+}

--- a/src/libraries/Hosting/AspNetCore/README.md
+++ b/src/libraries/Hosting/AspNetCore/README.md
@@ -7,6 +7,6 @@ ASP.NET Core integration package for hosting agents built with the Microsoft 365
 ## Main Types
 
 - `AddAgent<T>()`: Registers an agent with the DI container
-- `AddAgentApplicationOptions()`: Registers `AgentApplicationOptions` with DI
+- `AddAgentApplicationOptions()`: Registers `AgentApplicationOptions` with DI, and validates the `AgentApplication` configuration section during startup
 - `AddAgentAspNetAuthentication()`: Configures Azure Bot Service JWT authentication
 - `MapAgentApplicationEndpoints()`: Maps the agent HTTP endpoint (default: `/api/messages`)

--- a/src/libraries/Hosting/AspNetCore/ServiceCollectionExtensions.cs
+++ b/src/libraries/Hosting/AspNetCore/ServiceCollectionExtensions.cs
@@ -6,7 +6,9 @@ using Microsoft.Agents.Builder;
 using Microsoft.Agents.Builder.App;
 using Microsoft.Agents.Builder.App.UserAuth;
 using Microsoft.Agents.Hosting.AspNetCore.BackgroundQueue;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using System;
 using System.Linq;
 
@@ -32,6 +34,11 @@ namespace Microsoft.Agents.Hosting.AspNetCore
         /// <param name="autoSignIn">An optional delegate used to select the auto sign-in behavior. If provided, it is registered as a singleton
         /// service.</param>
         /// <param name="replaceExisting">If true, replaces existing registrations of the agent application options and auto sign-in selector.</param>
+        /// <remarks>
+        /// This also registers an <see cref="IStartupFilter"/> that validates the <c>AgentApplication</c> configuration
+        /// section during startup.  Since <see cref="AgentApplicationOptions"/> isn't created by DI until the first
+        /// inbound Activity, configuration errors would otherwise first appear as a failed conversation.
+        /// </remarks>
         public static IServiceCollection AddAgentApplicationOptions(this IServiceCollection services, AutoSignInSelector autoSignIn = null, bool replaceExisting = true)
         {
             if (autoSignIn != null)
@@ -46,6 +53,10 @@ namespace Microsoft.Agents.Hosting.AspNetCore
             {
                 services.AddSingleton<AgentApplicationOptions>();
             }
+
+            // AgentApplicationOptions is created on the first Activity.  Report configuration errors during startup instead.
+            services.TryAddEnumerable(ServiceDescriptor.Transient<IStartupFilter, AgentApplicationConfigurationStartupFilter>());
+
             return services;
         }
 

--- a/src/tests/Microsoft.Agents.Builder.Tests/App/AgentApplicationConfigurationValidatorTests.cs
+++ b/src/tests/Microsoft.Agents.Builder.Tests/App/AgentApplicationConfigurationValidatorTests.cs
@@ -1,0 +1,153 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Agents.Builder.App;
+using Microsoft.Extensions.Configuration;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Microsoft.Agents.Builder.Tests.App
+{
+    public class AgentApplicationConfigurationValidatorTests
+    {
+        private const int NoUserAuthorizationHandlersCode = -50012;
+        private const int DefaultHandlerNotFoundCode = -50032;
+
+        [Fact]
+        public void Validate_NullConfiguration_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => AgentApplicationConfigurationValidator.Validate(null));
+        }
+
+        [Fact]
+        public void Validate_NoAgentApplicationSection_DoesNotThrow()
+        {
+            var configuration = CreateConfiguration(new Dictionary<string, string>
+            {
+                { "Connections:ServiceConnection:Settings:ClientId", "client-id" }
+            });
+
+            AgentApplicationConfigurationValidator.Validate(configuration);
+        }
+
+        [Fact]
+        public void Validate_NoUserAuthorization_DoesNotThrow()
+        {
+            var configuration = CreateConfiguration(new Dictionary<string, string>
+            {
+                { "AgentApplication:StartTypingTimer", "true" }
+            });
+
+            AgentApplicationConfigurationValidator.Validate(configuration);
+        }
+
+        [Fact]
+        public void Validate_DefaultHandlerNameDefined_DoesNotThrow()
+        {
+            AgentApplicationConfigurationValidator.Validate(CreateUserAuthorizationConfiguration("me"));
+        }
+
+        [Theory]
+        [InlineData("AUTO")]
+        [InlineData(" auto ")]
+        public void Validate_DefaultHandlerNameNotAnExactMatch_DoesNotThrow(string defaultHandlerName)
+        {
+            // Handler lookup is case-insensitive and trims the name.
+            AgentApplicationConfigurationValidator.Validate(CreateUserAuthorizationConfiguration(defaultHandlerName));
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void Validate_NoDefaultHandlerName_DoesNotThrow(string defaultHandlerName)
+        {
+            // The first handler defined is used when a default isn't specified.
+            AgentApplicationConfigurationValidator.Validate(CreateUserAuthorizationConfiguration(defaultHandlerName));
+        }
+
+        [Fact]
+        public void Validate_UnknownDefaultHandlerName_Throws()
+        {
+            var configuration = CreateUserAuthorizationConfiguration("NotFound");
+
+            var exception = Assert.Throws<IndexOutOfRangeException>(() => AgentApplicationConfigurationValidator.Validate(configuration));
+
+            Assert.Contains("NotFound", exception.Message);
+            Assert.Equal(DefaultHandlerNotFoundCode, exception.HResult);
+        }
+
+        [Fact]
+        public void Validate_UserAuthorizationWithoutHandlers_Throws()
+        {
+            var configuration = CreateConfiguration(new Dictionary<string, string>
+            {
+                { "AgentApplication:UserAuthorization:AutoSignIn", "true" },
+                { "AgentApplication:UserAuthorization:DefaultHandlerName", "auto" }
+            });
+
+            var exception = Assert.Throws<InvalidOperationException>(() => AgentApplicationConfigurationValidator.Validate(configuration));
+
+            Assert.Equal(NoUserAuthorizationHandlersCode, exception.HResult);
+        }
+
+        [Fact]
+        public void Validate_ClassNameSection_Throws()
+        {
+            // AgentApplicationOptions falls back to the class name when the section name isn't found.
+            var configuration = CreateConfiguration(new Dictionary<string, string>
+            {
+                { "AgentApplicationOptions:UserAuthorization:DefaultHandlerName", "NotFound" },
+                { "AgentApplicationOptions:UserAuthorization:Handlers:auto:Settings:AzureBotOAuthConnectionName", "connection" }
+            });
+
+            Assert.Throws<IndexOutOfRangeException>(() => AgentApplicationConfigurationValidator.Validate(configuration));
+        }
+
+        [Fact]
+        public void Validate_CustomConfigKey_Throws()
+        {
+            var configuration = CreateConfiguration(new Dictionary<string, string>
+            {
+                { "MyAgent:UserAuthorization:DefaultHandlerName", "NotFound" },
+                { "MyAgent:UserAuthorization:Handlers:auto:Settings:AzureBotOAuthConnectionName", "connection" }
+            });
+
+            Assert.Throws<IndexOutOfRangeException>(() => AgentApplicationConfigurationValidator.Validate(configuration, "MyAgent"));
+        }
+
+        [Fact]
+        public void Validate_CustomConfigKeyNotUsedByConfiguration_DoesNotThrow()
+        {
+            // An invalid section that AgentApplicationOptions won't read isn't validated.
+            var configuration = CreateConfiguration(new Dictionary<string, string>
+            {
+                { "MyAgent:UserAuthorization:DefaultHandlerName", "NotFound" },
+                { "MyAgent:UserAuthorization:Handlers:auto:Settings:AzureBotOAuthConnectionName", "connection" }
+            });
+
+            AgentApplicationConfigurationValidator.Validate(configuration);
+        }
+
+        private static IConfiguration CreateUserAuthorizationConfiguration(string defaultHandlerName)
+        {
+            var settings = new Dictionary<string, string>
+            {
+                { "AgentApplication:UserAuthorization:AutoSignIn", "true" },
+                { "AgentApplication:UserAuthorization:DefaultHandlerName", defaultHandlerName },
+                { "AgentApplication:UserAuthorization:Handlers:auto:Settings:AzureBotOAuthConnectionName", "auto-connection" },
+                { "AgentApplication:UserAuthorization:Handlers:me:Settings:AzureBotOAuthConnectionName", "me-connection" }
+            };
+
+            return CreateConfiguration(settings);
+        }
+
+        private static IConfiguration CreateConfiguration(Dictionary<string, string> settings)
+        {
+            return new ConfigurationBuilder()
+                .AddInMemoryCollection(settings)
+                .Build();
+        }
+    }
+}

--- a/src/tests/Microsoft.Agents.Builder.Tests/UserAuthorizationDispatcherTests.cs
+++ b/src/tests/Microsoft.Agents.Builder.Tests/UserAuthorizationDispatcherTests.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Agents.Builder.UserAuth;
+using Microsoft.Agents.Storage;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Microsoft.Agents.Builder.Tests
+{
+    public class UserAuthorizationDispatcherTests
+    {
+        private const int NoUserAuthorizationHandlersCode = -50012;
+
+        [Fact]
+        public void Constructor_MissingHandlersSection_ThrowsNoHandlersDefined()
+        {
+            var configuration = CreateConfiguration(new Dictionary<string, string>
+            {
+                { "AgentApplication:UserAuthorization:DefaultHandlerName", "auto" }
+            });
+
+            var exception = Assert.Throws<InvalidOperationException>(() => CreateDispatcher(configuration));
+
+            Assert.Equal(NoUserAuthorizationHandlersCode, exception.HResult);
+        }
+
+        [Fact]
+        public void Constructor_HandlersDefined_LoadsHandlerNames()
+        {
+            var configuration = CreateConfiguration(new Dictionary<string, string>
+            {
+                { "AgentApplication:UserAuthorization:Handlers:auto:Settings:AzureBotOAuthConnectionName", "auto-connection" }
+            });
+
+            var dispatcher = CreateDispatcher(configuration);
+
+            Assert.False(dispatcher.TryGet("unknown", out var handler));
+            Assert.Null(handler);
+        }
+
+        private static UserAuthorizationDispatcher CreateDispatcher(IConfiguration configuration)
+        {
+            return new UserAuthorizationDispatcher(
+                new Mock<IServiceProvider>().Object,
+                NullLoggerFactory.Instance,
+                configuration,
+                new MemoryStorage(),
+                configKey: "AgentApplication:UserAuthorization:Handlers");
+        }
+
+        private static IConfiguration CreateConfiguration(Dictionary<string, string> settings)
+        {
+            return new ConfigurationBuilder()
+                .AddInMemoryCollection(settings)
+                .Build();
+        }
+    }
+}

--- a/src/tests/Microsoft.Agents.Hosting.AspNetCore/AgentApplicationConfigurationStartupFilterTests.cs
+++ b/src/tests/Microsoft.Agents.Hosting.AspNetCore/AgentApplicationConfigurationStartupFilterTests.cs
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Agents.Authentication;
+using Microsoft.Agents.Builder.App;
+using Microsoft.Agents.Builder.App.UserAuth;
+using Microsoft.Agents.Builder.UserAuth;
+using Microsoft.Agents.Storage;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.Agents.Hosting.AspNetCore.Tests
+{
+    public class AgentApplicationConfigurationStartupFilterTests
+    {
+        [Fact]
+        public void AddAgentApplicationOptions_RegistersStartupFilterOnce()
+        {
+            var services = new ServiceCollection();
+
+            services.AddAgentApplicationOptions();
+            services.AddAgentApplicationOptions();
+
+            Assert.Single(services, descriptor => descriptor.ServiceType == typeof(IStartupFilter));
+        }
+
+        [Fact]
+        public void Configure_InvalidUserAuthorization_Throws()
+        {
+            var filter = CreateStartupFilter(CreateConfiguration(new Dictionary<string, string>
+            {
+                { "AgentApplication:UserAuthorization:DefaultHandlerName", "NotFound" },
+                { "AgentApplication:UserAuthorization:Handlers:auto:Settings:AzureBotOAuthConnectionName", "auto-connection" }
+            }));
+
+            var exception = Assert.Throws<IndexOutOfRangeException>(() => filter.Configure(_ => { }));
+
+            Assert.Contains("NotFound", exception.Message);
+        }
+
+        [Fact]
+        public void Configure_ValidUserAuthorization_CallsNext()
+        {
+            var filter = CreateStartupFilter(CreateConfiguration(new Dictionary<string, string>
+            {
+                { "AgentApplication:UserAuthorization:DefaultHandlerName", "auto" },
+                { "AgentApplication:UserAuthorization:Handlers:auto:Settings:AzureBotOAuthConnectionName", "auto-connection" }
+            }));
+
+            var called = false;
+            Action<IApplicationBuilder> next = _ => called = true;
+
+            filter.Configure(next)(new Mock<IApplicationBuilder>().Object);
+
+            Assert.True(called);
+        }
+
+        [Fact]
+        public void Configure_UserAuthorizationOptionsFromDI_SkipsConfigurationValidation()
+        {
+            // AgentApplicationOptions uses a DI'd UserAuthorizationOptions instead of the configuration section.
+            var userAuthorizationOptions = new UserAuthorizationOptions(
+                NullLoggerFactory.Instance,
+                new MemoryStorage(),
+                new Mock<IConnections>().Object,
+                CreateHandler("auto"));
+
+            var filter = CreateStartupFilter(
+                CreateConfiguration(new Dictionary<string, string>
+                {
+                    { "AgentApplication:UserAuthorization:DefaultHandlerName", "NotFound" },
+                    { "AgentApplication:UserAuthorization:Handlers:auto:Settings:AzureBotOAuthConnectionName", "auto-connection" }
+                }),
+                services => services.AddSingleton(userAuthorizationOptions));
+
+            filter.Configure(_ => { });
+        }
+
+        private static IUserAuthorization CreateHandler(string name)
+        {
+            var handler = new Mock<IUserAuthorization>();
+            handler.SetupGet(e => e.Name).Returns(name);
+            return handler.Object;
+        }
+
+        private static IStartupFilter CreateStartupFilter(IConfiguration configuration, Action<IServiceCollection> configureServices = null)
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton(configuration);
+            services.AddAgentApplicationOptions();
+            configureServices?.Invoke(services);
+
+            return services.BuildServiceProvider().GetServices<IStartupFilter>().Single();
+        }
+
+        private static IConfiguration CreateConfiguration(Dictionary<string, string> settings)
+        {
+            return new ConfigurationBuilder()
+                .AddInMemoryCollection(settings)
+                .Build();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #244 — a misspelled `DefaultHandlerName` is now reported while the host is starting instead of on the first message.

- `AddAgentApplicationOptions` registers an `IStartupFilter` that validates the `AgentApplication` configuration section
- validation reads configuration only — nothing is instantiated, and it throws the same exceptions and error codes the Agent already throws
- validation is skipped when `UserAuthorizationOptions` is supplied by DI, since `AgentApplicationOptions` uses that instead of the configuration section
- a missing `Handlers` section reports `No UserAuthorization Handlers were defined` (-50012) instead of an `ArgumentNullException` from `Dictionary`

## Why

`AgentApplicationOptions` is a singleton that DI doesn't create until the Agent handles its first Activity, so `UserAuthorization` configuration mistakes first show up as a failed conversation. This is the "throw at startup rather than on first message" ask in #244, and an answer to the "Is there a way to make DI create on registration?" question in that thread.

Eagerly resolving `AgentApplicationOptions` at startup would also pull in the adapter, connections and token providers, and would change startup behavior for existing apps in ways that go well beyond the reported problem. Validating the configuration instead keeps the change to the mistake being reported.

An `IStartupFilter` is used rather than an `IHostedService` because startup filters run while the request pipeline is being built, which is before `GenericWebHostService` starts the server — a hosted service would run after the server is already listening.

## Behavior

Before, with `"DefaultHandlerName": "NotFound"`, the Agent started and then failed the first conversation. Now:

```
fail: Microsoft.Extensions.Hosting.Internal.Host[11]
      Hosting failed to start
      System.IndexOutOfRangeException: Handler name 'NotFound' not found in configuration under
      AgentApplication:UserAuthorization:Handlers, or
      AgentApplication:UserAuthorization:DefaultHandlerName is invalid.
         at Microsoft.Agents.Builder.App.AgentApplicationConfigurationValidator.ValidateUserAuthorization(...)
         at Microsoft.Agents.Hosting.AspNetCore.AgentApplicationConfigurationStartupFilter.Configure(...)
         at Microsoft.AspNetCore.Hosting.GenericWebHostService.StartAsync(...)
```

The exception type, message and HResult (-50032) are unchanged; only when it surfaces has changed. Valid configuration, a missing `DefaultHandlerName` (first handler wins), a missing `UserAuthorization` section, and case/whitespace differences in the handler name all start normally.

## Validation

- `dotnet test src/tests/Microsoft.Agents.Builder.Tests/Microsoft.Agents.Builder.Tests.csproj -c Debug` — 1029 passed (net8.0), 1029 passed (net48)
- `dotnet test src/tests/Microsoft.Agents.Hosting.AspNetCore/Microsoft.Agents.Hosting.AspNetCore.Tests.csproj -c Debug -f net8.0` — 87 passed
- `dotnet build src/libraries/Builder/Microsoft.Agents.Builder/Microsoft.Agents.Builder.csproj -c Debug -f netstandard2.0` — 0 warnings
- full solution run: the only failures are `Builder.Dialogs.Tests.NumberPromptTests` (4) and `Connector.Tests.UserTokenRestClientTests` (2), which reproduce unchanged on `main` in this environment
- verified in a real `WebApplication`: a misspelled `DefaultHandlerName` fails host startup, a valid one starts normally

New coverage: 20 tests across the validator (missing/valid/invalid sections, `AgentApplicationOptions` fallback section name, custom config keys, case and whitespace handling), the startup filter (registered once, throws on invalid config, calls `next` on valid config, skipped when `UserAuthorizationOptions` is in DI), and the dispatcher's missing-`Handlers` path.
