### PR TITLE
net10.0 support

### DIFF
--- a/.azdo/OneBranch.Nightly.yml
+++ b/.azdo/OneBranch.Nightly.yml
@@ -134,6 +134,15 @@ extends:
                   }
 
           - task: UseDotNet@2
+            displayName: Install .NET 8 SDK
+            inputs:
+              packageType: sdk
+              version: 8.0.x
+              performMultiLevelLookup: true
+            env:
+              ob_restore_phase: true
+
+          - task: UseDotNet@2
             displayName: Install .NET SDK from global.json
             inputs:
               packageType: sdk

--- a/.azdo/OneBranch.Nightly.yml
+++ b/.azdo/OneBranch.Nightly.yml
@@ -133,6 +133,15 @@ extends:
                     Write-Host "Replaced $($_.FullName)"
                   }
 
+          - task: UseDotNet@2
+            displayName: Install .NET SDK from global.json
+            inputs:
+              packageType: sdk
+              useGlobalJson: true
+              performMultiLevelLookup: true
+            env:
+              ob_restore_phase: true
+
           - task: NuGetAuthenticate@1
 
           - script: dotnet tool restore --configfile $(Build.SourcesDirectory)/.azdo/nuget.config
@@ -140,14 +149,6 @@ extends:
             workingDirectory: $(Build.SourcesDirectory)
             env:
               ob_restore_phase: true # # Steps decorated with this env variable will be run with network. All these steps are hoisted to the beginning of the build
-                      
-          # HELD IN COMMENT UNTIL FIX for TELEMETRY 
-          # - task: UseDotNet@2
-          #   continueOnError: true
-          #   inputs:
-          #     packageType: 'sdk'
-          #     useGlobalJson: true
-          #     performMultiLevelLookup: true
 
           - template: Agents-dotnet/.pipelines/templates/build-sign-package.yaml@tools
             parameters:

--- a/.azdo/OneBranch.PullRequest.yml
+++ b/.azdo/OneBranch.PullRequest.yml
@@ -108,6 +108,15 @@ extends:
                     Write-Host "Replaced $($_.FullName)"
                   }
 
+          - task: UseDotNet@2
+            displayName: Install .NET SDK from global.json
+            inputs:
+              packageType: sdk
+              useGlobalJson: true
+              performMultiLevelLookup: true
+            env:
+              ob_restore_phase: true
+
           - task: NuGetAuthenticate@1
 
           - script: dotnet tool restore --configfile $(Build.SourcesDirectory)/.azdo/nuget.config

--- a/.azdo/OneBranch.PullRequest.yml
+++ b/.azdo/OneBranch.PullRequest.yml
@@ -109,6 +109,15 @@ extends:
                   }
 
           - task: UseDotNet@2
+            displayName: Install .NET 8 SDK
+            inputs:
+              packageType: sdk
+              version: 8.0.x
+              performMultiLevelLookup: true
+            env:
+              ob_restore_phase: true
+
+          - task: UseDotNet@2
             displayName: Install .NET SDK from global.json
             inputs:
               packageType: sdk

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x        
+        dotnet-version: 10.0.x
 
     - uses: dotnet/nbgv@master
       with:
@@ -41,5 +41,8 @@ jobs:
     - name: Package
       run: dotnet pack --no-build --no-restore -c release src/Microsoft.Agents.SDK.sln 
 
-    - name: Test in net8 only
+    - name: Test in net8
       run: dotnet test --no-build --no-restore -c debug ./src/ -f net8.0
+
+    - name: Test in net10
+      run: dotnet test --no-build --no-restore -c debug ./src/ -f net10.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,5 +35,8 @@ jobs:
     - name: Package
       run: dotnet pack --no-build --no-restore -c debug src/Microsoft.Agents.SDK.sln 
 
-    - name: Test
-      run: dotnet test --no-build --no-restore -c debug ./src/
+    - name: Test in net8
+      run: dotnet test --no-build --no-restore -c debug ./src/ -f net8.0
+
+    - name: Test in net10
+      run: dotnet test --no-build --no-restore -c debug ./src/ -f net10.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x        
+        dotnet-version: 10.0.x
 
     - uses: dotnet/nbgv@master
       with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -76,7 +76,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x              
+        dotnet-version: 10.0.x
 
     - uses: dotnet/nbgv@master
       with:

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,12 +14,12 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
   </PropertyGroup>
   <PropertyGroup>
