### PR TITLE
Add opt-in per-turn DI scope to HostedActivityService (#442)

### DIFF
--- a/src/libraries/Hosting/AspNetCore/AdapterOptions.cs
+++ b/src/libraries/Hosting/AspNetCore/AdapterOptions.cs
@@ -34,7 +34,10 @@ namespace Microsoft.Agents.Hosting.AspNetCore
         /// from the root <see cref="System.IServiceProvider"/>. Any scoped registration in the Agent's dependency graph is then
         /// promoted to the root scope, giving a single instance shared by every turn for the lifetime of the process.
         /// Set this to <see langword="true"/> for Agents that depend on scoped services, such as an Entity Framework Core
-        /// <c>DbContext</c>. Services registered by the SDK are singletons and resolve identically either way.
+        /// <c>DbContext</c>. The SDK registers no scoped services, so enabling this affects only registrations made by the
+        /// application. Note that disposable transient dependencies resolved for a turn - <see cref="Microsoft.Agents.Builder.IAgent"/>
+        /// itself is registered transient - are then disposed with the turn scope, rather than being retained by the root
+        /// scope until the host shuts down.
         /// </remarks>
         public bool UseScopePerTurn { get; set; } = false;
     }

--- a/src/libraries/Hosting/AspNetCore/AdapterOptions.cs
+++ b/src/libraries/Hosting/AspNetCore/AdapterOptions.cs
@@ -25,5 +25,17 @@ namespace Microsoft.Agents.Hosting.AspNetCore
         /// Gets or sets a value indicating whether Activity.ServiceUrl should be validated using the 'serviceurl' claim in the incoming token. This is typically used to ensure that the request is coming from a trusted source.
         /// </summary>
         public bool ValidateServiceUrl { get; set; } = false;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether each queued Activity is processed in its own dependency injection scope.
+        /// </summary>
+        /// <remarks>
+        /// When <see langword="false"/> (the default), queued Activities resolve the <see cref="Microsoft.Agents.Builder.IAgent"/>
+        /// from the root <see cref="System.IServiceProvider"/>. Any scoped registration in the Agent's dependency graph is then
+        /// promoted to the root scope, giving a single instance shared by every turn for the lifetime of the process.
+        /// Set this to <see langword="true"/> for Agents that depend on scoped services, such as an Entity Framework Core
+        /// <c>DbContext</c>. Services registered by the SDK are singletons and resolve identically either way.
+        /// </remarks>
+        public bool UseScopePerTurn { get; set; } = false;
     }
 }

--- a/src/libraries/Hosting/AspNetCore/BackgroundQueue/HostedActivityService.cs
+++ b/src/libraries/Hosting/AspNetCore/BackgroundQueue/HostedActivityService.cs
@@ -54,8 +54,13 @@ namespace Microsoft.Agents.Hosting.AspNetCore.BackgroundQueue
             ArgumentNullException.ThrowIfNull(activityTaskQueue);
             ArgumentNullException.ThrowIfNull(provider);
 
-            _shutdownTimeoutSeconds = options != null ? options.ShutdownTimeoutSeconds : 60;
-            _useScopePerTurn = options != null && options.UseScopePerTurn;
+            // AdapterOptions is not registered in DI, so `options` is null unless the application registers it.
+            // Fall back to the same "CloudAdapterOptions" configuration section CloudAdapter binds, so the options
+            // are honored from appsettings as this constructor's `config` parameter documents.
+            var adapterOptions = options ?? config.GetSection("CloudAdapterOptions")?.Get<AdapterOptions>() ?? new AdapterOptions();
+
+            _shutdownTimeoutSeconds = adapterOptions.ShutdownTimeoutSeconds;
+            _useScopePerTurn = adapterOptions.UseScopePerTurn;
             _activityQueue = activityTaskQueue;
             _logger = logger ?? NullLogger<HostedActivityService>.Instance;
             _serviceProvider = provider;
