### PR TITLE
Add scoped service handling to HostedActivityService

### DIFF
--- a/src/libraries/Hosting/AspNetCore/AdapterOptions.cs
+++ b/src/libraries/Hosting/AspNetCore/AdapterOptions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Agents.Hosting.AspNetCore
         /// <remarks>If the shutdown process does not complete within the specified timeout, the
         /// application may be terminated forcefully. Set this value according to the expected shutdown duration of your
         /// application components.</remarks>
-        [Obsolete("Use HostedActivityServiceOptions instead.")]
+        [Obsolete("Use HostedActivityServiceOptions or HostedTaskServiceOptions instead.")]
         public int ShutdownTimeoutSeconds { get; set; } = 60;
 
         /// <summary>

--- a/src/libraries/Hosting/AspNetCore/BackgroundQueue/HostedActivityService.cs
+++ b/src/libraries/Hosting/AspNetCore/BackgroundQueue/HostedActivityService.cs
@@ -6,6 +6,7 @@ using Microsoft.Agents.Builder;
 using Microsoft.Agents.Core.HeaderPropagation;
 using Microsoft.Agents.Core.Models;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -177,13 +178,23 @@ namespace Microsoft.Agents.Hosting.AspNetCore.BackgroundQueue
                 ["ConversationId"] = activityWithClaims.Activity.Conversation?.Id
             });
 
+            AsyncServiceScope? turnScope = null;
             try
             {
                 // We must go back through DI to get the IAgent. This is because the IAgent is typically transient, and anything
                 // else that is transient as part of the Agent, that uses IServiceProvider will encounter error since that is scoped
                 // and disposed before this gets called.
-                var agent = _serviceProvider.GetService(activityWithClaims.AgentType ?? typeof(IAgent));
-                agent ??= _serviceProvider.GetService(typeof(IAgent));
+                //
+                // Resolving from the root IServiceProvider promotes any scoped registration in the Agent's dependency graph to
+                // the root scope, so a single instance is shared by every turn for the lifetime of the process. When
+                // AdapterOptions.UseScopePerTurn is set, the turn gets its own scope instead, which is disposed once the turn
+                // completes. The SDK registers no scoped services, so this only affects registrations made by the application.
+                // Note that disposable transients resolved for the turn - IAgent itself is registered transient - are then
+                // disposed with the turn scope instead of being retained by the root scope until the host shuts down.
+                turnScope = _serviceOptions.UseScopedServices ? _serviceProvider.CreateAsyncScope() : null;
+                var turnServices = turnScope?.ServiceProvider ?? _serviceProvider;
+                var agent = turnServices.GetService(activityWithClaims.AgentType ?? typeof(IAgent));
+                agent ??= turnServices.GetService(typeof(IAgent));
 
                 HeaderPropagationContext.HeadersFromRequest = activityWithClaims.Headers;
                 activityWithClaims.TelemetryActivity?.Start();
@@ -233,6 +244,20 @@ namespace Microsoft.Agents.Hosting.AspNetCore.BackgroundQueue
                 if (activityWithClaims.OnComplete != null)
                 {
                     await activityWithClaims.OnComplete(invokeResponse).ConfigureAwait(false);
+                }
+            }
+            finally
+            {
+                if (turnScope.HasValue)
+                {
+                    try
+                    {
+                        await turnScope.Value.DisposeAsync().ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Error occurred disposing activity service scope.");
+                    }
                 }
             }
         }

--- a/src/libraries/Hosting/AspNetCore/BackgroundQueue/HostedActivityService.cs
+++ b/src/libraries/Hosting/AspNetCore/BackgroundQueue/HostedActivityService.cs
@@ -187,8 +187,9 @@ namespace Microsoft.Agents.Hosting.AspNetCore.BackgroundQueue
                 //
                 // Resolving from the root IServiceProvider promotes any scoped registration in the Agent's dependency graph to
                 // the root scope, so a single instance is shared by every turn for the lifetime of the process. When
-                // AdapterOptions.UseScopePerTurn is set, the turn gets its own scope instead, which is disposed once the turn
-                // completes. The SDK registers no scoped services, so this only affects registrations made by the application.
+                // HostedActivityServiceOptions.UseScopedServices is set, the turn gets its own scope instead, which is disposed
+                // once the turn completes. The SDK registers no scoped services, so this only affects registrations made by
+                // the application.
                 // Note that disposable transients resolved for the turn - IAgent itself is registered transient - are then
                 // disposed with the turn scope instead of being retained by the root scope until the host shuts down.
                 turnScope = _serviceOptions.UseScopedServices ? _serviceProvider.CreateAsyncScope() : null;

--- a/src/libraries/Hosting/AspNetCore/BackgroundQueue/HostedActivityServiceOptions.cs
+++ b/src/libraries/Hosting/AspNetCore/BackgroundQueue/HostedActivityServiceOptions.cs
@@ -31,11 +31,11 @@ namespace Microsoft.Agents.Hosting.AspNetCore.BackgroundQueue
         /// Gets or sets a value indicating whether each queued Activity is processed in its own dependency injection scope.
         /// </summary>
         /// <remarks>