-    <Microsoft_Extentions_PkgVer>10.0.7</Microsoft_Extentions_PkgVer>
-    <Microsoft_Bcl_PkgVer>10.0.7</Microsoft_Bcl_PkgVer>
-    <Microsoft_System_PkgVer>10.0.7</Microsoft_System_PkgVer>
-    <Microsoft_AspNetCore_PkgVer>8.0.23</Microsoft_AspNetCore_PkgVer>
-    <Microsoft_IdentityModel_PkgVer>8.15.0</Microsoft_IdentityModel_PkgVer>
-    <Microsoft_IdentityClient_PkgVer>4.83.3</Microsoft_IdentityClient_PkgVer>
+    <Microsoft_Extentions_PkgVer>10.0.10</Microsoft_Extentions_PkgVer>
+    <Microsoft_Bcl_PkgVer>10.0.10</Microsoft_Bcl_PkgVer>
+    <Microsoft_System_PkgVer>10.0.10</Microsoft_System_PkgVer>
+    <Microsoft_AspNetCore_PkgVer>8.0.29</Microsoft_AspNetCore_PkgVer>
+    <Microsoft_IdentityModel_PkgVer>8.22.0</Microsoft_IdentityModel_PkgVer>
+    <Microsoft_IdentityClient_PkgVer>4.87.0</Microsoft_IdentityClient_PkgVer>
     <Xunit_PackageVersion>2.9.3</Xunit_PackageVersion>
     <Xunit_v3_PackageVersion>3.0.1</Xunit_v3_PackageVersion>
   </PropertyGroup>
@@ -85,10 +85,10 @@
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="$(Microsoft_Bcl_PkgVer)" />
     <PackageVersion Include="Microsoft.Bcl.Memory" Version="$(Microsoft_Bcl_PkgVer)" />
     <PackageVersion Include="Microsoft.Bcl.TimeProvider" Version="$(Microsoft_Bcl_PkgVer)" />
-    <PackageVersion Include="Azure.Identity" Version="1.17.1" />
-    <PackageVersion Include="Azure.Core" Version="1.50.0" />
-    <PackageVersion Include="Azure.Storage.Blobs" Version="12.26.0" />
-    <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.56.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.21.0" />
+    <PackageVersion Include="Azure.Core" Version="1.61.0" />
+    <PackageVersion Include="Azure.Storage.Blobs" Version="12.29.1" />
+    <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.62.0" />
     <PackageVersion Include="Microsoft.Recognizers.Text.Choice" Version="1.3.2" />
     <PackageVersion Include="Microsoft.Recognizers.Text.DateTime" Version="1.3.2" />
     <PackageVersion Include="Microsoft.Recognizers.Text.DataTypes.TimexExpression" Version="1.3.2" />
@@ -110,8 +110,8 @@
     <PackageVersion Include="AdaptiveCards" Version="3.1.0" />
     <PackageVersion Include="AdaptiveCards.Templating" Version="2.0.3" />
     <PackageVersion Include="AdaptiveCards.Rendering.Html" Version="2.7.3" />
-    <PackageVersion Include="Microsoft.Graph" Version="5.99.0" />
-    <PackageVersion Include="Microsoft.Graph.Core" Version="3.2.5" />
+    <PackageVersion Include="Microsoft.Graph" Version="6.5.0" />
+    <PackageVersion Include="Microsoft.Graph.Core" Version="4.0.1" />
     <PackageVersion Include="CsvHelper" Version="33.0.1" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <!-- To override older version in AdaptiveCards -->
@@ -145,6 +145,6 @@
     <!-- Azure Monitor (Application Insights) Exporter -->
     <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.5.0" />
     <!-- A365 -->
-    <PackageVersion Include="Microsoft.Agents.A365.Notifications" Version="1.1.9-preview" />
+    <PackageVersion Include="Microsoft.Agents.A365.Notifications" Version="1.1.14-preview" />
   </ItemGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.423",
+    "version": "10.0.302",
     "rollForward": "latestMajor",
     "allowPrerelease": false
   }

--- a/src/Build.Common.core.props
+++ b/src/Build.Common.core.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFrameworks)' == ''">
-    <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
   </PropertyGroup>
 

--- a/src/libraries/Extensions/Microsoft.Agents.Extensions.MSTeams/Microsoft.Agents.Extensions.MSTeams.csproj
+++ b/src/libraries/Extensions/Microsoft.Agents.Extensions.MSTeams/Microsoft.Agents.Extensions.MSTeams.csproj
@@ -5,7 +5,7 @@
 		<ComponentAreaName>CplTeams</ComponentAreaName>
 		<SignAssembly>true</SignAssembly>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<TargetFrameworks>net8.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
 		<!-- Set to true to see generated file in obj/Debug/.../Generated folder -->
 	    <EmitCompilerGeneratedFiles>false</EmitCompilerGeneratedFiles>
 	</PropertyGroup>

