### PR TITLE
Add typing indicator telemetry scope

### DIFF
--- a/src/libraries/Builder/Microsoft.Agents.Builder/App/TypingWorker.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/App/TypingWorker.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.Agents.Builder.Telemetry.App.Scopes;
 using Microsoft.Agents.Core.Models;
 using System;
 using System.Collections.Generic;
@@ -226,14 +227,27 @@ namespace Microsoft.Agents.Builder.App
 
         private async Task SendTypingActivityAsync(CancellationToken cancellationToken)
         {
-            // Send directly on the adapter to bypass OnSendActivities middleware (matching
-            // ShowTypingMiddleware's approach) so our own handler doesn't reset the interval.
-            var conversationReference = _turnContext.Activity.GetConversationReference();
-            var typingActivity = _strategy.TypingFactory(_turnContext, conversationReference);
-            typingActivity.ApplyConversationReference(conversationReference);
+            using var telemetryScope = new ScopeTypingIndicator(_turnContext);
+            try
+            {
+                // Send directly on the adapter to bypass OnSendActivities middleware (matching
+                // ShowTypingMiddleware's approach) so our own handler doesn't reset the interval.
+                var conversationReference = _turnContext.Activity.GetConversationReference();
+                var typingActivity = _strategy.TypingFactory(_turnContext, conversationReference);
+                typingActivity.ApplyConversationReference(conversationReference);
 
-            await _turnContext.Adapter.SendActivitiesAsync(
-                _turnContext, [typingActivity], cancellationToken).ConfigureAwait(false);
+                await _turnContext.Adapter.SendActivitiesAsync(
+                    _turnContext, [typingActivity], cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                telemetryScope.SetError(ex);
+                throw;
+            }
         }
 
         /// <summary>

--- a/src/libraries/Builder/Microsoft.Agents.Builder/Telemetry/App/Constants.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/Telemetry/App/Constants.cs
@@ -24,6 +24,9 @@ namespace Microsoft.Agents.Builder.Telemetry.App
         /// <summary>Activity name for downloading file attachments during a turn.</summary>
         internal static readonly string ScopeDownloadFiles = "agents.app.download_files";
 
+        /// <summary>Activity name for sending an automatic typing indicator.</summary>
+        internal static readonly string ScopeTypingIndicator = "agents.app.typing_indicator";
+
         /// <summary>Metric name for the counter of turns processed by the agent.</summary>
         internal static readonly string MetricTurnCount = "agents.turn.count";
 

--- a/src/libraries/Builder/Microsoft.Agents.Builder/Telemetry/App/Scopes/ScopeTypingIndicator.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/Telemetry/App/Scopes/ScopeTypingIndicator.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Agents.Core.Models;
+using Microsoft.Agents.Core.Telemetry;
+using System;
+
+namespace Microsoft.Agents.Builder.Telemetry.App.Scopes
+{
+    /// <summary>
+    /// A <see cref="TelemetryScope"/> that traces an automatic typing indicator send.
+    /// </summary>
+    internal class ScopeTypingIndicator : TelemetryScope
+    {
+        private readonly ITurnContext _turnContext;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ScopeTypingIndicator"/> class.
+        /// </summary>
+        /// <param name="turnContext">The turn for which the typing indicator is being sent.</param>
+        public ScopeTypingIndicator(ITurnContext turnContext) : base(Constants.ScopeTypingIndicator)
+        {
+            _turnContext = turnContext;
+        }
+
+        /// <inheritdoc />
+        protected override void Callback(System.Diagnostics.Activity telemetryActivity, double duration, Exception? error)
+        {
+            telemetryActivity.SetTag(TagNames.ActivityType, ActivityTypes.Typing);
+            telemetryActivity.SetTag(TagNames.ActivityChannelId, _turnContext.Activity.ChannelId?.ToString());
+            telemetryActivity.SetTag(TagNames.ConversationId, _turnContext.Activity.Conversation?.Id);
+        }
+    }
+}

--- a/src/tests/Microsoft.Agents.Builder.Tests/App/TypingWorkerTests.cs
+++ b/src/tests/Microsoft.Agents.Builder.Tests/App/TypingWorkerTests.cs
@@ -5,7 +5,9 @@ using Microsoft.Agents.Builder.App;
 using Microsoft.Agents.Builder.Testing;
 using Microsoft.Agents.Builder.Tests.App.TestUtils;
 using Microsoft.Agents.Core.Models;
+using Microsoft.Agents.Core.Telemetry;
 using Microsoft.Agents.Storage;
+using Microsoft.Agents.TestSupport;
 using Microsoft.Extensions.Time.Testing;
 using System;
 using System.Collections.Generic;
@@ -16,7 +18,8 @@ using Xunit;
 
 namespace Microsoft.Agents.Builder.Tests.App
 {
-    public class TypingWorkerTests
+    [Collection("TelemetryTests")]
+    public class TypingWorkerTests : TelemetryScopeTestBase
     {
         private static TypingOptions MakeOptions(int initialDelayMs, int intervalMs) =>
             new TypingOptions
@@ -152,6 +155,31 @@ namespace Microsoft.Agents.Builder.Tests.App
         }
 
         [Fact]
+        public async Task Start_EmitsTypingIndicatorTelemetryScope()
+        {
+            var time = new SignalingTimeProvider();
+            var adapter = new SignalingTestAdapter();
+            var context = new TurnContext(adapter, MakeMessageActivity());
+            var worker = TypingWorker.Create(
+                context, MakeOptions(initialDelayMs: 100, intervalMs: 30_000), time)!;
+
+            worker.Start();
+
+            await AwaitSignal(time.TimerArmed, "initial-delay timer armed");
+            time.Advance(TimeSpan.FromMilliseconds(100));
+            await AwaitSignal(adapter.TypingSent, "first typing activity");
+            await worker.DisposeAsync();
+
+            var stopped = Assert.Single(
+                StoppedActivities,
+                activity => activity.OperationName == "agents.app.typing_indicator");
+            Assert.Equal(System.Diagnostics.ActivityStatusCode.Unset, stopped.Status);
+            Assert.Equal(ActivityTypes.Typing, stopped.GetTagItem(TagNames.ActivityType));
+            Assert.Equal(Channels.Test, stopped.GetTagItem(TagNames.ActivityChannelId));
+            Assert.Equal("conv1", stopped.GetTagItem(TagNames.ConversationId));
+        }
+
+        [Fact]
         public async Task Start_SendsMultipleTypingActivities_AtInterval()
         {
             var time = new SignalingTimeProvider();
@@ -262,6 +290,64 @@ namespace Microsoft.Agents.Builder.Tests.App
 
             // Assert: DisposeAsync must not re-throw; a faulted _workerTask would propagate here.
             await worker.DisposeAsync();
+
+            var stopped = Assert.Single(
+                StoppedActivities,
+                activity => activity.OperationName == "agents.app.typing_indicator");
+            Assert.Equal(System.Diagnostics.ActivityStatusCode.Error, stopped.Status);
+            Assert.Equal("Simulated transport error", stopped.StatusDescription);
+            Assert.Contains(stopped.Events, telemetryEvent => telemetryEvent.Name == "exception");
+        }
+
+        [Fact]
+        public async Task RunAsync_RecordsTelemetry_WhenTypingFactoryThrows()
+        {
+            var adapter = new TestAdapter();
+            var context = new TurnContext(adapter, MakeMessageActivity());
+            var strategy = new ThrowingTypingStrategy();
+            var options = new TypingOptions
+            {
+                ChannelStrategies = new Dictionary<string, ITypingChannelStrategy>(
+                    StringComparer.OrdinalIgnoreCase)
+                {
+                    [Channels.Test] = strategy
+                }
+            };
+            var worker = TypingWorker.Create(context, options)!;
+
+            worker.Start();
+
+            await AwaitSignal(strategy.FactoryInvoked, "typing factory invocation");
+            await worker.DisposeAsync();
+
+            var stopped = Assert.Single(
+                StoppedActivities,
+                activity => activity.OperationName == "agents.app.typing_indicator");
+            Assert.Equal(System.Diagnostics.ActivityStatusCode.Error, stopped.Status);
+            Assert.Equal("Simulated typing factory error", stopped.StatusDescription);
+        }
+
+        [Fact]
+        public async Task DisposeAsync_DoesNotRecordExpectedCancellationAsError()
+        {
+            var time = new SignalingTimeProvider();
+            var adapter = new GatedSendAdapter();
+            var context = new TurnContext(adapter, MakeMessageActivity());
+            var worker = TypingWorker.Create(
+                context, MakeOptions(initialDelayMs: 100, intervalMs: 30_000), time)!;
+            worker.Start();
+
+            await AwaitSignal(time.TimerArmed, "initial-delay timer armed");
+            time.Advance(TimeSpan.FromMilliseconds(100));
+            await AwaitSignal(adapter.SendStarted, "typing send in-flight");
+
+            await worker.DisposeAsync();
+
+            var stopped = Assert.Single(
+                StoppedActivities,
+                activity => activity.OperationName == "agents.app.typing_indicator");
+            Assert.Equal(System.Diagnostics.ActivityStatusCode.Unset, stopped.Status);
+            Assert.DoesNotContain(stopped.Events, telemetryEvent => telemetryEvent.Name == "exception");
         }
 
         // ── Fix 2: negative delay values must be rejected early ──────────────────────
@@ -354,6 +440,24 @@ namespace Microsoft.Agents.Builder.Tests.App
                 _sendAttempted.Release();
                 throw new InvalidOperationException("Simulated transport error");
             }
+        }
+
+        private sealed class ThrowingTypingStrategy : ITypingChannelStrategy
+        {
+            private readonly SemaphoreSlim _factoryInvoked = new(0);
+
+            public int InitialDelayMs => 0;
+
+            public int IntervalMs => 30_000;
+
+            public Func<ITurnContext, ConversationReference, IActivity> TypingFactory =>
+                (_, _) =>
+                {
+                    _factoryInvoked.Release();
+                    throw new InvalidOperationException("Simulated typing factory error");
+                };
+
+            public SemaphoreSlim FactoryInvoked => _factoryInvoked;
         }
 
         [Fact]