-        /// When <see langword="true"/> (the default), the <see cref="Microsoft.Agents.Builder.IAgent"/> and its dependencies
-        /// are resolved from a scope that is disposed when the turn completes. Set this to <see langword="false"/> to resolve
-        /// from the root <see cref="System.IServiceProvider"/> instead. Root resolution promotes scoped registrations in the
-        /// Agent's dependency graph to the root scope, sharing one instance across turns for the lifetime of the process.
+        /// When <see langword="false"/> (the default), queued Activities resolve the
+        /// <see cref="Microsoft.Agents.Builder.IAgent"/> from the root <see cref="System.IServiceProvider"/>.
+        /// Set this to <see langword="true"/> to resolve the Agent and its dependencies from a scope that is disposed when
+        /// the turn completes.
         /// </remarks>
-        public bool UseScopedServices { get; set; } = true;
+        public bool UseScopedServices { get; set; } = false;
     }
 }

--- a/src/libraries/Hosting/AspNetCore/BackgroundQueue/HostedActivityServiceOptions.cs
+++ b/src/libraries/Hosting/AspNetCore/BackgroundQueue/HostedActivityServiceOptions.cs
@@ -31,11 +31,11 @@ namespace Microsoft.Agents.Hosting.AspNetCore.BackgroundQueue
         /// Gets or sets a value indicating whether each queued Activity is processed in its own dependency injection scope.
         /// </summary>
         /// <remarks>
-        /// When <see langword="false"/> (the default), queued Activities resolve the
-        /// <see cref="Microsoft.Agents.Builder.IAgent"/> from the root <see cref="System.IServiceProvider"/>.
-        /// Set this to <see langword="true"/> to resolve the Agent and its dependencies from a scope that is disposed when
-        /// the turn completes.
+        /// When <see langword="true"/> (the default), the <see cref="Microsoft.Agents.Builder.IAgent"/> and its dependencies
+        /// are resolved from a scope that is disposed when the turn completes. Set this to <see langword="false"/> to resolve
+        /// from the root <see cref="System.IServiceProvider"/> instead. Root resolution promotes scoped registrations in the
+        /// Agent's dependency graph to the root scope, sharing one instance across turns for the lifetime of the process.
         /// </remarks>
-        public bool UseScopedServices { get; set; } = false;
+        public bool UseScopedServices { get; set; } = true;
     }
 }

--- a/src/libraries/Hosting/AspNetCore/BackgroundQueue/HostedActivityServiceOptions.cs
+++ b/src/libraries/Hosting/AspNetCore/BackgroundQueue/HostedActivityServiceOptions.cs
@@ -31,15 +31,11 @@ namespace Microsoft.Agents.Hosting.AspNetCore.BackgroundQueue
         /// Gets or sets a value indicating whether each queued Activity is processed in its own dependency injection scope.
         /// </summary>
         /// <remarks>
-        /// When <see langword="false"/> (the default), queued Activities resolve the <see cref="Microsoft.Agents.Builder.IAgent"/>
-        /// from the root <see cref="System.IServiceProvider"/>. Any scoped registration in the Agent's dependency graph is then
-        /// promoted to the root scope, giving a single instance shared by every turn for the lifetime of the process.
-        /// Set this to <see langword="true"/> for Agents that depend on scoped services, such as an Entity Framework Core
-        /// <c>DbContext</c>. The SDK registers no scoped services, so enabling this affects only registrations made by the
-        /// application. Note that disposable transient dependencies resolved for a turn - <see cref="Microsoft.Agents.Builder.IAgent"/>
-        /// itself is registered transient - are then disposed with the turn scope, rather than being retained by the root
-        /// scope until the host shuts down.
+        /// When <see langword="true"/> (the default), the <see cref="Microsoft.Agents.Builder.IAgent"/> and its dependencies
+        /// are resolved from a scope that is disposed when the turn completes. Set this to <see langword="false"/> to resolve
+        /// from the root <see cref="System.IServiceProvider"/> instead. Root resolution promotes scoped registrations in the
+        /// Agent's dependency graph to the root scope, sharing one instance across turns for the lifetime of the process.
         /// </remarks>
-        public bool UseScopedServices { get; set; } = false;
+        public bool UseScopedServices { get; set; } = true;
     }
 }

--- a/src/libraries/Hosting/AspNetCore/BackgroundQueue/HostedActivityServiceOptions.cs
+++ b/src/libraries/Hosting/AspNetCore/BackgroundQueue/HostedActivityServiceOptions.cs
@@ -26,5 +26,20 @@ namespace Microsoft.Agents.Hosting.AspNetCore.BackgroundQueue
         /// Gets or sets the maximum number of seconds to wait for activity processing during shutdown.
         /// </summary>
         public int ShutdownTimeoutSeconds { get; set; } = 60;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether each queued Activity is processed in its own dependency injection scope.