--- a/src/libraries/Extensions/Microsoft.Agents.Extensions.SharePoint/Microsoft.Agents.Extensions.SharePoint.csproj
+++ b/src/libraries/Extensions/Microsoft.Agents.Extensions.SharePoint/Microsoft.Agents.Extensions.SharePoint.csproj
@@ -5,6 +5,7 @@
 		<ComponentAreaName>CplSharePoint</ComponentAreaName>
 		<SignAssembly>true</SignAssembly>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
 	</PropertyGroup>
 	<Import Project="..\..\..\Build.Common.core.props" />
 

--- a/src/libraries/Extensions/Microsoft.Agents.Extensions.SharePoint/Microsoft.Agents.Extensions.SharePoint.csproj
+++ b/src/libraries/Extensions/Microsoft.Agents.Extensions.SharePoint/Microsoft.Agents.Extensions.SharePoint.csproj
@@ -5,7 +5,6 @@
 		<ComponentAreaName>CplSharePoint</ComponentAreaName>
 		<SignAssembly>true</SignAssembly>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
 	</PropertyGroup>
 	<Import Project="..\..\..\Build.Common.core.props" />
 

--- a/src/libraries/Extensions/Microsoft.Agents.Extensions.Slack/Api/EventEnvelope.cs
+++ b/src/libraries/Extensions/Microsoft.Agents.Extensions.Slack/Api/EventEnvelope.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Agents.Extensions.Slack.Api
                 return "event";
 
             if (path.StartsWith("event_content.", StringComparison.OrdinalIgnoreCase))
-                return string.Concat("event", path.AsSpan("event_content".Length));
+                return string.Concat("event", path.Substring("event_content".Length));
 
             return path;
         }

--- a/src/libraries/Extensions/Microsoft.Agents.Extensions.Slack/Api/SlackApi.cs
+++ b/src/libraries/Extensions/Microsoft.Agents.Extensions.Slack/Api/SlackApi.cs
@@ -91,7 +91,11 @@ public class SlackApi
 
         using var httpClient = _httpClientFactory.CreateClient(nameof(SlackApi));
         var response = await httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+#if NETSTANDARD
+        var text = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+#else
         var text = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+#endif
 
         SlackResponse data;
         try

--- a/src/libraries/Extensions/Microsoft.Agents.Extensions.Slack/Microsoft.Agents.Extensions.Slack.csproj
+++ b/src/libraries/Extensions/Microsoft.Agents.Extensions.Slack/Microsoft.Agents.Extensions.Slack.csproj
@@ -5,7 +5,7 @@
 		<ComponentAreaName>CplSlack</ComponentAreaName>
 		<SignAssembly>true</SignAssembly>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<TargetFrameworks>net8.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
 	</PropertyGroup>
 	<Import Project="..\..\..\Build.Common.core.props" />
 

--- a/src/libraries/Extensions/Microsoft.Agents.Extensions.Slack/Microsoft.Agents.Extensions.Slack.csproj
+++ b/src/libraries/Extensions/Microsoft.Agents.Extensions.Slack/Microsoft.Agents.Extensions.Slack.csproj
@@ -5,7 +5,6 @@
 		<ComponentAreaName>CplSlack</ComponentAreaName>
 		<SignAssembly>true</SignAssembly>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
 	</PropertyGroup>
 	<Import Project="..\..\..\Build.Common.core.props" />
 
@@ -38,7 +37,6 @@
 	  <ProjectReference Include="..\..\Builder\Microsoft.Agents.Builder\Microsoft.Agents.Builder.csproj" />
 	  <ProjectReference Include="..\..\Core\Microsoft.Agents.Core\Microsoft.Agents.Core.csproj" />
 	  <ProjectReference Include="..\..\Core\Microsoft.Agents.Core.Analyzers\Microsoft.Agents.Core.Analyzers.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" PrivateAssets="all" />
-	  <ProjectReference Include="..\..\Hosting\AspNetCore\Microsoft.Agents.Hosting.AspNetCore.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/src/libraries/Hosting/A2A/Microsoft.Agents.Hosting.AspNetCore.A2A.csproj
+++ b/src/libraries/Hosting/A2A/Microsoft.Agents.Hosting.AspNetCore.A2A.csproj
@@ -4,7 +4,7 @@
 		<LangVersion>latest</LangVersion>
 		<ComponentAreaName>CplHostingA2A</ComponentAreaName>
 		<SignAssembly>true</SignAssembly>
-		<TargetFrameworks>net8.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 	</PropertyGroup>
 	<Import Project="..\..\..\Build.Common.core.props" />

--- a/src/libraries/Hosting/AspNetCore/Microsoft.Agents.Hosting.AspNetCore.csproj
+++ b/src/libraries/Hosting/AspNetCore/Microsoft.Agents.Hosting.AspNetCore.csproj
@@ -19,7 +19,7 @@
 		<Summary>Library for building agents using Microsoft Agents SDK</Summary>
 	</PropertyGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0'">
