### PR TITLE
Return unsupported for extended agent cards

### DIFF
--- a/src/libraries/Extensions/Microsoft.Agents.Extensions.A2A/A2AAdapter.cs
+++ b/src/libraries/Extensions/Microsoft.Agents.Extensions.A2A/A2AAdapter.cs
@@ -104,6 +104,7 @@ public class A2AAdapter : ChannelAdapter, IA2AHttpAdapter
             Skills = [],
             Capabilities = new AgentCapabilities()
             {
+                ExtendedAgentCard = false,
                 Streaming = true,
             },
             SupportedInterfaces = [],
@@ -247,9 +248,25 @@ public class A2AAdapter : ChannelAdapter, IA2AHttpAdapter
         return cache ? _a2aAgentContext.GetOrAdd(agentContext.RequestId, agentContext) : agentContext;
     }
 
-    private A2AServer GetA2AServerForAgent(AgentRequestContext agentContext)
+    private A2AServerWithoutExtendedAgentCard GetA2AServerForAgent(AgentRequestContext agentContext)
     {
-        return new A2AServer(agentContext, _taskStore, _a2aNotifier, _a2aServerLogger, _a2aServerOptions);
+        return new A2AServerWithoutExtendedAgentCard(agentContext, _taskStore, _a2aNotifier, _a2aServerLogger, _a2aServerOptions);
+    }
+
+    private sealed class A2AServerWithoutExtendedAgentCard(
+        IAgentHandler handler,
+        ITaskStore taskStore,
+        ChannelEventNotifier notifier,
+        ILogger<A2AServer> logger,
+        A2AServerOptions options)
+        : A2AServer(handler, taskStore, notifier, logger, options)
+    {
+        public override Task<AgentCard> GetExtendedAgentCardAsync(
+            GetExtendedAgentCardRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            throw new A2AException("Extended agent cards are not supported.", A2AErrorCode.UnsupportedOperation);
+        }
     }
 
     internal async Task ExecuteAgentTurnAsync(string requestId, ClaimsIdentity identity, IAgent agent, RequestContext context, AgentEventQueue eventQueue, CancellationToken cancellationToken)

--- a/src/tests/Microsoft.Agents.Extensions.A2A.Tests/A2AAdapterTests.cs
+++ b/src/tests/Microsoft.Agents.Extensions.A2A.Tests/A2AAdapterTests.cs
@@ -83,6 +83,10 @@ public class A2AAdapterTests
 
         // Assert
         mockHttpResponse.VerifySet(r => r.ContentType = "application/json", Times.Once);
+        mockHttpResponse.Object.Body.Position = 0;
+        var agentCard = await JsonSerializer.DeserializeAsync<AgentCard>(
+            mockHttpResponse.Object.Body, A2AJsonUtilities.DefaultOptions);
+        Assert.False(agentCard!.Capabilities.ExtendedAgentCard);
     }
 
     [Fact]
@@ -244,6 +248,35 @@ public class A2AAdapterTests
         var streamText = reader.ReadToEnd();
         Assert.NotEmpty(streamText);
         Assert.Contains("Echo: Hello", streamText);
+    }
+
+    [Fact]
+    public async Task ProcessJsonRpcGetExtendedAgentCardAsync_WhenUnsupported_ReturnsUnsupportedOperation()
+    {
+        // Arrange
+        var record = UseRecord(record =>
+        {
+            var options = new TestApplicationOptions(record.Storage);
+            return new TestApplication(options);
+        });
+
+        var jsonRpcRequest = new JsonRpcRequest
+        {
+            Id = Guid.NewGuid().ToString(),
+            Method = A2AMethods.GetExtendedAgentCard,
+            Params = JsonSerializer.SerializeToElement(new GetExtendedAgentCardRequest())
+        };
+
+        var context = CreateHttpContext(JsonSerializer.Serialize(jsonRpcRequest));
+
+        // Act
+        var result = await record.Adapter.ProcessJsonRpcAsync(context.Request, context.Response, record.Agent, CancellationToken.None);
+        await result.ExecuteAsync(context);
+
+        // Assert
+        context.Response.Body.Seek(0, SeekOrigin.Begin);
+        using var response = await JsonDocument.ParseAsync(context.Response.Body);
+        Assert.Equal((int)A2AErrorCode.UnsupportedOperation, response.RootElement.GetProperty("error").GetProperty("code").GetInt32());
     }
 
     #endregion


### PR DESCRIPTION
## Summary

- explicitly advertise extended agent cards as unsupported in the generated agent card
- return `UnsupportedOperationError` (`-32004`) from the custom Agents SDK JSON-RPC path
- add integration coverage for the public agent card and extended-card JSON-RPC request

## Context

The Agents SDK maps its own A2A endpoints and uses local HTTP/JSON-RPC processors rather than the a2a-dotnet ASP.NET Core endpoints. Those processors delegate to an `A2AServer`, whose current preview2 implementation returns `ExtendedAgentCardNotConfiguredError` (`-32007`) even though this integration does not advertise the capability. The adapter-specific server override keeps the custom endpoint consistent with its generated agent card.

The corresponding upstream server fix is a2aproject/a2a-dotnet#475.

This PR is stacked on #698 because the A2A extension has not yet merged to `main`. Its diff against `users/tracyboehrer/a2a-dotnet-int` contains only this compliance fix.

## TCK failure

`tests/compatibility/core_operations/test_error_handling.py::TestCapabilityExtendedCard::test_extended_card_not_supported_jsonrpc`

```text
CORE-CAP-003 [Extended agent card operations return error when not supported] failed on jsonrpc: Expected error code -32004 (UnsupportedOperationError), got -32007
```

## Tests

- `dotnet test src/tests/Microsoft.Agents.Extensions.A2A.Tests/Microsoft.Agents.Extensions.A2A.Tests.csproj --no-restore --nologo`