### PR TITLE
[#972] Add Outbound host validation to proactive paths

### DIFF
--- a/src/libraries/Builder/Microsoft.Agents.Builder/ChannelServiceAdapterBase.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/ChannelServiceAdapterBase.cs
@@ -29,9 +29,11 @@ namespace Microsoft.Agents.Builder
     /// </remarks>
     /// <param name="channelServiceClientFactory">The IChannelServiceClientFactory to use for creating IConnectorClient and IUserTokenClient instances.</param>
     /// <param name="logger">The ILogger implementation this adapter should use.</param>
+    /// <param name="hostValidator">The validator used to restrict outbound service URLs.</param>
     public abstract class ChannelServiceAdapterBase(
         IChannelServiceClientFactory channelServiceClientFactory,
-        ILogger logger = null) : ChannelAdapter(logger)
+        ILogger logger = null,
+        IOutboundHostValidator hostValidator = null) : ChannelAdapter(logger)
     {
         /// <summary>
         /// Gets the <see cref="Microsoft.Agents.Builder.IChannelServiceClientFactory" /> instance for this adapter.
@@ -40,6 +42,11 @@ namespace Microsoft.Agents.Builder
         /// The <see cref="Microsoft.Agents.Builder.IChannelServiceClientFactory" /> instance for this adapter.
         /// </value>
         protected IChannelServiceClientFactory ChannelServiceFactory { get; private set; } = channelServiceClientFactory ?? throw new ArgumentNullException(nameof(channelServiceClientFactory));
+
+        /// <summary>
+        /// Gets the validator used to restrict outbound service URLs.
+        /// </summary>
+        protected IOutboundHostValidator HostValidator { get; } = hostValidator;
 
         /// <inheritdoc/>
         public override async Task<ResourceResponse[]> SendActivitiesAsync(ITurnContext turnContext, IActivity[] activities, CancellationToken cancellationToken)
@@ -146,6 +153,7 @@ namespace Microsoft.Agents.Builder
             AssertionHelpers.ThrowIfNull(identity, nameof(identity));
             AssertionHelpers.ThrowIfNull(parameters, nameof(parameters));
             AssertionHelpers.ThrowIfNullOrWhiteSpace(channelId, nameof(channelId));
+            ValidateOutboundServiceUrl(serviceUrl, nameof(serviceUrl));
 
             bool useAnonymousAuthCallback = AgentClaims.AllowAnonymous(identity);
 
@@ -200,6 +208,7 @@ namespace Microsoft.Agents.Builder
             }
 
             ValidateContinuationActivity(continuationActivity);
+            ValidateOutboundServiceUrl(continuationActivity.ServiceUrl, nameof(continuationActivity));
 
             bool useAnonymousAuthCallback = AgentClaims.AllowAnonymous(claimsIdentity);
 
@@ -275,6 +284,16 @@ namespace Microsoft.Agents.Builder
 
             // If there are any results they will have been left on the TurnContext. 
             return ProcessTurnResults(context);
+        }
+
+        private void ValidateOutboundServiceUrl(string serviceUrl, string parameterName)
+        {
+            if (HostValidator?.Enabled == true
+                && !string.IsNullOrWhiteSpace(serviceUrl)
+                && !HostValidator.IsAllowed(serviceUrl))
+            {
+                throw new ArgumentException("The service URL host is not allowed.", parameterName);
+            }
         }
 
         protected virtual Task<bool> HostResponseAsync(IActivity incomingActivity, IActivity outActivity, CancellationToken cancellationToken)

--- a/src/libraries/Builder/Microsoft.Agents.Builder/ChannelServiceAdapterBase.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/ChannelServiceAdapterBase.cs
@@ -27,26 +27,43 @@ namespace Microsoft.Agents.Builder
     /// lot of functionality for free, including handling incoming activities, sending outgoing activities, and creating conversations.
     /// Otherwise, subclass the ChannelAdapter for more control over how activities are sent and received.
     /// </remarks>