@@ -153,7 +158,9 @@ namespace Microsoft.Agents.Hosting.AspNetCore.BackgroundQueue
                 // Resolving from the root IServiceProvider promotes any scoped registration in the Agent's dependency graph to
                 // the root scope, so a single instance is shared by every turn for the lifetime of the process. When
                 // AdapterOptions.UseScopePerTurn is set, the turn gets its own scope instead, which is disposed once the turn
-                // completes. Everything the SDK registers is a singleton and resolves identically either way.
+                // completes. The SDK registers no scoped services, so this only affects registrations made by the application.
+                // Note that disposable transients resolved for the turn - IAgent itself is registered transient - are then
+                // disposed with the turn scope instead of being retained by the root scope until the host shuts down.
                 using var turnScope = _useScopePerTurn ? _serviceProvider.CreateScope() : null;
                 var turnServices = turnScope?.ServiceProvider ?? _serviceProvider;
 

--- a/src/libraries/Hosting/AspNetCore/BackgroundQueue/HostedActivityService.cs
+++ b/src/libraries/Hosting/AspNetCore/BackgroundQueue/HostedActivityService.cs
@@ -7,6 +7,7 @@ using Microsoft.Agents.Core.HeaderPropagation;
 using Microsoft.Agents.Core.Models;
 using Microsoft.Agents.Core.Telemetry;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -30,6 +31,7 @@ namespace Microsoft.Agents.Hosting.AspNetCore.BackgroundQueue
         private readonly ConcurrentDictionary<ActivityWithClaims, Task> _activitiesProcessing = new();
         private readonly IActivityTaskQueue _activityQueue;
         private readonly int _shutdownTimeoutSeconds;
+        private readonly bool _useScopePerTurn;
         private readonly IServiceProvider _serviceProvider;
         private int _stopping;
 
@@ -53,6 +55,7 @@ namespace Microsoft.Agents.Hosting.AspNetCore.BackgroundQueue
             ArgumentNullException.ThrowIfNull(provider);
 
             _shutdownTimeoutSeconds = options != null ? options.ShutdownTimeoutSeconds : 60;
+            _useScopePerTurn = options != null && options.UseScopePerTurn;
             _activityQueue = activityTaskQueue;
             _logger = logger ?? NullLogger<HostedActivityService>.Instance;
             _serviceProvider = provider;
@@ -146,8 +149,16 @@ namespace Microsoft.Agents.Hosting.AspNetCore.BackgroundQueue
                 // We must go back through DI to get the IAgent. This is because the IAgent is typically transient, and anything
                 // else that is transient as part of the Agent, that uses IServiceProvider will encounter error since that is scoped
                 // and disposed before this gets called.
-                var agent = _serviceProvider.GetService(activityWithClaims.AgentType ?? typeof(IAgent));
-                agent ??= _serviceProvider.GetService(typeof(IAgent));
+                //
+                // Resolving from the root IServiceProvider promotes any scoped registration in the Agent's dependency graph to
+                // the root scope, so a single instance is shared by every turn for the lifetime of the process. When
+                // AdapterOptions.UseScopePerTurn is set, the turn gets its own scope instead, which is disposed once the turn
+                // completes. Everything the SDK registers is a singleton and resolves identically either way.
+                using var turnScope = _useScopePerTurn ? _serviceProvider.CreateScope() : null;
+                var turnServices = turnScope?.ServiceProvider ?? _serviceProvider;
+
+                var agent = turnServices.GetService(activityWithClaims.AgentType ?? typeof(IAgent));
+                agent ??= turnServices.GetService(typeof(IAgent));
 
                 HeaderPropagationContext.HeadersFromRequest = activityWithClaims.Headers;
                 activityWithClaims.TelemetryActivity?.Start();

--- a/src/tests/Microsoft.Agents.Hosting.AspNetCore/BackgroundActivityService/HostedActivityServiceTests.cs
+++ b/src/tests/Microsoft.Agents.Hosting.AspNetCore/BackgroundActivityService/HostedActivityServiceTests.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
@@ -191,7 +192,27 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
             Assert.All(probes, probe => Assert.False(probe.IsDisposed));
         }
 