+        /// </summary>
+        /// <remarks>
+        /// When <see langword="false"/> (the default), queued Activities resolve the <see cref="Microsoft.Agents.Builder.IAgent"/>
+        /// from the root <see cref="System.IServiceProvider"/>. Any scoped registration in the Agent's dependency graph is then
+        /// promoted to the root scope, giving a single instance shared by every turn for the lifetime of the process.
+        /// Set this to <see langword="true"/> for Agents that depend on scoped services, such as an Entity Framework Core
+        /// <c>DbContext</c>. The SDK registers no scoped services, so enabling this affects only registrations made by the
+        /// application. Note that disposable transient dependencies resolved for a turn - <see cref="Microsoft.Agents.Builder.IAgent"/>
+        /// itself is registered transient - are then disposed with the turn scope, rather than being retained by the root
+        /// scope until the host shuts down.
+        /// </remarks>
+        public bool UseScopedServices { get; set; } = false;
     }
 }

--- a/src/libraries/Hosting/AspNetCore/BackgroundQueue/HostedTaskService.cs
+++ b/src/libraries/Hosting/AspNetCore/BackgroundQueue/HostedTaskService.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -22,7 +23,7 @@ namespace Microsoft.Agents.Hosting.AspNetCore.BackgroundQueue
         private readonly ReaderWriterLockSlim _lock = new ReaderWriterLockSlim();
         private readonly ConcurrentDictionary<Func<CancellationToken,Task>, Task> _tasks = new();
         private readonly IBackgroundTaskQueue _taskQueue;
-        private readonly int _shutdownTimeoutSeconds;
+        private readonly HostedTaskServiceOptions _serviceOptions;
         private int _stopping;
 
         /// <summary>
@@ -33,16 +34,52 @@ namespace Microsoft.Agents.Hosting.AspNetCore.BackgroundQueue
         /// </remarks>
         /// <param name="taskQueue"><see cref="Microsoft.Agents.Hosting.AspNetCore.BackgroundQueue.ActivityTaskQueue"/> implementation where tasks are queued to be processed.</param>
         /// <param name="logger"><see cref="Microsoft.Extensions.Logging.ILogger"/> implementation, for logging including background thread exception information.</param>
-        /// <param name="options"></param>
-        public HostedTaskService(IBackgroundTaskQueue taskQueue, ILogger<HostedTaskService> logger, AdapterOptions options = null)
+        public HostedTaskService(IBackgroundTaskQueue taskQueue, ILogger<HostedTaskService> logger)
+            : this(taskQueue, logger, new HostedTaskServiceOptions(new ConfigurationBuilder().Build()))
+        {
+        }
+
+        /// <summary>
+        /// Create a <see cref="Microsoft.Agents.Hosting.AspNetCore.BackgroundQueue.HostedTaskService"/> instance for processing work on a background thread.
+        /// </summary>
+        /// <param name="taskQueue"><see cref="Microsoft.Agents.Hosting.AspNetCore.BackgroundQueue.ActivityTaskQueue"/> implementation where tasks are queued to be processed.</param>
+        /// <param name="logger"><see cref="Microsoft.Extensions.Logging.ILogger"/> implementation, for logging including background thread exception information.</param>
+        /// <param name="options">Legacy adapter options.</param>
+        [Obsolete("Use the constructor overload accepting HostedTaskServiceOptions instead.")]
+        public HostedTaskService(IBackgroundTaskQueue taskQueue, ILogger<HostedTaskService> logger, AdapterOptions options)
+            : this(taskQueue, logger, CreateHostedTaskServiceOptions(options))
+        {
+        }
+
+        /// <summary>
+        /// Create a <see cref="Microsoft.Agents.Hosting.AspNetCore.BackgroundQueue.HostedTaskService"/> instance for processing work on a background thread.
+        /// </summary>
+        /// <param name="taskQueue"><see cref="Microsoft.Agents.Hosting.AspNetCore.BackgroundQueue.ActivityTaskQueue"/> implementation where tasks are queued to be processed.</param>
+        /// <param name="logger"><see cref="Microsoft.Extensions.Logging.ILogger"/> implementation, for logging including background thread exception information.</param>
+        /// <param name="hostedOptions">Options for the hosted task service.</param>
+        public HostedTaskService(
+            IBackgroundTaskQueue taskQueue,
+            ILogger<HostedTaskService> logger,
+            HostedTaskServiceOptions hostedOptions)
         {
             ArgumentNullException.ThrowIfNull(taskQueue);
 
-#pragma warning disable CS0618
-            _shutdownTimeoutSeconds = options != null ? options.ShutdownTimeoutSeconds : 60;
-#pragma warning restore CS0618
+            _serviceOptions = hostedOptions ?? new HostedTaskServiceOptions(new ConfigurationBuilder().Build());
             _taskQueue = taskQueue;
-            _logger = logger ?? NullLogger<HostedTaskService>.Instance;;
+            _logger = logger ?? NullLogger<HostedTaskService>.Instance;
+        }
+
+        private static HostedTaskServiceOptions CreateHostedTaskServiceOptions(AdapterOptions options)
+        {
+            var hostedOptions = new HostedTaskServiceOptions(new ConfigurationBuilder().Build());
+            if (options != null)
+            {
+#pragma warning disable CS0618
+                hostedOptions.ShutdownTimeoutSeconds = options.ShutdownTimeoutSeconds;
+#pragma warning restore CS0618
+            }
+
+            return hostedOptions;
         }
 
         /// <summary>