-    /// <param name="channelServiceClientFactory">The IChannelServiceClientFactory to use for creating IConnectorClient and IUserTokenClient instances.</param>
-    /// <param name="logger">The ILogger implementation this adapter should use.</param>
-    /// <param name="hostValidator">The validator used to restrict outbound service URLs.</param>
-    public abstract class ChannelServiceAdapterBase(
-        IChannelServiceClientFactory channelServiceClientFactory,
-        ILogger logger = null,
-        IOutboundHostValidator hostValidator = null) : ChannelAdapter(logger)
+    public abstract class ChannelServiceAdapterBase : ChannelAdapter
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChannelServiceAdapterBase"/> class.
+        /// </summary>
+        /// <param name="channelServiceClientFactory">The IChannelServiceClientFactory to use for creating IConnectorClient and IUserTokenClient instances.</param>
+        /// <param name="logger">The ILogger implementation this adapter should use.</param>
+        public ChannelServiceAdapterBase(IChannelServiceClientFactory channelServiceClientFactory, ILogger logger = null)
+            : this(channelServiceClientFactory, logger, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChannelServiceAdapterBase"/> class with outbound service URL validation.
+        /// </summary>
+        /// <param name="channelServiceClientFactory">The IChannelServiceClientFactory to use for creating IConnectorClient and IUserTokenClient instances.</param>
+        /// <param name="logger">The ILogger implementation this adapter should use.</param>
+        /// <param name="hostValidator">The validator used to restrict outbound service URLs.</param>
+        public ChannelServiceAdapterBase(IChannelServiceClientFactory channelServiceClientFactory, ILogger logger, IOutboundHostValidator hostValidator)
+            : base(logger)
+        {
+            ChannelServiceFactory = channelServiceClientFactory ?? throw new ArgumentNullException(nameof(channelServiceClientFactory));
+            HostValidator = hostValidator;
+        }
+
         /// <summary>
         /// Gets the <see cref="Microsoft.Agents.Builder.IChannelServiceClientFactory" /> instance for this adapter.
         /// </summary>
         /// <value>
         /// The <see cref="Microsoft.Agents.Builder.IChannelServiceClientFactory" /> instance for this adapter.
         /// </value>
-        protected IChannelServiceClientFactory ChannelServiceFactory { get; private set; } = channelServiceClientFactory ?? throw new ArgumentNullException(nameof(channelServiceClientFactory));
+        protected IChannelServiceClientFactory ChannelServiceFactory { get; private set; }
 
         /// <summary>
         /// Gets the validator used to restrict outbound service URLs.
         /// </summary>
-        protected IOutboundHostValidator HostValidator { get; } = hostValidator;
+        protected IOutboundHostValidator HostValidator { get; }
 
         /// <inheritdoc/>
         public override async Task<ResourceResponse[]> SendActivitiesAsync(ITurnContext turnContext, IActivity[] activities, CancellationToken cancellationToken)
@@ -208,7 +225,7 @@ namespace Microsoft.Agents.Builder
             }
 
             ValidateContinuationActivity(continuationActivity);
-            ValidateOutboundServiceUrl(continuationActivity.ServiceUrl, nameof(continuationActivity));
+            ValidateOutboundServiceUrl(continuationActivity.ServiceUrl, nameof(continuationActivity.ServiceUrl));
 
             bool useAnonymousAuthCallback = AgentClaims.AllowAnonymous(claimsIdentity);
 

--- a/src/libraries/Builder/Microsoft.Agents.Builder/ChannelServiceAdapterBase.cs
+++ b/src/libraries/Builder/Microsoft.Agents.Builder/ChannelServiceAdapterBase.cs
@@ -170,13 +170,13 @@ namespace Microsoft.Agents.Builder
             AssertionHelpers.ThrowIfNull(identity, nameof(identity));
             AssertionHelpers.ThrowIfNull(parameters, nameof(parameters));
             AssertionHelpers.ThrowIfNullOrWhiteSpace(channelId, nameof(channelId));