-        private static ScopedRecord UseScopedRecord(bool useScopePerTurn, int expectedTurns)
+        [Fact]
+        public async Task ExecuteAsync_WithScopePerTurnFromConfiguration_ShouldResolveScopedDependencyPerTurn()
+        {
+            // AdapterOptions is not registered in DI, so the CloudAdapterOptions configuration section
+            // is the path applications actually use to enable this.
+            var record = UseScopedRecord(useScopePerTurn: true, expectedTurns: 2, viaConfiguration: true);
+
+            record.Queue.QueueBackgroundActivity(new ClaimsIdentity(), record.Adapter.Object, new Activity());
+            record.Queue.QueueBackgroundActivity(new ClaimsIdentity(), record.Adapter.Object, new Activity());
+
+            await record.Service.StartAsync(CancellationToken.None);
+            await record.AllTurnsProcessed.Task.WaitAsync(TimeSpan.FromSeconds(30));
+            await record.Service.StopAsync(CancellationToken.None);
+
+            var probes = record.Collector.Resolved.ToArray();
+            Assert.Equal(2, probes.Length);
+            Assert.NotSame(probes[0], probes[1]);
+            Assert.All(probes, probe => Assert.True(probe.IsDisposed, "Turn scope was not disposed."));
+        }
+
+        private static ScopedRecord UseScopedRecord(bool useScopePerTurn, int expectedTurns, bool viaConfiguration = false)
         {
             var collector = new ProbeCollector();
             var services = new ServiceCollection();
@@ -201,13 +222,24 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
 
             var serviceProvider = services.BuildServiceProvider();
             var queue = new ActivityTaskQueue();
-            var options = new AdapterOptions { UseScopePerTurn = useScopePerTurn };
+
+            // AdapterOptions is not registered in DI, so applications configure it through the
+            // "CloudAdapterOptions" section. Exercise both that path and the explicit options parameter.
+            var configBuilder = new ConfigurationBuilder();
+            if (viaConfiguration)
+            {
+                configBuilder.AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    ["CloudAdapterOptions:UseScopePerTurn"] = useScopePerTurn.ToString()
+                });
+            }
+
             var service = new HostedActivityService(
                 serviceProvider,
-                new ConfigurationBuilder().Build(),
+                configBuilder.Build(),
                 queue,
                 new Mock<ILogger<HostedActivityService>>().Object,
-                options);
+                viaConfiguration ? null : new AdapterOptions { UseScopePerTurn = useScopePerTurn });
 
             var allTurnsProcessed = new TaskCompletionSource();
             var processed = 0;

--- a/src/tests/Microsoft.Agents.Hosting.AspNetCore/BackgroundActivityService/HostedActivityServiceTests.cs
+++ b/src/tests/Microsoft.Agents.Hosting.AspNetCore/BackgroundActivityService/HostedActivityServiceTests.cs
@@ -7,9 +7,11 @@ using Microsoft.Agents.Builder.Testing;
 using Microsoft.Agents.Core.Models;
 using Microsoft.Agents.Hosting.AspNetCore.BackgroundQueue;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
 using System;
+using System.Collections.Concurrent;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
@@ -149,6 +151,111 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
             // must not throw LockRecursionException. See https://github.com/dotnet/aspnetcore/issues/40271.
             await record.Service.StopAsync(token);
             await record.Service.StopAsync(token);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_WithScopePerTurn_ShouldResolveScopedDependencyPerTurn()