--- a/src/tests/Microsoft.Agents.Builder.Tests/Telemetry/AppScopeTests.cs
+++ b/src/tests/Microsoft.Agents.Builder.Tests/Telemetry/AppScopeTests.cs
@@ -117,6 +117,46 @@ namespace Microsoft.Agents.Builder.Tests.Telemetry
 
         #endregion
 
+        #region ScopeTypingIndicator
+
+        [Fact]
+        public void ScopeTypingIndicator_CreatesActivity_WithCorrectName()
+        {
+            using var scope = new ScopeTypingIndicator(CreateTurnContext());
+
+            var started = Assert.Single(StartedActivities);
+            Assert.Equal("agents.app.typing_indicator", started.OperationName);
+        }
+
+        [Fact]
+        public void ScopeTypingIndicator_Callback_SetsActivityMetadataTags()
+        {
+            var turnContext = CreateTurnContext(
+                channelId: "msteams",
+                conversationId: "conv-typing");
+            var scope = new ScopeTypingIndicator(turnContext);
+            scope.Dispose();
+
+            var stopped = Assert.Single(StoppedActivities);
+            Assert.Equal(ActivityTypes.Typing, stopped.GetTagItem(TagNames.ActivityType));
+            Assert.Equal("msteams", stopped.GetTagItem(TagNames.ActivityChannelId));
+            Assert.Equal("conv-typing", stopped.GetTagItem(TagNames.ConversationId));
+        }
+
+        [Fact]
+        public void ScopeTypingIndicator_SetError_SetsErrorStatus()
+        {
+            var scope = new ScopeTypingIndicator(CreateTurnContext());
+            scope.SetError(new InvalidOperationException("typing error"));
+            scope.Dispose();
+
+            var stopped = Assert.Single(StoppedActivities);
+            Assert.Equal(System.Diagnostics.ActivityStatusCode.Error, stopped.Status);
+            Assert.Equal("typing error", stopped.StatusDescription);
+        }
+
+        #endregion
+
         #region ScopeBeforeTurn
 
         [Fact]


### PR DESCRIPTION
## Summary

- add a dedicated `agents.app.typing_indicator` telemetry scope around automatic typing-indicator operations
- tag spans with activity type, channel, and conversation metadata
- record activity-construction and adapter-send failures before the best-effort worker intentionally swallows them
- leave expected worker-shutdown cancellation unmarked rather than emitting false error telemetry
- add scope and worker integration coverage for success, transport failure, typing-factory failure, and in-flight cancellation

## Testing

- `dotnet format` verification for the changed Builder and test files
- `dotnet test src/tests/Microsoft.Agents.Builder.Tests/Microsoft.Agents.Builder.Tests.csproj --configuration Release --no-restore`
  - net8.0: 1,085 passed, 5 skipped, 0 failed
  - net10.0: 1,085 passed, 5 skipped, 0 failed
  - net48: 1,085 passed, 5 skipped, 0 failed

Fixes #973