+	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net9.0' Or '$(TargetFramework)' == 'net10.0'">
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
 	</ItemGroup>
 

--- a/src/libraries/Hosting/AspNetCore/Microsoft.Agents.Hosting.AspNetCore.csproj
+++ b/src/libraries/Hosting/AspNetCore/Microsoft.Agents.Hosting.AspNetCore.csproj
@@ -5,7 +5,7 @@
 		<ComponentAreaName>CplHostingAspNet</ComponentAreaName>
 		<SignAssembly>true</SignAssembly>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<TargetFrameworks>net8.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 
 		<!-- Suppress AD0001 because the route analyzer will generate this for route extensions that are generic, but otherwise work -->
@@ -19,15 +19,7 @@
 		<Summary>Library for building agents using Microsoft Agents SDK</Summary>
 	</PropertyGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-		<FrameworkReference Include="Microsoft.AspNetCore.App" />
-	</ItemGroup>
-
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-		<FrameworkReference Include="Microsoft.AspNetCore.App" />
-	</ItemGroup>
-
-	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0'">
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
 	</ItemGroup>
 

--- a/src/libraries/Hosting/DirectLine.NamedPipes/Microsoft.Agents.Hosting.DirectLine.NamedPipes.csproj
+++ b/src/libraries/Hosting/DirectLine.NamedPipes/Microsoft.Agents.Hosting.DirectLine.NamedPipes.csproj
@@ -5,7 +5,7 @@
 		<ComponentAreaName>CplHostingDirectLineNamedPipes</ComponentAreaName>
 		<SignAssembly>true</SignAssembly>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<TargetFrameworks>net8.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 	</PropertyGroup>
 	<Import Project="..\..\..\Build.Common.core.props" />
@@ -20,7 +20,7 @@
 		<Nullable>annotations</Nullable>
 	</PropertyGroup>
 
-	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net10.0'">
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
 	</ItemGroup>
 