-            ValidateOutboundServiceUrl(serviceUrl, nameof(serviceUrl));
 
             bool useAnonymousAuthCallback = AgentClaims.AllowAnonymous(identity);
 
             var reference = ConversationReferenceBuilder.Create(identity.GetIncomingAudience(), channelId, serviceUrl)
                 .WithUser(parameters.Members?.Count > 0 ? parameters.Members[0] : new ChannelAccount(identity.GetIncomingAudience(), role: RoleTypes.User))
                 .Build();
+            ValidateOutboundServiceUrl(reference.ServiceUrl, nameof(serviceUrl));
 
             // Create the initial TurnContext with the create conversation activity, so that we can create the connector client
             // with the correct context and then make the create conversation call.

--- a/src/libraries/Hosting/AspNetCore/CloudAdapter.cs
+++ b/src/libraries/Hosting/AspNetCore/CloudAdapter.cs
@@ -35,7 +35,6 @@ namespace Microsoft.Agents.Hosting.AspNetCore
         private readonly IActivityTaskQueue _activityTaskQueue;
         private readonly AdapterOptions _adapterOptions;
         private readonly ChannelResponseQueue _responseQueue;
-        private readonly IOutboundHostValidator _hostValidator;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Microsoft.Agents.Hosting.AspNetCore.CloudAdapter"/> class.
@@ -56,13 +55,11 @@ namespace Microsoft.Agents.Hosting.AspNetCore
             Builder.IMiddleware[] middlewares = null,
             IConfiguration config = null,
             IOutboundHostValidator hostValidator = null)