@@ -65,10 +102,10 @@ namespace Microsoft.Agents.Hosting.AspNetCore.BackgroundQueue
             _logger.LogInformation("Queued Hosted Service is stopping.");
 
             // Obtain a write lock and do not release it, preventing new tasks from starting
-            if (_lock.TryEnterWriteLock(TimeSpan.FromSeconds(_shutdownTimeoutSeconds)))
+            if (_lock.TryEnterWriteLock(TimeSpan.FromSeconds(_serviceOptions.ShutdownTimeoutSeconds)))
             {
                 // Wait for currently running tasks, but only n seconds.
-                await Task.WhenAny(Task.WhenAll(_tasks.Values), Task.Delay(TimeSpan.FromSeconds(_shutdownTimeoutSeconds), stoppingToken)).ConfigureAwait(false);
+                await Task.WhenAny(Task.WhenAll(_tasks.Values), Task.Delay(TimeSpan.FromSeconds(_serviceOptions.ShutdownTimeoutSeconds), stoppingToken)).ConfigureAwait(false);
             }
 
             await base.StopAsync(stoppingToken).ConfigureAwait(false);

--- a/src/libraries/Hosting/AspNetCore/BackgroundQueue/HostedTaskServiceOptions.cs
+++ b/src/libraries/Hosting/AspNetCore/BackgroundQueue/HostedTaskServiceOptions.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Extensions.Configuration;
+using System;
+
+namespace Microsoft.Agents.Hosting.AspNetCore.BackgroundQueue
+{
+    /// <summary>
+    /// Configuration options for the hosted task service.
+    /// </summary>
+    public class HostedTaskServiceOptions
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HostedTaskServiceOptions"/> class.
+        /// </summary>
+        /// <param name="configuration">The application configuration.</param>
+        public HostedTaskServiceOptions(IConfiguration configuration)
+        {
+            ArgumentNullException.ThrowIfNull(configuration);
+
+            configuration.GetSection(nameof(HostedTaskServiceOptions)).Bind(this);
+        }
+
+        /// <summary>
+        /// Gets or sets the maximum number of seconds to wait for task processing during shutdown.
+        /// </summary>
+        public int ShutdownTimeoutSeconds { get; set; } = 60;
+    }
+}

--- a/src/libraries/Hosting/AspNetCore/ServiceCollectionExtensions.cs
+++ b/src/libraries/Hosting/AspNetCore/ServiceCollectionExtensions.cs
@@ -196,6 +196,7 @@ namespace Microsoft.Agents.Hosting.AspNetCore
             if (!services.Any(x => x.ServiceType == typeof(IActivityTaskQueue)))
             {
                 services.AddSingleton<HostedActivityServiceOptions>();
+                services.AddSingleton<HostedTaskServiceOptions>();
 
                 // Activity specific BackgroundService for processing authenticated activities.
                 services.AddHostedService<HostedActivityService>();

--- a/src/tests/Microsoft.Agents.Hosting.AspNetCore/BackgroundActivityService/HostedActivityServiceOptionsTests.cs
+++ b/src/tests/Microsoft.Agents.Hosting.AspNetCore/BackgroundActivityService/HostedActivityServiceOptionsTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
             var options = new HostedActivityServiceOptions(configuration);
 
             Assert.Equal(60, options.ShutdownTimeoutSeconds);
-            Assert.False(options.UseScopedServices);
+            Assert.True(options.UseScopedServices);
         }
 
         [Fact]

--- a/src/tests/Microsoft.Agents.Hosting.AspNetCore/BackgroundActivityService/HostedActivityServiceOptionsTests.cs
+++ b/src/tests/Microsoft.Agents.Hosting.AspNetCore/BackgroundActivityService/HostedActivityServiceOptionsTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
             var options = new HostedActivityServiceOptions(configuration);
 
             Assert.Equal(60, options.ShutdownTimeoutSeconds);
-            Assert.True(options.UseScopedServices);
+            Assert.False(options.UseScopedServices);
         }
 
         [Fact]

--- a/src/tests/Microsoft.Agents.Hosting.AspNetCore/BackgroundActivityService/HostedActivityServiceTests.cs
+++ b/src/tests/Microsoft.Agents.Hosting.AspNetCore/BackgroundActivityService/HostedActivityServiceTests.cs
@@ -160,9 +160,9 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
         }
 
         [Fact]
