### PR TITLE
Add support for symbol packages in nightly build artifact publishing

### DIFF
--- a/.azdo/OneBranch.Nightly.yml
+++ b/.azdo/OneBranch.Nightly.yml
@@ -162,7 +162,9 @@ extends:
             displayName: "Copy Files for 'Publish packages (Release)' publish task"
             inputs:
                 SourceFolder: '$(Build.SourcesDirectory)\bin'
-                Contents: '**/*.nupkg'
+                Contents: |
+                  **/*.nupkg
+                  **/*.snupkg
                 FlattenFolders : true
                 TargetFolder: $(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT/packages
             condition: always()


### PR DESCRIPTION
This pull request makes a small but important update to the build pipeline configuration. The change ensures that both `.nupkg` and `.snupkg` package files are included when copying files for the publish task.

Build pipeline improvements:

* [`.azdo/OneBranch.Nightly.yml`](diffhunk://#diff-da8946022fae5014bc6b1d1fc713edee9d12d9700548d8681dc082c3dad985adL165-R167): Updated the `Contents` input in the file copy step to include both `**/*.nupkg` and `**/*.snupkg` files, ensuring that both main and symbol packages are published.