-            : base(channelServiceClientFactory, logger)
+            : base(channelServiceClientFactory, logger, hostValidator ?? new OutboundHostValidator(config?.GetSection("OutboundHostValidator")?.Get<OutboundHostValidatorOptions>()))
         {
             _activityTaskQueue = activityTaskQueue ?? throw new ArgumentNullException(nameof(activityTaskQueue));
             _adapterOptions = options ?? config?.GetSection("CloudAdapterOptions")?.Get<AdapterOptions>() ?? new AdapterOptions();
             _responseQueue = new ChannelResponseQueue(Logger);
-            _hostValidator = hostValidator ?? new OutboundHostValidator(config?.GetSection("OutboundHostValidator")?.Get<OutboundHostValidatorOptions>());
-
             if (middlewares != null)
             {
                 foreach (var middleware in middlewares)
@@ -303,10 +300,10 @@ namespace Microsoft.Agents.Hosting.AspNetCore
         {
             // Shared allowed-hosts control (opt-in, disabled by default). Evaluated unconditionally so
             // that the allowlist blocks disallowed hosts even when identity is null (no token claims).
-            if (_hostValidator != null
-                && _hostValidator.Enabled
+            if (HostValidator != null
+                && HostValidator.Enabled
                 && !string.IsNullOrWhiteSpace(activity.ServiceUrl)
-                && !_hostValidator.IsAllowed(activity.ServiceUrl))
+                && !HostValidator.IsAllowed(activity.ServiceUrl))
             {
                 CloudAdapterLog.LogServiceUrlHostNotAllowed(Logger, activity.ServiceUrl);
                 return false;
@@ -324,7 +321,7 @@ namespace Microsoft.Agents.Hosting.AspNetCore
                 var validActivityUri = Uri.TryCreate(activity.ServiceUrl, UriKind.Absolute, out var activityUrl);
                 if (!validClaimUri || !validActivityUri || !string.Equals(claimUrl.Host, activityUrl.Host, StringComparison.OrdinalIgnoreCase))
                 {
-                    if (_hostValidator.Enabled)
+                    if (HostValidator.Enabled)
                     {
                         CloudAdapterLog.LogInvalidServiceUrl(Logger, serviceUrlClaim.Value, activity.ServiceUrl);
                         return false;

--- a/src/tests/Microsoft.Agents.Builder.Tests/ChannelServiceAdapterBaseTests.cs
+++ b/src/tests/Microsoft.Agents.Builder.Tests/ChannelServiceAdapterBaseTests.cs
@@ -128,6 +128,23 @@ namespace Microsoft.Agents.Builder.Tests
         }
 
         [Fact]
+        public async Task ContinueConversationAsync_ShouldRejectDisallowedServiceUrl()
+        {
+            // Arrange
+            var factory = CreateMockChannelServiceClientFactory();
+            var adapter = new TestChannelAdapter(
+                factory.Object,
+                new OutboundHostValidator(new OutboundHostValidatorOptions { Enabled = true, IncludeDefaultMicrosoftHosts = false }));
+
+            // Act & Assert
+            await Assert.ThrowsAsync<ArgumentException>(
+                () => adapter.ContinueConversationAsync(new ClaimsIdentity(), _reference, ContinueCallback, CancellationToken.None));
+            factory.Verify(
+                x => x.CreateConnectorClientAsync(It.IsAny<ITurnContext>(), It.IsAny<string>(), It.IsAny<IList<string>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        [Fact]
         public async Task ContinueConversationAsync_ShouldSendMessageWithClaims()
         {
             // Arrange
@@ -413,6 +430,30 @@ namespace Microsoft.Agents.Builder.Tests
         }
 
         [Fact]
+        public async Task CreateConversationAsync_ShouldRejectDisallowedServiceUrl()
+        {
+            // Arrange
+            var factory = CreateMockChannelServiceClientFactory();
+            var adapter = new TestChannelAdapter(
+                factory.Object,
+                new OutboundHostValidator(new OutboundHostValidatorOptions { Enabled = true, IncludeDefaultMicrosoftHosts = false }));
+
+            // Act & Assert
+            await Assert.ThrowsAsync<ArgumentException>(
+                () => adapter.CreateConversationAsync(
+                    new ClaimsIdentity(),
+                    Channels.Test,
+                    "https://evil.example.com",
+                    null,
+                    new ConversationParameters(),
+                    ContinueCallback,
+                    CancellationToken.None));
+            factory.Verify(
+                x => x.CreateConnectorClientAsync(It.IsAny<ITurnContext>(), It.IsAny<string>(), It.IsAny<IList<string>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        [Fact]
         public async Task SendActivitiesAsync_ShouldNotUseConnectorForExpectReplies()
         {
             // Arrange
@@ -510,8 +551,8 @@ namespace Microsoft.Agents.Builder.Tests
 
         private class TestChannelAdapter : ChannelServiceAdapterBase
         {
-            public TestChannelAdapter(IChannelServiceClientFactory channelServiceClientFactory)
-                : base(channelServiceClientFactory)
+            public TestChannelAdapter(IChannelServiceClientFactory channelServiceClientFactory, IOutboundHostValidator hostValidator = null)
+                : base(channelServiceClientFactory, hostValidator: hostValidator)
             {
             }
         }

--- a/src/tests/Microsoft.Agents.Builder.Tests/ChannelServiceAdapterBaseTests.cs
+++ b/src/tests/Microsoft.Agents.Builder.Tests/ChannelServiceAdapterBaseTests.cs
@@ -552,7 +552,7 @@ namespace Microsoft.Agents.Builder.Tests
         private class TestChannelAdapter : ChannelServiceAdapterBase
         {
             public TestChannelAdapter(IChannelServiceClientFactory channelServiceClientFactory, IOutboundHostValidator hostValidator = null)
-                : base(channelServiceClientFactory, hostValidator: hostValidator)
+                : base(channelServiceClientFactory, null, hostValidator)
             {
             }
         }

--- a/src/tests/Microsoft.Agents.Builder.Tests/ChannelServiceAdapterBaseTests.cs
+++ b/src/tests/Microsoft.Agents.Builder.Tests/ChannelServiceAdapterBaseTests.cs
@@ -441,9 +441,33 @@ namespace Microsoft.Agents.Builder.Tests
             // Act & Assert
             await Assert.ThrowsAsync<ArgumentException>(
                 () => adapter.CreateConversationAsync(
-                    new ClaimsIdentity(),
+                    new ClaimsIdentity([new Claim("aud", "agent-id")]),
                     Channels.Test,
                     "https://evil.example.com",
+                    null,
+                    new ConversationParameters(),
+                    ContinueCallback,
+                    CancellationToken.None));
+            factory.Verify(
+                x => x.CreateConnectorClientAsync(It.IsAny<ITurnContext>(), It.IsAny<string>(), It.IsAny<IList<string>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task CreateConversationAsync_ShouldRejectDisallowedDefaultServiceUrl()
+        {
+            // Arrange
+            var factory = CreateMockChannelServiceClientFactory();
+            var adapter = new TestChannelAdapter(
+                factory.Object,
+                new OutboundHostValidator(new OutboundHostValidatorOptions { Enabled = true, IncludeDefaultMicrosoftHosts = false }));
+
+            // Act & Assert
+            await Assert.ThrowsAsync<ArgumentException>(
+                () => adapter.CreateConversationAsync(
+                    new ClaimsIdentity([new Claim("aud", "agent-id")]),
+                    Channels.Test,
+                    null,
                     null,
                     new ConversationParameters(),
                     ContinueCallback,


### PR DESCRIPTION
Fixes #972

## Description
This pull request strengthens outbound service URL validation in the `ChannelServiceAdapterBase` and its consumers, ensuring that only allowed hosts can be used for outbound connections. It introduces a new `IOutboundHostValidator` optional parameter, applies validation checks in key methods, and updates tests to verify this behavior.

**Outbound host validation enhancements:**

* Added an optional `IOutboundHostValidator` parameter to the `ChannelServiceAdapterBase` constructor and exposed it via a protected property, enabling host validation in adapters. [[1]](diffhunk://#diff-7284f34e8ecfaae1391e7aef5a8d109a7eb06123db969f7530d40d5ae4fcfcb4R32-R36) [[2]](diffhunk://#diff-7284f34e8ecfaae1391e7aef5a8d109a7eb06123db969f7530d40d5ae4fcfcb4R46-R50)
* Implemented `ValidateOutboundServiceUrl` method and invoked it in `CreateConversationAsync` and `ProcessProactiveAsync` to enforce host restrictions before proceeding with outbound operations. [[1]](diffhunk://#diff-7284f34e8ecfaae1391e7aef5a8d109a7eb06123db969f7530d40d5ae4fcfcb4R156) [[2]](diffhunk://#diff-7284f34e8ecfaae1391e7aef5a8d109a7eb06123db969f7530d40d5ae4fcfcb4R211) [[3]](diffhunk://#diff-7284f34e8ecfaae1391e7aef5a8d109a7eb06123db969f7530d40d5ae4fcfcb4R289-R298)

**CloudAdapter integration:**

* Updated `CloudAdapter` to pass the `hostValidator` to the base class and removed redundant local storage, ensuring consistent host validation logic. Also updated host validation references in the adapter. [[1]](diffhunk://#diff-177240223108fa2f1e97c9ce015809724c4e5f280d8a28f63b5ea555601b7789L38) [[2]](diffhunk://#diff-177240223108fa2f1e97c9ce015809724c4e5f280d8a28f63b5ea555601b7789L59-L65) [[3]](diffhunk://#diff-177240223108fa2f1e97c9ce015809724c4e5f280d8a28f63b5ea555601b7789L306-R306) [[4]](diffhunk://#diff-177240223108fa2f1e97c9ce015809724c4e5f280d8a28f63b5ea555601b7789L327-R324)

**Unit test improvements:**

* Added tests to verify that disallowed service URLs are rejected in `ContinueConversationAsync` and `CreateConversationAsync`, and ensured that connector clients are not created in these cases. [[1]](diffhunk://#diff-d79e7b81e26b12c1e04db1fe0017efa5e8fdfb1750ffe48d93e4106f034a1bf1R130-R146) [[2]](diffhunk://#diff-d79e7b81e26b12c1e04db1fe0017efa5e8fdfb1750ffe48d93e4106f034a1bf1R432-R455) [[3]](diffhunk://#diff-d79e7b81e26b12c1e04db1fe0017efa5e8fdfb1750ffe48d93e4106f034a1bf1L513-R555)

## Testing
These images show the Proactive agent sample working after the changes.
<img width="1430" height="476" alt="image" src="https://github.com/user-attachments/assets/4710ba05-dd82-45a7-a418-f1d49a9840be" />