-        public async Task ExecuteAsync_WithScopedServices_ShouldResolveAndDisposeDependencyPerActivity()
+        public async Task ExecuteAsync_WithDefaultOptions_ShouldResolveAndDisposeDependencyPerActivity()
         {
-            var record = UseScopedRecord(useScopedServices: true, expectedActivities: 2);
+            var record = UseScopedRecord(useScopedServices: null, expectedActivities: 2);
 
             record.Queue.QueueBackgroundActivity(new ClaimsIdentity(), record.Adapter.Object, new Activity());
             record.Queue.QueueBackgroundActivity(new ClaimsIdentity(), record.Adapter.Object, new Activity());
@@ -304,7 +304,7 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
             return options.ShutdownTimeoutSeconds;
         }
 
-        private static ScopedRecord UseScopedRecord(bool useScopedServices, int expectedActivities)
+        private static ScopedRecord UseScopedRecord(bool? useScopedServices, int expectedActivities)
         {
             var collector = new ProbeCollector();
             var services = new ServiceCollection();
@@ -332,10 +332,11 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
                     }
                 });
 
-            var options = new HostedActivityServiceOptions(new ConfigurationBuilder().Build())
+            var options = new HostedActivityServiceOptions(new ConfigurationBuilder().Build());
+            if (useScopedServices.HasValue)
             {
-                UseScopedServices = useScopedServices
-            };
+                options.UseScopedServices = useScopedServices.Value;
+            }
             var service = new HostedActivityService(
                 provider,
                 new ConfigurationBuilder().Build(),

--- a/src/tests/Microsoft.Agents.Hosting.AspNetCore/BackgroundActivityService/HostedActivityServiceTests.cs
+++ b/src/tests/Microsoft.Agents.Hosting.AspNetCore/BackgroundActivityService/HostedActivityServiceTests.cs
@@ -7,9 +7,12 @@ using Microsoft.Agents.Builder.Testing;
 using Microsoft.Agents.Core.Models;
 using Microsoft.Agents.Hosting.AspNetCore.BackgroundQueue;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
 using System;
+using System.Collections.Concurrent;
+using System.Linq;
 using System.Reflection;
 using System.Security.Claims;
 using System.Threading;
@@ -157,6 +160,91 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
         }
 
         [Fact]