--- a/src/libraries/Storage/Microsoft.Agents.Storage.Transcript/BlobsTranscriptStore.cs
+++ b/src/libraries/Storage/Microsoft.Agents.Storage.Transcript/BlobsTranscriptStore.cs
@@ -247,7 +247,7 @@ namespace Microsoft.Agents.Storage.Transcript
             do
             {
                 var resultSegment = _containerClient.Value
-                    .GetBlobsAsync(BlobTraits.Metadata, prefix: $"{SanitizeKey(channelId)}/{SanitizeKey(conversationId)}/")
+                    .GetBlobsAsync(BlobTraits.Metadata, BlobStates.None, prefix: $"{SanitizeKey(channelId)}/{SanitizeKey(conversationId)}/", cancellationToken: default)
                     .AsPages(token).ConfigureAwait(false);
                 
                 token = null;
@@ -318,7 +318,7 @@ namespace Microsoft.Agents.Storage.Transcript
             List<TranscriptInfo> conversations = [];
             do
             {
-                var resultSegment = _containerClient.Value.GetBlobsAsync(BlobTraits.Metadata, prefix: $"{SanitizeKey(channelId)}/")
+                var resultSegment = _containerClient.Value.GetBlobsAsync(BlobTraits.Metadata, BlobStates.None, prefix: $"{SanitizeKey(channelId)}/", cancellationToken: default)
                                     .AsPages(token).ConfigureAwait(false);
                 token = null;
 
@@ -383,7 +383,7 @@ namespace Microsoft.Agents.Storage.Transcript
             do
             {
                 var resultSegment = _containerClient.Value
-                    .GetBlobsAsync(BlobTraits.Metadata, prefix: $"{SanitizeKey(channelId)}/{SanitizeKey(conversationId)}/")
+                    .GetBlobsAsync(BlobTraits.Metadata, BlobStates.None, prefix: $"{SanitizeKey(channelId)}/{SanitizeKey(conversationId)}/", cancellationToken: default)
                     .AsPages(token).ConfigureAwait(false);
 
                 token = null;
@@ -414,7 +414,7 @@ namespace Microsoft.Agents.Storage.Transcript
                     do
                     {
                         var resultSegment = _containerClient.Value
-                            .GetBlobsAsync(BlobTraits.Metadata, prefix: $"{SanitizeKey(activity.ChannelId)}/{SanitizeKey(activity.Conversation.Id)}/")
+                            .GetBlobsAsync(BlobTraits.Metadata, BlobStates.None, prefix: $"{SanitizeKey(activity.ChannelId)}/{SanitizeKey(activity.Conversation.Id)}/", cancellationToken: default)
                             .AsPages(token).ConfigureAwait(false);
 
                         token = null;

--- a/src/samples/A2AAgent/A2AAgent.csproj
+++ b/src/samples/A2AAgent/A2AAgent.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>disable</ImplicitUsings>
 		<Nullable>enable</Nullable>

--- a/src/samples/A2ATCKAgent/A2ATCKAgent.csproj
+++ b/src/samples/A2ATCKAgent/A2ATCKAgent.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>disable</ImplicitUsings>
 		<Nullable>enable</Nullable>

--- a/src/samples/A365LoopTest/A365LoopTest.csproj
+++ b/src/samples/A365LoopTest/A365LoopTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>disable</ImplicitUsings>
 		<Nullable>enable</Nullable>

--- a/src/samples/AgentToAgent/Agent1/Agent1.csproj
+++ b/src/samples/AgentToAgent/Agent1/Agent1.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/src/samples/AgentToAgent/Agent2/Agent2.csproj
+++ b/src/samples/AgentToAgent/Agent2/Agent2.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/src/samples/AgentToAgent/StreamingAgent1/StreamingAgent1.csproj
+++ b/src/samples/AgentToAgent/StreamingAgent1/StreamingAgent1.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/src/samples/AgenticAI/AgenticAI.csproj
+++ b/src/samples/AgenticAI/AgenticAI.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>disable</ImplicitUsings>
 		<Nullable>enable</Nullable>

--- a/src/samples/Authorization/AutoSignIn/AutoSignIn.csproj
+++ b/src/samples/Authorization/AutoSignIn/AutoSignIn.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/src/samples/Authorization/OBOAuthorization/OBOAuthorization.csproj
+++ b/src/samples/Authorization/OBOAuthorization/OBOAuthorization.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/src/samples/Authorization/OutlookUAM/OutlookUAM.csproj
+++ b/src/samples/Authorization/OutlookUAM/OutlookUAM.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>

--- a/src/samples/Authorization/SidecarAuth/SidecarAuth.csproj
+++ b/src/samples/Authorization/SidecarAuth/SidecarAuth.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/src/samples/Compat/SkillsDialog/DialogRootBot/DialogRootBot.csproj
+++ b/src/samples/Compat/SkillsDialog/DialogRootBot/DialogRootBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <IncludeAspNetSampleHelpers>false</IncludeAspNetSampleHelpers>
   </PropertyGroup>

--- a/src/samples/Compat/SkillsDialog/DialogSkillBot/DialogSkillBot.csproj
+++ b/src/samples/Compat/SkillsDialog/DialogSkillBot/DialogSkillBot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <IncludeAspNetSampleHelpers>false</IncludeAspNetSampleHelpers>
   </PropertyGroup>

--- a/src/samples/CopilotStudioAgentConnector/CopilotStudioAgentConnector.csproj
+++ b/src/samples/CopilotStudioAgentConnector/CopilotStudioAgentConnector.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/src/samples/CopilotStudioClient/CopilotStudioClient/CopilotStudioClient.csproj
+++ b/src/samples/CopilotStudioClient/CopilotStudioClient/CopilotStudioClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<IncludeAspNetSampleHelpers>false</IncludeAspNetSampleHelpers>

--- a/src/samples/CopilotStudioClient/CopilotStudioSubscriberClient/CopilotStudioSubscriberClient.csproj
+++ b/src/samples/CopilotStudioClient/CopilotStudioSubscriberClient/CopilotStudioSubscriberClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<IncludeAspNetSampleHelpers>false</IncludeAspNetSampleHelpers>

--- a/src/samples/CopilotStudioClient/EvalClient/EvalClient.csproj
+++ b/src/samples/CopilotStudioClient/EvalClient/EvalClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<IncludeAspNetSampleHelpers>false</IncludeAspNetSampleHelpers>

--- a/src/samples/CopilotStudioClient/OrchestratedClient/OrchestratedClient.csproj
+++ b/src/samples/CopilotStudioClient/OrchestratedClient/OrchestratedClient.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<IncludeAspNetSampleHelpers>false</IncludeAspNetSampleHelpers>

--- a/src/samples/CopilotStudioEchoSkill/CopilotStudioEchoSkill.csproj
+++ b/src/samples/CopilotStudioEchoSkill/CopilotStudioEchoSkill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/src/samples/DialogAgent/DialogAgent.csproj
+++ b/src/samples/DialogAgent/DialogAgent.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>disable</ImplicitUsings>
 		<Nullable>enable</Nullable>

--- a/src/samples/EmptyAgent/EmptyAgent.csproj
+++ b/src/samples/EmptyAgent/EmptyAgent.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>disable</ImplicitUsings>
 		<Nullable>enable</Nullable>

--- a/src/samples/HandlingAttachments/HandlingAttachments.csproj
+++ b/src/samples/HandlingAttachments/HandlingAttachments.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/src/samples/MultiAgent/MultiAgent.csproj
+++ b/src/samples/MultiAgent/MultiAgent.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>disable</ImplicitUsings>
 		<Nullable>enable</Nullable>

--- a/src/samples/NamedPipeAgent/NamedPipeAgent.csproj
+++ b/src/samples/NamedPipeAgent/NamedPipeAgent.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>disable</ImplicitUsings>
 		<Nullable>enable</Nullable>

--- a/src/samples/Proactive/Proactive.csproj
+++ b/src/samples/Proactive/Proactive.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>disable</ImplicitUsings>
 		<Nullable>enable</Nullable>

--- a/src/samples/SemanticKernel/WeatherAgent/WeatherAgent.csproj
+++ b/src/samples/SemanticKernel/WeatherAgent/WeatherAgent.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>disable</ImplicitUsings>
 		<NoWarn>$(NoWarn);SKEXP0110;SKEXP0010</NoWarn>

--- a/src/samples/SlackAgent/SlackAgent.csproj
+++ b/src/samples/SlackAgent/SlackAgent.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>disable</ImplicitUsings>
 		<Nullable>enable</Nullable>

--- a/src/samples/StreamingMessageAgent/StreamingMessageAgent.csproj
+++ b/src/samples/StreamingMessageAgent/StreamingMessageAgent.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>disable</ImplicitUsings>
 		<Nullable>enable</Nullable>

--- a/src/samples/Teams/ConversationAgent/ConversationAgent.csproj
+++ b/src/samples/Teams/ConversationAgent/ConversationAgent.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/src/samples/Teams/MessageExtensions/MessageExtensions.csproj
+++ b/src/samples/Teams/MessageExtensions/MessageExtensions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/src/samples/Teams/TaskModules/TaskModules.csproj
+++ b/src/samples/Teams/TaskModules/TaskModules.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>

--- a/src/samples/TelemetryAgent/TelemetryAgent.csproj
+++ b/src/samples/TelemetryAgent/TelemetryAgent.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>disable</ImplicitUsings>
 		<Nullable>enable</Nullable>

--- a/src/tests/Directory.Build.props
+++ b/src/tests/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <!-- See: https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build?view=vs-2019#directorybuildprops-and-directorybuildtargets -->
     <PropertyGroup Condition="'$(TargetFrameworks)' == ''">
-        <TargetFrameworks>net8.0;net10.0;net4.8</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0;net48</TargetFrameworks>
         <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
       </PropertyGroup>
     <PropertyGroup>

--- a/src/tests/Directory.Build.props
+++ b/src/tests/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <!-- See: https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build?view=vs-2019#directorybuildprops-and-directorybuildtargets -->
     <PropertyGroup Condition="'$(TargetFrameworks)' == ''">
-        <TargetFrameworks>net8.0;net4.8</TargetFrameworks>
+        <TargetFrameworks>net8.0;net10.0;net4.8</TargetFrameworks>
         <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
       </PropertyGroup>
     <PropertyGroup>

--- a/src/tests/Microsoft.Agents.CopilotStudio.Client.Tests/Microsoft.Agents.CopilotStudio.Client.Tests.csproj
+++ b/src/tests/Microsoft.Agents.CopilotStudio.Client.Tests/Microsoft.Agents.CopilotStudio.Client.Tests.csproj
@@ -4,7 +4,7 @@
 		<LangVersion>latest</LangVersion>
 		<ComponentAreaName>CplTests.DirectToEngine</ComponentAreaName>
 		<SignAssembly>true</SignAssembly>
-		<TargetFrameworks>net8.0;net48</TargetFrameworks>
+		<TargetFrameworks>net8.0;net10.0;net48</TargetFrameworks>
 	</PropertyGroup>
 	<Import Project="..\..\Build.Common.core.props" />
 

--- a/src/tests/Microsoft.Agents.Core.Analyzers.Tests/Microsoft.Agents.Core.Analyzers.Tests.csproj
+++ b/src/tests/Microsoft.Agents.Core.Analyzers.Tests/Microsoft.Agents.Core.Analyzers.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
     <ComponentAreaName>CplTests.Analyzers</ComponentAreaName>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/tests/Microsoft.Agents.Extensions.MSTeams.Analyzers.Tests/Microsoft.Agents.Extensions.MSTeams.Analyzers.Tests.csproj
+++ b/src/tests/Microsoft.Agents.Extensions.MSTeams.Analyzers.Tests/Microsoft.Agents.Extensions.MSTeams.Analyzers.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
     <ComponentAreaName>CplTests.TeamsAnalyzers</ComponentAreaName>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/tests/Microsoft.Agents.Extensions.MSTeams.Tests/Microsoft.Agents.Extensions.MSTeams.Tests.csproj
+++ b/src/tests/Microsoft.Agents.Extensions.MSTeams.Tests/Microsoft.Agents.Extensions.MSTeams.Tests.csproj
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<LangVersion>latest</LangVersion>
 		<ComponentAreaName>CplTests.Teams</ComponentAreaName>
-		<TargetFrameworks>net8.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
 		<SignAssembly>true</SignAssembly>
 	</PropertyGroup>
 	<Import Project="..\..\Build.Common.core.props" />

--- a/src/tests/Microsoft.Agents.Extensions.SharePoint.Tests/Microsoft.Agents.Extensions.SharePoint.Tests.csproj
+++ b/src/tests/Microsoft.Agents.Extensions.SharePoint.Tests/Microsoft.Agents.Extensions.SharePoint.Tests.csproj
@@ -3,6 +3,7 @@
 		<LangVersion>latest</LangVersion>
 		<ComponentAreaName>CplTests.SharePoint</ComponentAreaName>
 		<SignAssembly>true</SignAssembly>
+		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
 	</PropertyGroup>
 	<Import Project="..\..\Build.Common.core.props" />
 	

--- a/src/tests/Microsoft.Agents.Extensions.SharePoint.Tests/Microsoft.Agents.Extensions.SharePoint.Tests.csproj
+++ b/src/tests/Microsoft.Agents.Extensions.SharePoint.Tests/Microsoft.Agents.Extensions.SharePoint.Tests.csproj
@@ -3,7 +3,9 @@
 		<LangVersion>latest</LangVersion>
 		<ComponentAreaName>CplTests.SharePoint</ComponentAreaName>
 		<SignAssembly>true</SignAssembly>
-		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+		<!-- Microsoft.Extensions.TimeProvider.Testing ships a net462 asset that works on net4.8
+		     via the Microsoft.Bcl.TimeProvider polyfill; silence its heuristic TFM-support warning. -->
+		<SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
 	</PropertyGroup>
 	<Import Project="..\..\Build.Common.core.props" />
 	

--- a/src/tests/Microsoft.Agents.Extensions.Slack.Tests/Microsoft.Agents.Extensions.Slack.Tests.csproj
+++ b/src/tests/Microsoft.Agents.Extensions.Slack.Tests/Microsoft.Agents.Extensions.Slack.Tests.csproj
@@ -3,8 +3,6 @@
 		<LangVersion>latest</LangVersion>
 		<ComponentAreaName>CplTests.Slack</ComponentAreaName>
 		<SignAssembly>true</SignAssembly>
-		<!-- Slack extension targets modern .NET only; match that here. -->
-		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
 	</PropertyGroup>
 	<Import Project="..\..\Build.Common.core.props" />
 

--- a/src/tests/Microsoft.Agents.Extensions.Slack.Tests/Microsoft.Agents.Extensions.Slack.Tests.csproj
+++ b/src/tests/Microsoft.Agents.Extensions.Slack.Tests/Microsoft.Agents.Extensions.Slack.Tests.csproj
@@ -3,8 +3,8 @@
 		<LangVersion>latest</LangVersion>
 		<ComponentAreaName>CplTests.Slack</ComponentAreaName>
 		<SignAssembly>true</SignAssembly>
-		<!-- Slack extension targets net8.0 only; match that here -->
-		<TargetFrameworks>net8.0</TargetFrameworks>
+		<!-- Slack extension targets modern .NET only; match that here. -->
+		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
 	</PropertyGroup>
 	<Import Project="..\..\Build.Common.core.props" />
 

--- a/src/tests/Microsoft.Agents.Extensions.Slack.Tests/SlackApiTests.cs
+++ b/src/tests/Microsoft.Agents.Extensions.Slack.Tests/SlackApiTests.cs
@@ -96,7 +96,12 @@ public class SlackApiTests
         string? mediaType = null;
         var slackApi = CreateSlackApi(async (request, cancellationToken) =>
         {
+#if NETSTANDARD
             body = await request.Content!.ReadAsStringAsync(cancellationToken);
+#else
+            body = await request.Content!.ReadAsStringAsync();
+#endif
+
             mediaType = request.Content.Headers.ContentType?.MediaType;
             return CreateJsonResponse("""{"ok":true}""");
         });
@@ -114,7 +119,11 @@ public class SlackApiTests
         string? body = null;
         var slackApi = CreateSlackApi(async (request, cancellationToken) =>
         {
+#if NETSTANDARD
             body = await request.Content!.ReadAsStringAsync(cancellationToken);
+#else
+            body = await request.Content!.ReadAsStringAsync();
+#endif
             return CreateJsonResponse("""{"ok":true}""");
         });
 

--- a/src/tests/Microsoft.Agents.Extensions.Teams.Tests/Microsoft.Agents.Extensions.Teams.Tests.csproj
+++ b/src/tests/Microsoft.Agents.Extensions.Teams.Tests/Microsoft.Agents.Extensions.Teams.Tests.csproj
@@ -3,6 +3,9 @@
 		<LangVersion>latest</LangVersion>
 		<ComponentAreaName>CplTests.Teams</ComponentAreaName>
 		<SignAssembly>true</SignAssembly>
+		<!-- Microsoft.Extensions.TimeProvider.Testing ships a net462 asset that works on net4.8
+		     via the Microsoft.Bcl.TimeProvider polyfill; silence its heuristic TFM-support warning. -->
+		<SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
 	</PropertyGroup>
 	<Import Project="..\..\Build.Common.core.props" />
 	

--- a/src/tests/Microsoft.Agents.Hosting.AspNetCore/Microsoft.Agents.Hosting.AspNetCore.Tests.csproj
+++ b/src/tests/Microsoft.Agents.Hosting.AspNetCore/Microsoft.Agents.Hosting.AspNetCore.Tests.csproj
@@ -4,7 +4,7 @@
 		<LangVersion>latest</LangVersion>
 		<ComponentAreaName>CplTests.AspNetCore</ComponentAreaName>
 		<SignAssembly>true</SignAssembly>
-		<TargetFrameworks>net8.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
 	</PropertyGroup>
 	<Import Project="..\..\Build.Common.core.props" />
 

--- a/src/tests/Microsoft.Agents.Hosting.DirectLine.NamedPipes/Microsoft.Agents.Hosting.DirectLine.NamedPipes.Tests.csproj
+++ b/src/tests/Microsoft.Agents.Hosting.DirectLine.NamedPipes/Microsoft.Agents.Hosting.DirectLine.NamedPipes.Tests.csproj
@@ -4,7 +4,7 @@
 		<LangVersion>latest</LangVersion>
 		<ComponentAreaName>CplTests.NamedPipes</ComponentAreaName>
 		<SignAssembly>true</SignAssembly>
-		<TargetFrameworks>net8.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
 	</PropertyGroup>
 	<Import Project="..\..\Build.Common.core.props" />
 

--- a/src/tests/Microsoft.Agents.SampleTest/Microsoft.Agents.SampleTest.csproj
+++ b/src/tests/Microsoft.Agents.SampleTest/Microsoft.Agents.SampleTest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+		<TargetFrameworks>net10.0</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 		<ComponentAreaName>CplTests.SampleTest</ComponentAreaName>
 		<SignAssembly>true</SignAssembly>

--- a/src/tests/Microsoft.Agents.SampleTest/Microsoft.Agents.SampleTest.csproj
+++ b/src/tests/Microsoft.Agents.SampleTest/Microsoft.Agents.SampleTest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net8.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net10.0</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 		<ComponentAreaName>CplTests.SampleTest</ComponentAreaName>
 		<SignAssembly>true</SignAssembly>

--- a/src/tests/Microsoft.Agents.Storage.Tests/Microsoft.Agents.Storage.Tests.csproj
+++ b/src/tests/Microsoft.Agents.Storage.Tests/Microsoft.Agents.Storage.Tests.csproj
@@ -14,7 +14,7 @@
 
 	<ItemGroup>
       <PackageReference Include="Microsoft.NET.Test.Sdk" />
-	  <PackageReference Condition="'$(TargetFramework)' == 'net4.8'" Include="System.IO.Compression" />
+	  <PackageReference Condition="'$(TargetFramework)' == 'net48'" Include="System.IO.Compression" />
       <PackageReference Include="xunit" />
       <PackageReference Include="xunit.runner.visualstudio">
         <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Summary

- Add `net10.0` support while retaining `net8.0` and `netstandard2.0` library targets.
- Add `net10.0` coverage to the test projects while retaining existing .NET 8 and .NET Framework coverage.
- Update the repository SDK to .NET `10.0.302` and refresh dependencies needed for .NET 10 compatibility.
- Update `BlobsTranscriptStore` for the current `Azure.Storage.Blobs` `GetBlobsAsync` signature.

## Pipeline changes

- Update the Windows, Linux, and CodeQL GitHub Actions workflows to install .NET 10.
- Add an explicit `net10.0` test pass to the Linux workflow while preserving the `net8.0` test pass.
- Add `UseDotNet@2` steps to the OneBranch pull-request and nightly pipelines before the first `dotnet` command.
- Install both the .NET 8 SDK/runtime and the .NET 10 SDK selected by `global.json` into the OneBranch tool directory. This allows the same test task to run the `net8.0` and `net10.0` testhosts.
- Mark both SDK installations as network-enabled restore-phase steps.

## Validation

- Built the SDK libraries for `netstandard2.0`, `net8.0`, and `net10.0`.
- Ran the .NET 10 test suite and targeted storage tests across .NET Framework 4.8, .NET 8, and .NET 10.
- Verified generated packages contain the expected target-framework assets.