+        {
+            var record = UseScopedRecord(useScopePerTurn: true, expectedTurns: 2);
+
+            record.Queue.QueueBackgroundActivity(new ClaimsIdentity(), record.Adapter.Object, new Activity());
+            record.Queue.QueueBackgroundActivity(new ClaimsIdentity(), record.Adapter.Object, new Activity());
+
+            await record.Service.StartAsync(CancellationToken.None);
+            await record.AllTurnsProcessed.Task.WaitAsync(TimeSpan.FromSeconds(30));
+            await record.Service.StopAsync(CancellationToken.None);
+
+            var probes = record.Collector.Resolved.ToArray();
+            Assert.Equal(2, probes.Length);
+            Assert.NotSame(probes[0], probes[1]);
+            Assert.All(probes, probe => Assert.True(probe.IsDisposed, "Turn scope was not disposed."));
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_WithoutScopePerTurn_ShouldShareScopedDependencyAcrossTurns()
+        {
+            var record = UseScopedRecord(useScopePerTurn: false, expectedTurns: 2);
+
+            record.Queue.QueueBackgroundActivity(new ClaimsIdentity(), record.Adapter.Object, new Activity());
+            record.Queue.QueueBackgroundActivity(new ClaimsIdentity(), record.Adapter.Object, new Activity());
+
+            await record.Service.StartAsync(CancellationToken.None);
+            await record.AllTurnsProcessed.Task.WaitAsync(TimeSpan.FromSeconds(30));
+            await record.Service.StopAsync(CancellationToken.None);
+
+            // Default behavior: resolving from the root provider promotes the scoped registration to the
+            // root scope, so every turn shares one instance and it is not disposed between turns.
+            var probes = record.Collector.Resolved.ToArray();
+            Assert.Equal(2, probes.Length);
+            Assert.Same(probes[0], probes[1]);
+            Assert.All(probes, probe => Assert.False(probe.IsDisposed));
+        }
+
+        private static ScopedRecord UseScopedRecord(bool useScopePerTurn, int expectedTurns)
+        {
+            var collector = new ProbeCollector();
+            var services = new ServiceCollection();
+            services.AddSingleton(collector);
+            services.AddScoped<ScopedProbe>();
+            services.AddTransient<IAgent, ProbeAgent>();
+
+            var serviceProvider = services.BuildServiceProvider();
+            var queue = new ActivityTaskQueue();
+            var options = new AdapterOptions { UseScopePerTurn = useScopePerTurn };
+            var service = new HostedActivityService(
+                serviceProvider,
+                new ConfigurationBuilder().Build(),
+                queue,
+                new Mock<ILogger<HostedActivityService>>().Object,
+                options);
+
+            var allTurnsProcessed = new TaskCompletionSource();
+            var processed = 0;
+            var adapter = new Mock<IChannelAdapter>();
+            adapter
+                .Setup(a => a.ProcessActivityAsync(It.IsAny<ClaimsIdentity>(), It.IsAny<Activity>(), It.IsAny<AgentCallbackHandler>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new InvokeResponse())
+                .Callback(() =>
+                {
+                    if (Interlocked.Increment(ref processed) == expectedTurns)
+                    {
+                        allTurnsProcessed.TrySetResult();
+                    }
+                });
+
+            return new(service, queue, adapter, collector, allTurnsProcessed);
+        }
+
+        private record ScopedRecord(
+            HostedActivityService Service,
+            ActivityTaskQueue Queue,
+            Mock<IChannelAdapter> Adapter,
+            ProbeCollector Collector,
+            TaskCompletionSource AllTurnsProcessed);
+
+        private sealed class ScopedProbe : IDisposable
+        {
+            public bool IsDisposed { get; private set; }
+
+            public void Dispose() => IsDisposed = true;
+        }
+
+        private sealed class ProbeCollector
+        {
+            public ConcurrentQueue<ScopedProbe> Resolved { get; } = new();
+        }
+
+        private sealed class ProbeAgent : IAgent
+        {
+            public ProbeAgent(ScopedProbe probe, ProbeCollector collector)
+            {
+                collector.Resolved.Enqueue(probe);
+            }
+
+            public Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default)
+            {
+                return Task.CompletedTask;
+            }
         }
 
         private static Record UseRecord(IAgent agent = null)


### PR DESCRIPTION
## Problem

`HostedActivityService.ProcessAsync` resolves the Agent from the **root** `IServiceProvider`:

```csharp
var agent = _serviceProvider.GetService(activityWithClaims.AgentType ?? typeof(IAgent));
agent ??= _serviceProvider.GetService(typeof(IAgent));
```

The comment above it correctly identifies that the request scope is already disposed by this point. But resolving from root doesn't avoid scoping — it silently changes the lifetime of everything scoped underneath the Agent. From `CallSiteRuntimeResolver` in dotnet/runtime:

```csharp
protected override object? VisitScopeCache(ServiceCallSite callSite, RuntimeResolverContext context)
{
    // Check if we are in the situation where scoped service was promoted to singleton
    // and we need to lock the root
    return context.Scope.IsRootScope ?
        VisitRootCache(callSite, context) :
        VisitCache(callSite, context, context.Scope, RuntimeResolverLock.Scope);
}
```

`VisitRootCache` caches the instance on the call site and registers it with `Root.CaptureDisposable(...)`, so it lives until the `ServiceProvider` is disposed at host shutdown. For an app that wrote `builder.Services.AddDbContext<T>()` — scoped by default — that means **one `DbContext` shared by every concurrent turn for the lifetime of the process**, with a change tracker that never releases anything.

Two things make this hard to discover:

1. `ValidateScopes` defaults to `HostingEnvironment.IsDevelopment()`, so the invalid resolution throws locally and succeeds in production.
2. When it does throw, `ProcessAsync` catches it and logs `"Error occurred executing WorkItem."`. The Agent simply stops replying, with nothing pointing at DI.

This is #442, open since September 2025 and reported by several teams migrating from Bot Framework.

## Prior art in this repo

The SDK already implements per-turn scoping — in `Hosting/DirectLine.NamedPipes/NamedPipeActivityHandler.cs`:

```csharp
using var scope = _services.CreateScope();
var adapter = scope.ServiceProvider.GetRequiredService<IChannelAdapter>();
var agent = scope.ServiceProvider.GetRequiredService<IAgent>();
...
await adapter.ProcessActivityAsync(identity, activity, agent.OnTurnAsync, cancellationToken);
```

That's currently the only `CreateScope` in `src/libraries`. This PR brings the ASP.NET host in line with it.

## Change

Adds `AdapterOptions.UseScopePerTurn`, **default `false`** so existing behavior is unchanged. When enabled, each queued Activity resolves its Agent from a scope that is disposed once the turn completes:

```csharp
using var turnScope = _useScopePerTurn ? _serviceProvider.CreateScope() : null;
var turnServices = turnScope?.ServiceProvider ?? _serviceProvider;

var agent = turnServices.GetService(activityWithClaims.AgentType ?? typeof(IAgent));
agent ??= turnServices.GetService(typeof(IAgent));
```

No constructor change — `_serviceProvider` is already injected. `activityWithClaims.ChannelAdapter` is captured at enqueue time and is a singleton, so nothing else moves.

## Risk

Low. `grep -rn "AddScoped" src/` returns no registrations — everything the SDK registers is a singleton, and singletons resolve identically from a child scope. Enabling the option can only affect registrations made by the application itself, which today are silently broken anyway.

## Tests

Two tests added to `HostedActivityServiceTests`, using a real `ServiceCollection` rather than the mocked `IServiceProvider` the existing tests use, so scoping is actually exercised:

- `ExecuteAsync_WithScopePerTurn_ShouldResolveScopedDependencyPerTurn` — two turns get distinct instances, and each is disposed after its turn.
- `ExecuteAsync_WithoutScopePerTurn_ShouldShareScopedDependencyAcrossTurns` — asserts `Assert.Same` across turns and that the instance is never disposed, pinning today's behavior so the difference is explicit.

`Microsoft.Agents.Hosting.AspNetCore.Tests`: 85/85 passing. Full `AgentSdk.proj` build succeeds with no new warnings.

## Notes

Happy to adjust naming, or to flip the default to `true` if the team would rather this be the standard behavior — that would also stop transient `IDisposable` Agents accumulating in the root scope, since `CaptureDisposable` captures regardless of lifetime and the root scope only drains at shutdown.

A related follow-up I'd be glad to send separately: `ActivityTaskQueue`, `BackgroundTaskQueue`, `HostedActivityService` and `HostedTaskService` are all `internal`, so the workaround people are using today in #442 has to string-match `"Microsoft.Agents.Hosting.AspNetCore.BackgroundQueue.HostedActivityService"` to remove it from DI. Making these public/overridable would let people subclass instead.