+        public async Task ExecuteAsync_WithScopedServices_ShouldResolveAndDisposeDependencyPerActivity()
+        {
+            var record = UseScopedRecord(useScopedServices: true, expectedActivities: 2);
+
+            record.Queue.QueueBackgroundActivity(new ClaimsIdentity(), record.Adapter.Object, new Activity());
+            record.Queue.QueueBackgroundActivity(new ClaimsIdentity(), record.Adapter.Object, new Activity());
+
+            await record.Service.StartAsync(CancellationToken.None);
+            await record.AllActivitiesProcessed.Task.WaitAsync(TimeSpan.FromSeconds(30));
+            await record.Service.StopAsync(CancellationToken.None);
+
+            var probes = record.Collector.Resolved.ToArray();
+            Assert.Equal(2, probes.Length);
+            Assert.NotSame(probes[0], probes[1]);
+            Assert.All(probes, probe => Assert.True(probe.IsDisposed));
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_WithoutScopedServices_ShouldResolveDependencyFromRootProvider()
+        {
+            var record = UseScopedRecord(useScopedServices: false, expectedActivities: 2);
+
+            record.Queue.QueueBackgroundActivity(new ClaimsIdentity(), record.Adapter.Object, new Activity());
+            record.Queue.QueueBackgroundActivity(new ClaimsIdentity(), record.Adapter.Object, new Activity());
+
+            await record.Service.StartAsync(CancellationToken.None);
+            await record.AllActivitiesProcessed.Task.WaitAsync(TimeSpan.FromSeconds(30));
+            await record.Service.StopAsync(CancellationToken.None);
+
+            var probes = record.Collector.Resolved.ToArray();
+            Assert.Equal(2, probes.Length);
+            Assert.Same(probes[0], probes[1]);
+            Assert.All(probes, probe => Assert.False(probe.IsDisposed));
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_WithScopedServices_ShouldDisposeAsyncDependencyAndCompleteOnce()
+        {
+            var collector = new AsyncProbeCollector();
+            var services = new ServiceCollection();
+            services.AddSingleton(collector);
+            services.AddScoped<AsyncScopedProbe>();
+            services.AddTransient<IAgent, AsyncProbeAgent>();
+
+            await using var provider = services.BuildServiceProvider();
+            var queue = new ActivityTaskQueue();
+            var adapter = new Mock<IChannelAdapter>();
+            var adapterCalled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            adapter
+                .Setup(a => a.ProcessActivityAsync(
+                    It.IsAny<ClaimsIdentity>(),
+                    It.IsAny<Activity>(),
+                    It.IsAny<AgentCallbackHandler>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new InvokeResponse())
+                .Callback(() => adapterCalled.TrySetResult());
+
+            var configuration = new ConfigurationBuilder().Build();
+            var service = new HostedActivityService(
+                provider,
+                configuration,
+                queue,
+                Mock.Of<ILogger<HostedActivityService>>(),
+                new HostedActivityServiceOptions(configuration) { UseScopedServices = true });
+            var completionCount = 0;
+            queue.QueueBackgroundActivity(
+                new ClaimsIdentity(),
+                adapter.Object,
+                new Activity(),
+                onComplete: _ =>
+                {
+                    Interlocked.Increment(ref completionCount);
+                    return Task.CompletedTask;
+                });
+
+            await service.StartAsync(CancellationToken.None);
+            await adapterCalled.Task.WaitAsync(TimeSpan.FromSeconds(30));
+            await service.StopAsync(CancellationToken.None);
+
+            var probe = Assert.Single(collector.Resolved);
+            Assert.True(probe.IsDisposed);
+            Assert.Equal(1, completionCount);
+        }
+
+        [Fact]
         public void Constructor_WithHostedOptions_UsesHostedShutdownTimeout()
         {
             var config = new ConfigurationBuilder().Build();
@@ -216,6 +304,48 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
             return options.ShutdownTimeoutSeconds;
         }
 
+        private static ScopedRecord UseScopedRecord(bool useScopedServices, int expectedActivities)
+        {
+            var collector = new ProbeCollector();
+            var services = new ServiceCollection();
+            services.AddSingleton(collector);
+            services.AddScoped<ScopedProbe>();
+            services.AddTransient<IAgent, ProbeAgent>();
+
+            var provider = services.BuildServiceProvider();
+            var queue = new ActivityTaskQueue();
+            var adapter = new Mock<IChannelAdapter>();
+            var processed = 0;
+            var allActivitiesProcessed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            adapter
+                .Setup(a => a.ProcessActivityAsync(
+                    It.IsAny<ClaimsIdentity>(),
+                    It.IsAny<Activity>(),
+                    It.IsAny<AgentCallbackHandler>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new InvokeResponse())
+                .Callback(() =>
+                {
+                    if (Interlocked.Increment(ref processed) == expectedActivities)
+                    {
+                        allActivitiesProcessed.TrySetResult();
+                    }
+                });
+
+            var options = new HostedActivityServiceOptions(new ConfigurationBuilder().Build())
+            {
+                UseScopedServices = useScopedServices
+            };
+            var service = new HostedActivityService(
+                provider,
+                new ConfigurationBuilder().Build(),
+                queue,
+                Mock.Of<ILogger<HostedActivityService>>(),
+                options);
+
+            return new(service, queue, adapter, collector, allActivitiesProcessed);
+        }
+
         private static Record UseRecord(IAgent agent = null)
         {
             var config = new ConfigurationBuilder().Build();
@@ -229,7 +359,11 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
                 .Setup(s => s.GetService(It.IsAny<Type>()))
                 .Returns(agent);
 
-            var service = new HostedActivityService(sp.Object, config, queue, logger.Object, new HostedActivityServiceOptions(config));
+            var options = new HostedActivityServiceOptions(config)
+            {
+                UseScopedServices = false
+            };
+            var service = new HostedActivityService(sp.Object, config, queue, logger.Object, options);
             return new(service, queue, bot, adapter, logger);
         }
 
@@ -243,6 +377,70 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
             public void VerifyMocks()
             {
                 Mock.Verify(Bot, Adapter, Logger);
+            }
+        }
+
+        private record ScopedRecord(
+            HostedActivityService Service,
+            ActivityTaskQueue Queue,
+            Mock<IChannelAdapter> Adapter,
+            ProbeCollector Collector,
+            TaskCompletionSource AllActivitiesProcessed);
+
+        private sealed class ScopedProbe : IDisposable
+        {
+            public bool IsDisposed { get; private set; }
+
+            public void Dispose()
+            {
+                IsDisposed = true;
+            }
+        }
+
+        private sealed class ProbeCollector
+        {
+            public ConcurrentQueue<ScopedProbe> Resolved { get; } = new();
+        }
+
+        private sealed class ProbeAgent : IAgent
+        {
+            public ProbeAgent(ScopedProbe probe, ProbeCollector collector)
+            {
+                collector.Resolved.Enqueue(probe);
+            }
+
+            public Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default)
+            {
+                return Task.CompletedTask;
+            }
+        }
+
+        private sealed class AsyncScopedProbe : IAsyncDisposable
+        {
+            public bool IsDisposed { get; private set; }
+
+            public ValueTask DisposeAsync()
+            {
+                IsDisposed = true;
+                return ValueTask.CompletedTask;
+            }
+        }
+
+        private sealed class AsyncProbeCollector
+        {
+            public ConcurrentQueue<AsyncScopedProbe> Resolved { get; } = new();
+        }
+
+        private sealed class AsyncProbeAgent : IAgent
+        {
+            public AsyncProbeAgent(AsyncScopedProbe probe, AsyncProbeCollector collector)
+            {
+                collector.Resolved.Enqueue(probe);
+            }
+
+            public Task OnTurnAsync(ITurnContext turnContext, CancellationToken cancellationToken = default)
+            {
+                return Task.CompletedTask;
             }
         }
     }

--- a/src/tests/Microsoft.Agents.Hosting.AspNetCore/BackgroundTaskService/HostedTaskServiceOptionsTests.cs
+++ b/src/tests/Microsoft.Agents.Hosting.AspNetCore/BackgroundTaskService/HostedTaskServiceOptionsTests.cs
@@ -6,42 +6,39 @@ using Microsoft.Extensions.Configuration;
 using System;
 using System.Collections.Generic;
 
-namespace Microsoft.Agents.Hosting.AspNetCore.Tests
+namespace Microsoft.Agents.Hosting.AspNetCore.Tests.BackgroundTaskService
 {
-    public class HostedActivityServiceOptionsTests
+    public class HostedTaskServiceOptionsTests
     {
         [Fact]
         public void Constructor_WithoutSection_UsesDefaultShutdownTimeout()
         {
             var configuration = new ConfigurationBuilder().Build();
 
-            var options = new HostedActivityServiceOptions(configuration);
+            var options = new HostedTaskServiceOptions(configuration);
 
             Assert.Equal(60, options.ShutdownTimeoutSeconds);
-            Assert.False(options.UseScopedServices);
         }
 
         [Fact]
-        public void Constructor_BindsHostedActivityServiceOptionsSection()
+        public void Constructor_BindsHostedTaskServiceOptionsSection()
         {
             var configuration = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string>
                 {
-                    ["HostedActivityServiceOptions:ShutdownTimeoutSeconds"] = "17",
-                    ["HostedActivityServiceOptions:UseScopedServices"] = "false"
+                    ["HostedTaskServiceOptions:ShutdownTimeoutSeconds"] = "17"
                 })
                 .Build();
 
-            var options = new HostedActivityServiceOptions(configuration);
+            var options = new HostedTaskServiceOptions(configuration);
 
             Assert.Equal(17, options.ShutdownTimeoutSeconds);
-            Assert.False(options.UseScopedServices);
         }
 
         [Fact]
         public void Constructor_WithNullConfiguration_Throws()
         {
-            Assert.Throws<ArgumentNullException>(() => new HostedActivityServiceOptions(null));
+            Assert.Throws<ArgumentNullException>(() => new HostedTaskServiceOptions(null));
         }
     }
 }

