### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/actions/get-ado-token/action.yml
+++ b/.github/actions/get-ado-token/action.yml
@@ -19,7 +19,7 @@ runs:
   using: "composite"
   steps:
     - name: OIDC Login with AzPowershell
-      uses: azure/login@v2
+      uses: azure/login@7184910d9eb2b1c5e48f7073824a90609bb9b6d6 # v2.3.1
       with:
         client-id: ${{ inputs.client-id }}
         tenant-id: ${{ inputs.tenant-id }}
@@ -27,7 +27,7 @@ runs:
         enable-AzPSSession: true
     - id: ADOAuth
       name: Get ADO Access Token
-      uses: azure/powershell@v1
+      uses: azure/powershell@1300bbd2b3e1c21c029fe34887d16d2809a1397f # v1.4.0
       with:
         azPSVersion: "latest"
         inlineScript: |

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,3 +40,12 @@ updates:
 #    - 'dependencies'
 #  reviewers:
 #    - 'microsoft/botframework-sdk'      
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    groups:
+      github-actions:
+        patterns: ["*"]
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         dotnet-version: 10.0.x
 
-    - uses: dotnet/nbgv@master
+    - uses: dotnet/nbgv@705dad19ab067f12f4e9eeaa60812e01edef5d25 # v0.5.2
       with:
           setAllVars: true        
     - run: echo "NuGetPackageVersion $NuGetPackageVersion"      

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         fetch-depth: 0
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
       with:
         dotnet-version: 10.0.x
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: windows-latest
     steps:
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         fetch-depth: 0
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
       with:
         dotnet-version: 10.0.x
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         dotnet-version: 10.0.x
 
-    - uses: dotnet/nbgv@master
+    - uses: dotnet/nbgv@705dad19ab067f12f4e9eeaa60812e01edef5d25 # v0.5.2
       with:
           setAllVars: true        
     - run: echo "NuGetPackageVersion $NuGetPackageVersion"      

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,7 +57,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         fetch-depth: 0
 
@@ -69,12 +69,12 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3.37.6
       with:
         languages: csharp
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
       with:
         dotnet-version: 10.0.x
 
@@ -90,6 +90,6 @@ jobs:
       run: dotnet build --no-restore -c debug AgentSdk.proj
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3.37.6
       with:
         category: "/language:csharp"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -78,7 +78,7 @@ jobs:
       with:
         dotnet-version: 10.0.x
 
-    - uses: dotnet/nbgv@master
+    - uses: dotnet/nbgv@705dad19ab067f12f4e9eeaa60812e01edef5d25 # v0.5.2
       with:
           setAllVars: true        
     - run: echo "NuGetPackageVersion $NuGetPackageVersion"  

--- a/.github/workflows/issue-triage-agent.yml
+++ b/.github/workflows/issue-triage-agent.yml
@@ -41,12 +41,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,7 +19,7 @@ jobs:
     outputs:
       should_run: ${{ steps.should_run.outputs.should_run }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: print latest_commit
         run: echo ${{ github.sha }}
       - id: should_run
@@ -34,7 +34,7 @@ jobs:
     name: Nightly Build when something has changed in the last 24 hrs.
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
     - name: Get Azure DevOps Access Token
       id: getToken
       uses: "./.github/actions/get-ado-token"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
     - name: Get Azure DevOps Access Token
       id: getToken
       uses: "./.github/actions/get-ado-token"

--- a/.github/workflows/pullrequestlabeler.yml
+++ b/.github/workflows/pullrequestlabeler.yml
@@ -17,7 +17,7 @@ jobs:
     if: github.repository_owner == 'microsoft'
     steps:
       - name: Label pull request
-        uses: actions/labeler@v5 # v5.0.0
+        uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5
         with:
             repo-token: '${{ secrets.GITHUB_TOKEN }}'
             sync-labels: true

--- a/.github/workflows/verify-sequence-diagrams.yml
+++ b/.github/workflows/verify-sequence-diagrams.yml
@@ -34,10 +34,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
 


### PR DESCRIPTION
## Summary

Pins third-party GitHub Actions to full-length commit SHAs for improved supply-chain security and reproducibility, and adds a 7-day Dependabot cooldown for GitHub Actions updates.

This recreates #967 from the latest `main` and addresses its Copilot review comments by pinning `dotnet/nbgv` in the Windows, Linux, and CodeQL workflows to the v0.5.2 commit SHA instead of the mutable `master` ref.

## Changes

- Pin external actions in workflows and the `get-ado-token` composite action to full commit SHAs with version annotations.
- Pin `dotnet/nbgv` to `705dad19ab067f12f4e9eeaa60812e01edef5d25` (`v0.5.2`) in all three workflows.
- Add weekly Dependabot updates for GitHub Actions with a 7-day cooldown.

## Validation

- Verified every pinned SHA resolves to its annotated upstream release.
- Verified no mutable external action references remain.
- Verified the branch changes only the 10 files included in #967.