--- a/src/tests/Microsoft.Agents.Hosting.AspNetCore/BackgroundTaskService/HostedTaskServiceTests.cs
+++ b/src/tests/Microsoft.Agents.Hosting.AspNetCore/BackgroundTaskService/HostedTaskServiceTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
 using System;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -120,6 +121,45 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests.BackgroundTaskService
             // must not throw LockRecursionException. See https://github.com/dotnet/aspnetcore/issues/40271.
             await record.Service.StopAsync(token);
             await record.Service.StopAsync(token);
+        }
+
+        [Fact]
+        public void Constructor_WithHostedOptions_UsesHostedShutdownTimeout()
+        {
+            var options = new HostedTaskServiceOptions(new ConfigurationBuilder().Build())
+            {
+                ShutdownTimeoutSeconds = 17
+            };
+
+            var service = new HostedTaskService(
+                new BackgroundTaskQueue(),
+                Mock.Of<ILogger<HostedTaskService>>(),
+                options);
+
+            Assert.Equal(17, GetShutdownTimeoutSeconds(service));
+        }
+
+        [Fact]
+        public void LegacyConstructor_WithAdapterOptions_UsesLegacyShutdownTimeout()
+        {
+#pragma warning disable CS0618
+            var service = new HostedTaskService(
+                new BackgroundTaskQueue(),
+                Mock.Of<ILogger<HostedTaskService>>(),
+                new AdapterOptions { ShutdownTimeoutSeconds = 29 });
+#pragma warning restore CS0618
+
+            Assert.Equal(29, GetShutdownTimeoutSeconds(service));
+        }
+
+        private static int GetShutdownTimeoutSeconds(HostedTaskService service)
+        {
+            var field = typeof(HostedTaskService).GetField(
+                "_serviceOptions",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            var options = (HostedTaskServiceOptions)field.GetValue(service);
+
+            return options.ShutdownTimeoutSeconds;
         }
 
         private static Record UseRecord()

--- a/src/tests/Microsoft.Agents.Hosting.AspNetCore/CloudAdapterTests.cs
+++ b/src/tests/Microsoft.Agents.Hosting.AspNetCore/CloudAdapterTests.cs
@@ -1056,7 +1056,11 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
             var queue = new ActivityTaskQueue();
             var adapter = new CloudAdapter(factory.Object, queue, adapterLogger.Object, options: options, hostValidator: hostValidator);
             var configuration = new ConfigurationBuilder().Build();
-            var service = new HostedActivityService(sp.Object, configuration, queue, serviceLogger.Object, new HostedActivityServiceOptions(configuration));
+            var hostedOptions = new HostedActivityServiceOptions(configuration)
+            {
+                UseScopedServices = false
+            };
+            var service = new HostedActivityService(sp.Object, configuration, queue, serviceLogger.Object, hostedOptions);
 
             var record = new Record(null, adapter, factory, service, queue, adapterLogger, serviceLogger);
 
@@ -1168,7 +1172,11 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
             var queue = new ActivityTaskQueue();
             var adapter = new CloudAdapter(factory.Object, queue, adapterLogger.Object, middlewares: middleware);
             var configuration = new ConfigurationBuilder().Build();
-            var service = new HostedActivityService(sp.Object, configuration, queue, serviceLogger.Object, new HostedActivityServiceOptions(configuration));
+            var hostedOptions = new HostedActivityServiceOptions(configuration)
+            {
+                UseScopedServices = false
+            };
+            var service = new HostedActivityService(sp.Object, configuration, queue, serviceLogger.Object, hostedOptions);
 
             var record = new Record(null, adapter, factory, service, queue, adapterLogger, serviceLogger);
 

--- a/src/tests/Microsoft.Agents.Hosting.AspNetCore/ServiceCollectionExtensionsTests.cs
+++ b/src/tests/Microsoft.Agents.Hosting.AspNetCore/ServiceCollectionExtensionsTests.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
                 .ToList();
             var expected = new List<Type>{
                 typeof(HostedActivityServiceOptions),
+                typeof(HostedTaskServiceOptions),
                 typeof(HostedActivityService),
                 typeof(HostedTaskService),
                 typeof(BackgroundTaskQueue),
@@ -44,25 +45,35 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
         }
 
         [Fact]
-        public void AddAsyncAdapterSupport_ShouldRegisterHostedActivityServiceOptionsOnce()
+        public void AddAsyncAdapterSupport_ShouldRegisterHostedServiceOptionsOnce()
         {
             var configuration = new ConfigurationBuilder()
                 .AddInMemoryCollection(new Dictionary<string, string>
                 {
-                    ["HostedActivityServiceOptions:ShutdownTimeoutSeconds"] = "23"
+                    ["HostedActivityServiceOptions:ShutdownTimeoutSeconds"] = "23",
+                    ["HostedTaskServiceOptions:ShutdownTimeoutSeconds"] = "29"
                 })
                 .Build();
             var services = new ServiceCollection();
             services.AddSingleton<IConfiguration>(configuration);
+            services.AddLogging();
 
             services.AddAsyncAdapterSupport();
             services.AddAsyncAdapterSupport();
 
             using var provider = services.BuildServiceProvider();
-            var options = provider.GetRequiredService<HostedActivityServiceOptions>();
+            var activityOptions = provider.GetRequiredService<HostedActivityServiceOptions>();
+            var taskOptions = provider.GetRequiredService<HostedTaskServiceOptions>();
+            var hostedServices = provider.GetServices<IHostedService>().ToList();
 
-            Assert.Equal(23, options.ShutdownTimeoutSeconds);
+            Assert.Equal(23, activityOptions.ShutdownTimeoutSeconds);
+            Assert.Equal(29, taskOptions.ShutdownTimeoutSeconds);
+            Assert.Collection(
+                hostedServices,
+                service => Assert.IsType<HostedActivityService>(service),
+                service => Assert.IsType<HostedTaskService>(service));
             Assert.Single(services, service => service.ServiceType == typeof(HostedActivityServiceOptions));
+            Assert.Single(services, service => service.ServiceType == typeof(HostedTaskServiceOptions));
         }
 
         [Fact]
@@ -81,6 +92,7 @@ namespace Microsoft.Agents.Hosting.AspNetCore.Tests
                 typeof(IOutboundHostValidator),
                 // CloudAdapter services.
                 typeof(HostedActivityServiceOptions),
+                typeof(HostedTaskServiceOptions),
                 typeof(HostedActivityService),
                 typeof(HostedTaskService),
                 typeof(BackgroundTaskQueue),


### PR DESCRIPTION
## Summary

- process each queued activity in an asynchronous dependency injection scope by default
- add `HostedActivityServiceOptions.UseScopedServices`, with an explicit `false` opt-out for root-provider resolution
- add `HostedTaskServiceOptions` so hosted task shutdown configuration no longer depends on `AdapterOptions`
- preserve legacy shutdown-option constructor behavior and cover scoped disposal, configuration binding, default scoped resolution, and DI activation

Fixes #442.

## Attribution

This supersedes #960 and builds on the scoped-lifetime issue and implementation originally contributed by Laith Zeyadeh (@LaithZdevnas). Huge thanks to Laith for identifying the root-provider lifetime problem, documenting its production impact, and contributing the source fix.

## Testing

- `dotnet test src\tests\Microsoft.Agents.Hosting.AspNetCore\Microsoft.Agents.Hosting.AspNetCore.Tests.csproj --no-restore`
- 127 tests passed on both .NET 8 and .NET 10