### PR TITLE
Add metadata validation checks.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,31 @@ jobs:
     - name: Build
       run: dotnet build --no-restore -c debug AgentSdk.proj
 
+    - name: Validate Teams API metadata
+      shell: pwsh
+      env:
+        PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      run: |
+        $validatorArguments = @(
+          "run",
+          "--project", "scripts/TeamsApiDrift/Microsoft.Agents.TeamsApiDrift.csproj",
+          "-c", "Debug",
+          "--no-build",
+          "--",
+          "validate-metadata",
+          "--assembly", "bin/Debug/CplTeams/net8.0/Microsoft.Agents.Extensions.MSTeams.dll",
+          "--assembly", "bin/Debug/CplTeams/net10.0/Microsoft.Agents.Extensions.MSTeams.dll",
+          "--manifest", "scripts/TeamsApiDrift/teams-api-usage.json",
+          "--capabilities", "scripts/TeamsApiDrift/teams-capabilities.json",
+          "--props", "Directory.Packages.props",
+          "--repository-root", "$env:GITHUB_WORKSPACE"
+        )
+        if (-not [string]::IsNullOrWhiteSpace($env:PR_BASE_SHA)) {
+          $validatorArguments += @("--base-ref", "$env:PR_BASE_SHA")
+        }
+        & dotnet @validatorArguments
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
     - name: Package
       run: dotnet pack --no-build --no-restore -c debug src/Microsoft.Agents.SDK.sln 
 

--- a/scripts/TeamsApiDrift/ComparisonAndUsage.cs
+++ b/scripts/TeamsApiDrift/ComparisonAndUsage.cs
@@ -202,6 +202,9 @@ public static partial class AssemblyUsageCollector
         var pdbPath = Path.ChangeExtension(assemblyPath, ".pdb");
         if (!File.Exists(pdbPath)) return [];
         using var stream = File.OpenRead(pdbPath);
+        Span<byte> signature = stackalloc byte[4];
+        if (stream.Read(signature) != signature.Length || !signature.SequenceEqual("BSJB"u8)) return [];
+        stream.Position = 0;
         using var provider = MetadataReaderProvider.FromPortablePdbStream(stream);
         var reader = provider.GetMetadataReader();
         return reader.Documents.Select(handle => Paths.Normalize(reader.GetString(reader.GetDocument(handle).Name)))

--- a/scripts/TeamsApiDrift/Contracts.cs
+++ b/scripts/TeamsApiDrift/Contracts.cs
@@ -57,6 +57,7 @@ public sealed class UsageManifest
     public string DeclaredVersion { get; set; } = string.Empty;
     public string SourceRoot { get; set; } = PackageConstants.SourceRoot;
     public List<UsageEntry> Usages { get; set; } = [];
+    public SourceReview? SourceReview { get; set; }
 }
 
 public sealed class UsageEntry
@@ -73,6 +74,13 @@ public sealed class CapabilityDocument
     public int SchemaVersion { get; set; } = 1;
     public string Package { get; set; } = PackageConstants.PackageId;
     public Dictionary<string, Capability> Capabilities { get; set; } = [];
+    public SourceReview? SourceReview { get; set; }
+}
+
+public sealed class SourceReview
+{
+    public string Outcome { get; set; } = string.Empty;
+    public string Reason { get; set; } = string.Empty;
 }
 
 public sealed class Capability
@@ -103,6 +111,18 @@ public sealed record UsageValidation(
     IReadOnlyList<string> Warnings,
     IReadOnlyList<string> MissingSymbols,
     IReadOnlyList<string> MissingMembers);
+
+public sealed record MetadataValidation(
+    int SchemaVersion,
+    bool Valid,
+    IReadOnlyList<MetadataFinding> Findings);
+
+public sealed record MetadataFinding(
+    string RuleId,
+    string Path,
+    string Message,
+    string Fix,
+    string? Subject = null);
 
 public sealed record FindingsResult(
     int SchemaVersion,

--- a/scripts/TeamsApiDrift/DriftPipeline.cs
+++ b/scripts/TeamsApiDrift/DriftPipeline.cs
@@ -95,7 +95,7 @@ public static class FindingClassifier
             RecommendedAction(classification, category, change));
     }
 
-    private static KeyValuePair<string?, Capability?> MatchCapability(string symbol, CapabilityDocument document)
+    internal static KeyValuePair<string?, Capability?> MatchCapability(string symbol, CapabilityDocument document)
     {
         return document.Capabilities
             .Select(item => new

--- a/scripts/TeamsApiDrift/MetadataValidation.cs
+++ b/scripts/TeamsApiDrift/MetadataValidation.cs
@@ -1,0 +1,439 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+
+namespace Microsoft.Agents.TeamsApiDrift;
+
+public static class MetadataValidator
+{
+    internal const string UsageStaleRule = "compat/teams-api-usage-manifest-stale";
+    internal const string UsageReviewRule = "compat/teams-api-usage-review-missing";
+    internal const string CapabilitiesStaleRule = "compat/teams-api-capabilities-stale";
+    internal const string CapabilitiesReviewRule = "compat/teams-api-capabilities-review-missing";
+    internal const string UsageReviewOutcome = "no-usage-metadata-change";
+    internal const string CapabilitiesReviewOutcome = "no-capability-metadata-change";
+
+    private const string ProjectFile = "src/libraries/Extensions/Microsoft.Agents.Extensions.MSTeams/Microsoft.Agents.Extensions.MSTeams.csproj";
+
+    public static MetadataValidation Validate(
+        UsageManifest manifest,
+        CapabilityDocument capabilities,
+        CollectedUsage collected,
+        string declaredVersion,
+        string repositoryRoot,
+        string manifestPath,
+        string capabilitiesPath,
+        string? baseRef = null)
+    {
+        var root = Path.GetFullPath(repositoryRoot);
+        var manifestRelativePath = RepositoryPath(root, manifestPath);
+        var capabilitiesRelativePath = RepositoryPath(root, capabilitiesPath);
+        var findings = new List<MetadataFinding>();
+
+        ValidateManifest(manifest, collected, declaredVersion, root, manifestRelativePath, findings);
+        ValidateCapabilities(manifest, capabilities, capabilitiesRelativePath, findings);
+        ValidateReviewShape(manifest.SourceReview, UsageReviewOutcome, UsageStaleRule, manifestRelativePath, findings);
+        ValidateReviewShape(capabilities.SourceReview, CapabilitiesReviewOutcome, CapabilitiesStaleRule, capabilitiesRelativePath, findings);
+
+        var git = GitChangeSet.TryCreate(root, baseRef);
+        if (git is not null)
+        {
+            ValidateChangeReviews(root, git, manifest, capabilities, manifestRelativePath, capabilitiesRelativePath, findings);
+        }
+
+        var ordered = findings
+            .OrderBy(item => item.Path, StringComparer.Ordinal)
+            .ThenBy(item => item.RuleId, StringComparer.Ordinal)
+            .ThenBy(item => item.Message, StringComparer.Ordinal)
+            .ToArray();
+        return new MetadataValidation(1, ordered.Length == 0, ordered);
+    }
+
+    private static void ValidateManifest(
+        UsageManifest manifest,
+        CollectedUsage collected,
+        string declaredVersion,
+        string root,
+        string manifestPath,
+        List<MetadataFinding> findings)
+    {
+        if (manifest.SchemaVersion != 1)
+        {
+            Add(findings, UsageStaleRule, manifestPath, "Usage manifest must use schemaVersion 1.", "Set schemaVersion to 1.");
+        }
+        if (manifest.Package != PackageConstants.PackageId)
+        {
+            Add(findings, UsageStaleRule, manifestPath, $"Usage manifest must describe {PackageConstants.PackageId}.", $"Set package to {JsonSerializer.Serialize(PackageConstants.PackageId)}.");
+        }
+        if (manifest.DeclaredVersion != declaredVersion)
+        {
+            Add(findings, UsageStaleRule, manifestPath, $"Manifest version {manifest.DeclaredVersion} does not match Directory.Packages.props version {declaredVersion}.", $"Set declaredVersion to {JsonSerializer.Serialize(declaredVersion)}.");
+        }
+        if (Paths.Normalize(manifest.SourceRoot).TrimEnd('/') != Paths.Normalize(PackageConstants.SourceRoot))
+        {
+            Add(findings, UsageStaleRule, manifestPath, $"sourceRoot must be {JsonSerializer.Serialize(PackageConstants.SourceRoot)}.", "Restore the MSTeams source root.");
+        }
+
+        foreach (var duplicate in manifest.Usages.GroupBy(item => item.UpstreamSymbol, StringComparer.Ordinal).Where(group => group.Count() > 1))
+        {
+            Add(findings, UsageStaleRule, manifestPath, $"Usage manifest declares {duplicate.Key} more than once.", "Merge the duplicate usage entries.", duplicate.Key);
+        }
+
+        var manifestBySymbol = manifest.Usages
+            .Where(item => !string.IsNullOrWhiteSpace(item.UpstreamSymbol))
+            .GroupBy(item => item.UpstreamSymbol, StringComparer.Ordinal)
+            .ToDictionary(group => group.Key, group => group.First(), StringComparer.Ordinal);
+        var collectedBySymbol = collected.Usages.ToDictionary(item => item.UpstreamSymbol, StringComparer.Ordinal);
+        foreach (var actual in collected.Usages)
+        {
+            if (!manifestBySymbol.TryGetValue(actual.UpstreamSymbol, out var expected))
+            {
+                Add(findings, UsageStaleRule, manifestPath, $"Built extension usage is missing from the manifest: {actual.UpstreamSymbol}.", "Add the symbol and its affected source files to the usage manifest.", actual.UpstreamSymbol);
+                continue;
+            }
+
+            if (expected.Members.Count > 0)
+            {
+                foreach (var member in actual.Members.Except(expected.Members, StringComparer.Ordinal))
+                {
+                    Add(findings, UsageStaleRule, manifestPath, $"Built extension member usage is missing from the manifest: {actual.UpstreamSymbol}.{member}.", "Add the member to the usage entry.", actual.UpstreamSymbol);
+                }
+                foreach (var member in expected.Members.Except(actual.Members, StringComparer.Ordinal))
+                {
+                    Add(findings, UsageStaleRule, manifestPath, $"Manifest member is stale; the built extension does not reference {actual.UpstreamSymbol}.{member}.", "Remove the stale member or restore its usage.", actual.UpstreamSymbol);
+                }
+            }
+            if (!string.Equals(actual.Exposure, expected.Exposure, StringComparison.Ordinal))
+            {
+                Add(findings, UsageStaleRule, manifestPath, $"{actual.UpstreamSymbol} has {actual.Exposure} exposure in the built extension but the manifest records {expected.Exposure}.", $"Set exposure to {JsonSerializer.Serialize(actual.Exposure)}.", actual.UpstreamSymbol);
+            }
+        }
+
+        foreach (var expected in manifest.Usages)
+        {
+            if (string.IsNullOrWhiteSpace(expected.UpstreamSymbol))
+            {
+                Add(findings, UsageStaleRule, manifestPath, "Every usage must include a non-empty upstreamSymbol.", "Repair or remove the malformed usage entry.");
+                continue;
+            }
+            if (!collectedBySymbol.ContainsKey(expected.UpstreamSymbol))
+            {
+                Add(findings, UsageStaleRule, manifestPath, $"Manifest usage is stale; the built extension does not reference {expected.UpstreamSymbol}.", "Remove the stale usage entry or restore its usage.", expected.UpstreamSymbol);
+            }
+            if (expected.Files.Count == 0)
+            {
+                Add(findings, UsageStaleRule, manifestPath, $"Usage {expected.UpstreamSymbol} must identify at least one affected source file.", "Add the affected MSTeams source path.", expected.UpstreamSymbol);
+            }
+            foreach (var file in expected.Files)
+            {
+                ValidateSourceFile(manifest, collected, root, manifestPath, expected.UpstreamSymbol, file, findings);
+            }
+        }
+    }
+
+    private static void ValidateSourceFile(
+        UsageManifest manifest,
+        CollectedUsage collected,
+        string root,
+        string manifestPath,
+        string symbol,
+        string file,
+        List<MetadataFinding> findings)
+    {
+        var sourceRoot = Path.GetFullPath(Path.Combine(root, manifest.SourceRoot));
+        var fullPath = Path.GetFullPath(Path.Combine(root, file));
+        if (!Paths.IsContainedBy(root, sourceRoot) || !Paths.IsContainedBy(sourceRoot, fullPath) || !File.Exists(fullPath))
+        {
+            Add(findings, UsageStaleRule, manifestPath, $"Usage {symbol} references missing or unsafe source file {JsonSerializer.Serialize(file)}.", "Replace it with an existing file under the MSTeams source root.", symbol);
+            return;
+        }
+
+        var collectedFiles = collected.SourceFiles ?? [];
+        if (collectedFiles.Count > 0 && !collectedFiles.Any(document => Paths.Normalize(document).EndsWith(Paths.Normalize(file), StringComparison.OrdinalIgnoreCase)))
+        {
+            Add(findings, UsageStaleRule, manifestPath, $"Usage {symbol} source file is absent from the portable PDB: {file}.", "Use a compiled MSTeams source file or correct the manifest path.", symbol);
+        }
+    }
+
+    private static void ValidateCapabilities(
+        UsageManifest manifest,
+        CapabilityDocument document,
+        string path,
+        List<MetadataFinding> findings)
+    {
+        if (document.SchemaVersion != 1)
+        {
+            Add(findings, CapabilitiesStaleRule, path, "Capabilities metadata must use schemaVersion 1.", "Set schemaVersion to 1.");
+        }
+        if (document.Package != PackageConstants.PackageId)
+        {
+            Add(findings, CapabilitiesStaleRule, path, $"Capabilities metadata must describe {PackageConstants.PackageId}.", $"Set package to {JsonSerializer.Serialize(PackageConstants.PackageId)}.");
+        }
+        if (document.Capabilities.Count == 0)
+        {
+            Add(findings, CapabilitiesStaleRule, path, "Capabilities metadata must contain at least one capability.", "Restore the capability mappings.");
+        }
+        foreach (var (name, capability) in document.Capabilities)
+        {
+            if (string.IsNullOrWhiteSpace(name) || capability.Owners.Count == 0 || string.IsNullOrWhiteSpace(capability.AdoptionPolicy) ||
+                capability.UpstreamNamespaces.Count + capability.UpstreamTypes.Count == 0)
+            {
+                Add(findings, CapabilitiesStaleRule, path, $"Capability {name} must include owners, an adoptionPolicy, and at least one upstream namespace or type.", "Repair the malformed capability mapping.", name);
+            }
+        }
+        foreach (var usage in manifest.Usages.Where(item => !string.IsNullOrWhiteSpace(item.UpstreamSymbol)))
+        {
+            if (FindingClassifier.MatchCapability(usage.UpstreamSymbol, document).Value is null)
+            {
+                Add(findings, CapabilitiesStaleRule, path, $"No capability maps usage symbol {usage.UpstreamSymbol}.", "Add an exact upstreamTypes entry or a containing upstreamNamespaces entry.", usage.UpstreamSymbol);
+            }
+        }
+    }
+
+    private static void ValidateReviewShape(
+        SourceReview? review,
+        string expectedOutcome,
+        string rule,
+        string path,
+        List<MetadataFinding> findings)
+    {
+        if (review is null) return;
+        if (review.Outcome != expectedOutcome || string.IsNullOrWhiteSpace(review.Reason))
+        {
+            Add(findings, rule, path, $"sourceReview must use outcome {JsonSerializer.Serialize(expectedOutcome)} and include a non-empty reason.", "Correct sourceReview or remove it when the document contains a substantive metadata update.");
+        }
+    }
+
+    private static void ValidateChangeReviews(
+        string root,
+        GitChangeSet git,
+        UsageManifest currentManifest,
+        CapabilityDocument currentCapabilities,
+        string manifestPath,
+        string capabilitiesPath,
+        List<MetadataFinding> findings)
+    {
+        var baseManifest = git.ReadJson<UsageManifest>(manifestPath);
+        var baseCapabilities = git.ReadJson<CapabilityDocument>(capabilitiesPath);
+        if (baseManifest is null || baseCapabilities is null) return;
+
+        var currentUsageFiles = currentManifest.Usages.SelectMany(item => item.Files).Select(Paths.Normalize).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var baseUsageFiles = baseManifest.Usages.SelectMany(item => item.Files).Select(Paths.Normalize).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var sourcePrefix = Paths.Normalize(PackageConstants.SourceRoot).TrimEnd('/') + "/";
+        var changedSourceFiles = git.ChangedFiles
+            .Where(file => file.StartsWith(sourcePrefix, StringComparison.OrdinalIgnoreCase) && file.EndsWith(".cs", StringComparison.OrdinalIgnoreCase))
+            .ToArray();
+        var usageRelevant = changedSourceFiles.Where(file =>
+        {
+            var newFile = git.ReadBaseFile(file) is null && File.Exists(Path.Combine(root, file));
+            return newFile || currentUsageFiles.Contains(file) || baseUsageFiles.Contains(file) ||
+                ContainsTeamsReference(git.ReadBaseFile(file)) || ContainsTeamsReference(ReadWorkingFile(root, file));
+        }).ToList();
+        if (git.ChangedFiles.Contains(ProjectFile)) usageRelevant.Add(ProjectFile);
+        usageRelevant = usageRelevant.Distinct(StringComparer.OrdinalIgnoreCase).Order(StringComparer.OrdinalIgnoreCase).ToList();
+
+        if (usageRelevant.Count > 0)
+        {
+            var fresh = git.MetadataChangeIsFresh(usageRelevant, manifestPath);
+            var substantiveUpdate = !SemanticEqual(baseManifest.Usages, currentManifest.Usages);
+            var explicitReview = ReviewChanged(baseManifest.SourceReview, currentManifest.SourceReview, UsageReviewOutcome);
+            if (!fresh || (!substantiveUpdate && !explicitReview))
+            {
+                Add(findings, UsageReviewRule, manifestPath, $"{usageRelevant.Count} Teams API usage-related source file(s) changed without a fresh usage-manifest update or non-impact review.", "Update usages, or update sourceReview with outcome \"no-usage-metadata-change\" and a specific reason.", string.Join(", ", usageRelevant.Take(4)));
+            }
+        }
+
+        var baseSymbols = baseManifest.Usages.Select(item => item.UpstreamSymbol).ToHashSet(StringComparer.Ordinal);
+        var currentSymbols = currentManifest.Usages.Select(item => item.UpstreamSymbol).ToHashSet(StringComparer.Ordinal);
+        var affectedSymbols = baseSymbols.SymmetricExcept(currentSymbols).Order(StringComparer.Ordinal).ToArray();
+        if (affectedSymbols.Length > 0 && usageRelevant.Count > 0)
+        {
+            var fresh = git.MetadataChangeIsFresh(usageRelevant, capabilitiesPath);
+            var targetedUpdate = fresh && affectedSymbols.All(symbol =>
+                !string.Equals(CapabilityFingerprint(baseCapabilities, symbol), CapabilityFingerprint(currentCapabilities, symbol), StringComparison.Ordinal));
+            var explicitReview = ReviewChanged(baseCapabilities.SourceReview, currentCapabilities.SourceReview, CapabilitiesReviewOutcome);
+            if (!targetedUpdate && !(fresh && explicitReview))
+            {
+                Add(findings, CapabilitiesReviewRule, capabilitiesPath, $"Teams API usage symbols changed without a targeted capability update or fresh non-impact review: {string.Join(", ", affectedSymbols)}.", "Update the affected capability mapping, or update sourceReview with outcome \"no-capability-metadata-change\" and a specific reason.", string.Join(", ", affectedSymbols.Take(4)));
+            }
+        }
+    }
+
+    private static string? CapabilityFingerprint(CapabilityDocument document, string symbol)
+    {
+        var match = FindingClassifier.MatchCapability(symbol, document);
+        return match.Value is null ? null : $"{match.Key}:{JsonSerializer.Serialize(match.Value, ToolJson.Options)}";
+    }
+
+    private static bool ReviewChanged(SourceReview? before, SourceReview? after, string outcome)
+        => !SemanticEqual(before, after) && after?.Outcome == outcome && !string.IsNullOrWhiteSpace(after.Reason);
+
+    private static bool SemanticEqual<T>(T before, T after)
+        => string.Equals(JsonSerializer.Serialize(before, ToolJson.Options), JsonSerializer.Serialize(after, ToolJson.Options), StringComparison.Ordinal);
+
+    private static bool ContainsTeamsReference(string? text)
+        => text?.Contains(PackageConstants.PackageId, StringComparison.Ordinal) == true;
+
+    private static string? ReadWorkingFile(string root, string relativePath)
+    {
+        var path = Path.Combine(root, relativePath);
+        return File.Exists(path) ? File.ReadAllText(path) : null;
+    }
+
+    private static string RepositoryPath(string root, string path)
+    {
+        var fullPath = Path.GetFullPath(Path.IsPathRooted(path) ? path : Path.Combine(root, path));
+        if (!Paths.IsContainedBy(root, fullPath)) throw new InvalidDataException($"Metadata path escapes the repository: {path}.");
+        return Paths.Normalize(Path.GetRelativePath(root, fullPath));
+    }
+
+    private static void Add(List<MetadataFinding> findings, string rule, string path, string message, string fix, string? subject = null)
+        => findings.Add(new MetadataFinding(rule, Paths.Normalize(path), message, fix, subject));
+}
+
+internal sealed class GitChangeSet
+{
+    private readonly GitRepository _repository;
+
+    private GitChangeSet(GitRepository repository, string @base, HashSet<string> workingFiles, HashSet<string> changedFiles)
+    {
+        _repository = repository;
+        Base = @base;
+        WorkingFiles = workingFiles;
+        ChangedFiles = changedFiles;
+    }
+
+    public string Base { get; }
+    public HashSet<string> WorkingFiles { get; }
+    public HashSet<string> ChangedFiles { get; }
+
+    public static GitChangeSet? TryCreate(string root, string? explicitBaseRef)
+    {
+        var repository = new GitRepository(root);
+        if (!repository.Succeeds("rev-parse", "--is-inside-work-tree"))
+        {
+            if (!string.IsNullOrWhiteSpace(explicitBaseRef)) throw new InvalidOperationException($"Unable to resolve Git base ref {explicitBaseRef}.");
+            return null;
+        }
+
+        var baseRef = ResolveBaseRef(repository, explicitBaseRef);
+        var mergeBase = repository.Text("merge-base", "HEAD", baseRef)?.Trim();
+        if (string.IsNullOrWhiteSpace(mergeBase))
+        {
+            if (!string.IsNullOrWhiteSpace(explicitBaseRef)) throw new InvalidOperationException($"Unable to resolve Git base ref {explicitBaseRef}.");
+            return null;
+        }
+
+        var committed = repository.NullList("diff", "--name-only", "--no-renames", "-z", mergeBase, "HEAD");
+        var working = repository.NullList("diff", "--name-only", "--no-renames", "-z", "HEAD");
+        working.UnionWith(repository.NullList("ls-files", "--others", "--exclude-standard", "-z"));
+        committed.UnionWith(working);
+        return new GitChangeSet(repository, mergeBase, working, committed);
+    }
+
+    public string? ReadBaseFile(string path) => _repository.Text("show", $"{Base}:{Paths.Normalize(path)}");
+
+    public T? ReadJson<T>(string path) where T : class
+    {
+        var text = ReadBaseFile(path);
+        if (text is null) return null;
+        try
+        {
+            return JsonSerializer.Deserialize<T>(text, ToolJson.Options);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    public bool MetadataChangeIsFresh(IReadOnlyCollection<string> sourceFiles, string metadataFile)
+    {
+        var normalizedSources = sourceFiles.Select(Paths.Normalize).ToArray();
+        var normalizedMetadata = Paths.Normalize(metadataFile);
+        if (normalizedSources.Any(WorkingFiles.Contains)) return WorkingFiles.Contains(normalizedMetadata);
+        if (WorkingFiles.Contains(normalizedMetadata)) return true;
+
+        var sourceCommit = LatestCommit(normalizedSources);
+        var metadataCommit = LatestCommit([normalizedMetadata]);
+        return sourceCommit is not null && metadataCommit is not null &&
+            (sourceCommit == metadataCommit || _repository.Succeeds("merge-base", "--is-ancestor", sourceCommit, metadataCommit));
+    }
+
+    private string? LatestCommit(IReadOnlyCollection<string> files)
+    {
+        var arguments = new List<string> { "log", "-1", "--format=%H", $"{Base}..HEAD", "--" };
+        arguments.AddRange(files);
+        var commit = _repository.Text(arguments.ToArray())?.Trim();
+        return string.IsNullOrWhiteSpace(commit) ? null : commit;
+    }
+
+    private static string ResolveBaseRef(GitRepository repository, string? explicitBaseRef)
+    {
+        var candidates = new List<string>();
+        if (!string.IsNullOrWhiteSpace(explicitBaseRef))
+        {
+            candidates.Add(explicitBaseRef);
+        }
+        else
+        {
+            var githubBase = Environment.GetEnvironmentVariable("GITHUB_BASE_REF");
+            if (!string.IsNullOrWhiteSpace(githubBase)) candidates.AddRange([$"origin/{githubBase}", githubBase]);
+            var azureBase = Environment.GetEnvironmentVariable("SYSTEM_PULLREQUEST_TARGETBRANCH");
+            if (!string.IsNullOrWhiteSpace(azureBase))
+            {
+                var branch = azureBase.Replace("refs/heads/", string.Empty, StringComparison.Ordinal);
+                candidates.AddRange([$"origin/{branch}", branch, azureBase]);
+            }
+            candidates.AddRange(["origin/main", "upstream/main", "main", "HEAD"]);
+        }
+
+        var resolved = candidates.FirstOrDefault(candidate => repository.Succeeds("rev-parse", "--verify", $"{candidate}^{{commit}}"));
+        if (resolved is null && !string.IsNullOrWhiteSpace(explicitBaseRef)) throw new InvalidOperationException($"Unable to resolve Git base ref {explicitBaseRef}.");
+        return resolved ?? "HEAD";
+    }
+}
+
+internal sealed class GitRepository(string root)
+{
+    public string? Text(params string[] arguments)
+    {
+        var result = Run(arguments);
+        return result.ExitCode == 0 ? result.Output : null;
+    }
+
+    public bool Succeeds(params string[] arguments) => Run(arguments).ExitCode == 0;
+
+    public HashSet<string> NullList(params string[] arguments)
+        => Text(arguments)?.Split('\0', StringSplitOptions.RemoveEmptyEntries).Select(Paths.Normalize).ToHashSet(StringComparer.OrdinalIgnoreCase) ?? new(StringComparer.OrdinalIgnoreCase);
+
+    private (int ExitCode, string Output) Run(IReadOnlyList<string> arguments)
+    {
+        var startInfo = new ProcessStartInfo("git")
+        {
+            WorkingDirectory = root,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            StandardOutputEncoding = Encoding.UTF8
+        };
+        foreach (var argument in arguments) startInfo.ArgumentList.Add(argument);
+        using var process = Process.Start(startInfo) ?? throw new InvalidOperationException("Unable to start Git.");
+        var errorTask = process.StandardError.ReadToEndAsync();
+        var output = process.StandardOutput.ReadToEnd();
+        process.WaitForExit();
+        _ = errorTask.GetAwaiter().GetResult();
+        return (process.ExitCode, output);
+    }
+}
+
+internal static class SetExtensions
+{
+    public static HashSet<T> SymmetricExcept<T>(this IReadOnlySet<T> left, IReadOnlySet<T> right)
+    {
+        var result = new HashSet<T>(left, left is HashSet<T> set ? set.Comparer : EqualityComparer<T>.Default);
+        result.SymmetricExceptWith(right);
+        return result;
+    }
+}

--- a/scripts/TeamsApiDrift/Program.cs
+++ b/scripts/TeamsApiDrift/Program.cs
@@ -19,6 +19,7 @@ internal static class Program
                 "compare" => await CompareAsync(options).ConfigureAwait(false),
                 "collect-usage" => CollectUsage(options),
                 "validate-usage" => ValidateUsage(options),
+                "validate-metadata" => ValidateMetadata(options),
                 "classify" => Classify(options),
                 "write-test-summary" => WriteTestSummary(options),
                 "render-report" => RenderReport(options),
@@ -63,6 +64,13 @@ internal static class Program
     {
         var assemblies = options.Many("--assembly");
         if (assemblies.Count == 0) throw new ArgumentException("At least one --assembly is required.");
+        var result = CollectUsage(assemblies);
+        ToolJson.Write(ToolJson.OutputFile(options.Required("--output"), "collected-usage.json", ".json"), result);
+        return 0;
+    }
+
+    private static CollectedUsage CollectUsage(IEnumerable<string> assemblies)
+    {
         var collected = assemblies.Select(AssemblyUsageCollector.Collect).ToArray();
         var usages = collected.SelectMany(item => item.Usages)
             .GroupBy(item => item.UpstreamSymbol, StringComparer.Ordinal)
@@ -73,9 +81,7 @@ internal static class Program
                 group.Any(item => item.Exposure == "publicly-exposed") ? "publicly-exposed" : "internal-only"))
             .ToArray();
         var sourceFiles = collected.SelectMany(item => item.SourceFiles ?? []).Distinct(StringComparer.OrdinalIgnoreCase).Order(StringComparer.OrdinalIgnoreCase).ToArray();
-        var result = new CollectedUsage(1, PackageConstants.PackageId, string.Join(",", collected.Select(item => item.Assembly)), usages, sourceFiles);
-        ToolJson.Write(ToolJson.OutputFile(options.Required("--output"), "collected-usage.json", ".json"), result);
-        return 0;
+        return new CollectedUsage(1, PackageConstants.PackageId, string.Join(",", collected.Select(item => item.Assembly)), usages, sourceFiles);
     }
 
     private static int ValidateUsage(Arguments options)
@@ -86,6 +92,28 @@ internal static class Program
             ToolJson.Read<ApiModel>(options.Required("--api-model")),
             options.Optional("--repository-root") ?? Directory.GetCurrentDirectory());
         ToolJson.Write(ToolJson.OutputFile(options.Required("--output"), "usage-validation.json", ".json"), result);
+        return result.Valid ? 0 : 1;
+    }
+
+    private static int ValidateMetadata(Arguments options)
+    {
+        var assemblies = options.Many("--assembly");
+        if (assemblies.Count == 0) throw new ArgumentException("At least one --assembly is required.");
+        var propsPath = options.Required("--props");
+        using var props = File.OpenText(propsPath);
+        var result = MetadataValidator.Validate(
+            ToolJson.Read<UsageManifest>(options.Required("--manifest")),
+            ToolJson.Read<CapabilityDocument>(options.Required("--capabilities")),
+            CollectUsage(assemblies),
+            VersionResolver.Resolve(props),
+            options.Optional("--repository-root") ?? Directory.GetCurrentDirectory(),
+            options.Required("--manifest"),
+            options.Required("--capabilities"),
+            options.Optional("--base-ref"));
+        foreach (var finding in result.Findings)
+        {
+            Console.Error.WriteLine($"TeamsApiDrift: [{finding.RuleId}] {finding.Path}: {finding.Message} Fix: {finding.Fix}");
+        }
         return result.Valid ? 0 : 1;
     }
 
@@ -152,5 +180,5 @@ internal static class Program
     }
 
     private static void PrintUsage() => Console.Error.WriteLine(
-        "Commands: resolve-version, compare, collect-usage, validate-usage, classify, write-test-summary, render-report, prepare-agent-context, validate-agent-report");
+        "Commands: resolve-version, compare, collect-usage, validate-usage, validate-metadata, classify, write-test-summary, render-report, prepare-agent-context, validate-agent-report");
 }

--- a/scripts/TeamsApiDrift/technicalDescription.md
+++ b/scripts/TeamsApiDrift/technicalDescription.md
@@ -15,6 +15,7 @@ The tool is a .NET command-line application in `scripts/TeamsApiDrift`. It reads
 | `Contracts.cs` | Defines the serialized contracts for API models, changes, usage data, findings, test summaries, and agent-report validation. |
 | `MetadataApiExtractor.cs` | Downloads or resolves package versions, selects reference/implementation assets for supported target frameworks, and extracts the public API from assembly metadata. |
 | `ComparisonAndUsage.cs` | Compares normalized API models, scans the compiled MSTeams assembly for dependency use, and validates collected use against the curated manifest. |
+| `MetadataValidation.cs` | Validates the repository metadata against built assemblies and requires fresh, document-specific review of relevant source changes. |
 | `DriftPipeline.cs` | Resolves centrally managed package versions, classifies changes, renders reports, creates bounded agent context, and validates an agent-authored report. |
 | `ToolUtilities.cs` | Supplies common argument, JSON, path-containment, hashing, and normalization helpers. |
 | `teams-api-usage.json` | Curated inventory of the `Microsoft.Teams.Apps` symbols and members intentionally used by MSTeams, including exposure and affected source files. |
@@ -22,7 +23,7 @@ The tool is a .NET command-line application in `scripts/TeamsApiDrift`. It reads
 | `teams-api-drift-instructions.md` | Constrains the optional Copilot report format, accepted evidence, required finding IDs, and advisory language. |
 | `teams-api-drift-pr.yml` | Runs drift detection for package-version pull requests or manual PR-style comparisons, publishes artifacts, and updates an internal PR comment. |
 | `teams-api-drift-scheduled.yml` | Compares the repository baseline with the latest stable package on a schedule or by manual dispatch and creates or updates an advisory issue. |
-| `Microsoft.Agents.TeamsApiDrift.Tests` | Exercises package resolution, extraction, comparison, usage validation, classification, rendering, context generation, and report validation. |
+| `Microsoft.Agents.TeamsApiDrift.Tests` | Exercises package resolution, extraction, comparison, usage and repository-metadata validation, classification, rendering, context generation, and report validation. |
 | `TeamsApiContractTests.cs` | Compile-time contract coverage that detects source-level breaks in the APIs consumed by MSTeams. |
 | `TeamsApiClientExtensionsTests.cs` | Runtime boundary tests for selected MSTeams-to-Teams API interactions. |
 
@@ -79,9 +80,11 @@ The package comparison is always **baseline → candidate**:
 
 `validate-usage` is a separate manifest-integrity check; it does not compare package versions. It accepts one API model and verifies that `teams-api-usage.json` describes valid APIs for the repository state to which the manifest belongs. In a package-update PR, that repository state has moved to the candidate, so validation uses the `after` model. During a scheduled probe, the repository has not adopted the latest release and its manifest still declares the baseline version, so validation uses the `before` model. The scheduled workflow still compares, builds, and tests the baseline against the latest stable candidate.
 
+`validate-metadata` is the ordinary repository CI gate. It does not contact a NuGet source or compare package releases. Instead, it validates the checked-in manifests against the centrally declared version and the already-built `net8.0` and `net10.0` MSTeams assemblies. When Git history is available, it also compares relevant source and metadata changes with their merge base.
+
 ## CLI commands
 
-All commands write diagnostic errors to standard error. An unhandled command error returns exit code `2`. `validate-usage` and `validate-agent-report` return `1` for an invalid result; `classify --fail-on-drift` returns `1` for blocking or required findings. Successful commands return `0`.
+All commands write diagnostic errors to standard error. An unhandled command or configuration error returns exit code `2`. `validate-usage`, `validate-metadata`, and `validate-agent-report` return `1` for an invalid result; `classify --fail-on-drift` returns `1` for blocking or required findings. Successful commands return `0`.
 
 | Command | Primary inputs | Output | Notes |
 | --- | --- | --- | --- |
@@ -89,6 +92,7 @@ All commands write diagnostic errors to standard error. An unhandled command err
 | `compare` | `--from`, optional `--to`, `--output`, repeated `--source`, optional `--config-file` | Before model, after model, raw diff, and the resolved candidate version on standard output | When `--to` is omitted, selects the latest stable version found in the configured sources. |
 | `collect-usage` | One or more `--assembly` values and `--output` | Collected dependency usage JSON | Uses assembly metadata and portable PDBs; it does not execute the MSTeams assembly. |
 | `validate-usage` | `--manifest`, `--collected`, `--api-model`, optional `--repository-root`, `--output` | Usage-validation JSON | Checks package/version alignment, symbol/member existence, source paths, PDB evidence, exposure, and stale or missing manifest entries. |
+| `validate-metadata` | Repeated `--assembly`, `--manifest`, `--capabilities`, `--props`, optional `--repository-root` and `--base-ref` | Diagnostics and exit status | Performs offline current-state validation and Git-based source-review validation. An explicitly supplied base ref must resolve. |
 | `classify` | `--comparison`, `--manifest`, `--capabilities`, `--output`, optional `--fail-on-drift` | Findings JSON | With `--fail-on-drift`, returns `1` when blocking or required findings exist. |
 | `write-test-summary` | Repeated `--check <name>=<status>` values and `--output` | Test-summary JSON | Converts workflow step outcomes into one normalized artifact. |
 | `render-report` | `--findings`, optional `--test-summary`, `--output` | Deterministic Markdown report | Always derives the maintainer-facing sections from machine-readable artifacts. |
@@ -138,9 +142,53 @@ The metadata reader includes enough signature information to identify enum value
 
 The compiled assembly/PDB scan is independent evidence. `validate-usage` compares that evidence with the manifest so that a stale or incomplete manifest cannot silently drive classification.
 
+The repository gate additionally checks the manifest against both built target frameworks. It verifies the centrally managed dependency version, symbols, tracked members, public exposure in both directions, safe existing source paths, and stale manifest entries. A non-impact acknowledgment cannot suppress these provable errors.
+
 ### Capability manifest
 
 `teams-capabilities.json` maps namespaces and, where necessary, specific types to product capability areas. A mapping supplies ownership and an adoption policy. The classifier uses the most specific matching mapping to distinguish additive APIs that require feature review from internal implementation opportunities.
+
+The .NET capabilities document keeps `owners` as maintainer labels rather than source-path patterns. Repository validation requires every usage symbol to resolve through an exact `upstreamTypes` entry or the longest matching `upstreamNamespaces` entry.
+
+### Source-review acknowledgments
+
+Relevant MSTeams changes must either update the affected metadata or record a fresh, document-specific non-impact review. For `teams-api-usage.json`, add or update this top-level property:
+
+```json
+"sourceReview": {
+  "outcome": "no-usage-metadata-change",
+  "reason": "Explain specifically why the changed source does not alter Teams API usage metadata."
+}
+```
+
+For `teams-capabilities.json`, use:
+
+```json
+"sourceReview": {
+  "outcome": "no-capability-metadata-change",
+  "reason": "Explain specifically why the changed usage symbols do not alter capability mapping or policy."
+}
+```
+
+Use an acknowledgment only after reviewing the corresponding source change. The reason must be non-empty and must differ from the review at the Git base. A usage review cannot satisfy capability review, or vice versa. For committed changes, the metadata update must be in the same commit as the relevant source change or a later commit. For staged, unstaged, or untracked source changes, the corresponding metadata file must also change in the working tree.
+
+Usage review applies to changed C# files that currently or previously reference `Microsoft.Teams.Apps`, files listed in the current or base usage manifest, new C# files, and the MSTeams project file. A substantive change to the `usages` array satisfies the review. When the set of consumed upstream symbols changes, the capability document must receive either a targeted change to the matching capability or its own fresh non-impact acknowledgment.
+
+Run the same offline check used by CI after building the solution:
+
+```powershell
+dotnet run --project scripts/TeamsApiDrift/Microsoft.Agents.TeamsApiDrift.csproj -c Debug --no-build -- `
+  validate-metadata `
+  --assembly bin/Debug/CplTeams/net8.0/Microsoft.Agents.Extensions.MSTeams.dll `
+  --assembly bin/Debug/CplTeams/net10.0/Microsoft.Agents.Extensions.MSTeams.dll `
+  --manifest scripts/TeamsApiDrift/teams-api-usage.json `
+  --capabilities scripts/TeamsApiDrift/teams-capabilities.json `
+  --props Directory.Packages.props `
+  --repository-root . `
+  --base-ref main
+```
+
+Omit `--base-ref` to let the tool use the pull-request environment or known `main` refs. Outside a Git checkout, current-state validation still runs and change-review validation is skipped.
 
 ## Generated artifacts
 
@@ -184,6 +232,10 @@ Every finding carries the raw change evidence, dependency-usage evidence where a
 
 ## Workflow integration
 
+### Main repository CI
+
+`.github/workflows/ci.yml` runs `validate-metadata` immediately after the normal Debug solution build. It reuses the built drift tool and both MSTeams assemblies with `--no-build`, passes the pull-request base SHA through the step environment, and fails before packaging when either metadata document is stale or lacks required review. Push builds still perform current-state validation without a PR base.
+
 ### Pull-request workflow
 
 `.github/workflows/teams-api-drift-pr.yml` runs on relevant pull requests and manual dispatch. It:
@@ -213,10 +265,11 @@ The feature deliberately uses multiple evidence layers:
 2. The raw comparison records every normalized API difference independently of current repository use.
 3. Assembly and PDB scanning discovers compiled MSTeams references and source locations.
 4. Usage validation checks the curated manifest against both compiled evidence and an API model.
-5. Compile-time contract tests catch source compatibility failures in selected critical contracts.
-6. Runtime boundary tests exercise selected behavior at the MSTeams boundary.
-7. Unit tests verify deterministic comparison, classification, report, security-boundary, and validation behavior.
-8. Workflow policy combines step outcomes and finding severity into the final pass/fail result.
+5. Repository metadata validation checks the built extension and requires fresh review of relevant source changes.
+6. Compile-time contract tests catch source compatibility failures in selected critical contracts.
+7. Runtime boundary tests exercise selected behavior at the MSTeams boundary.
+8. Unit tests verify deterministic comparison, classification, report, security-boundary, and validation behavior.
+9. Workflow policy combines step outcomes and finding severity into the final pass/fail result.
 
 These layers are complementary: a successful build does not replace API comparison, and an agent-authored report cannot replace deterministic validation or policy.
 

--- a/src/tests/Microsoft.Agents.TeamsApiDrift.Tests/MetadataValidationTests.cs
+++ b/src/tests/Microsoft.Agents.TeamsApiDrift.Tests/MetadataValidationTests.cs
@@ -1,0 +1,308 @@
+using System.Diagnostics;
+using Microsoft.Agents.TeamsApiDrift;
+using Xunit;
+
+namespace Microsoft.Agents.TeamsApiDrift.Tests;
+
+public sealed class MetadataValidationTests
+{
+    [Fact]
+    public void CurrentMetadataMatchesBuiltUsage()
+    {
+        using var fixture = new MetadataFixture();
+
+        Assert.True(fixture.Validate().Valid);
+    }
+
+    [Fact]
+    public void CurrentStateReportsVersionSymbolMemberExposurePathReviewAndCapabilityErrors()
+    {
+        AssertFinding(fixture => fixture.Manifest.DeclaredVersion = "1.0.0", MetadataValidator.UsageStaleRule, "does not match Directory.Packages.props");
+        AssertFinding(fixture => fixture.Manifest.Usages[0].UpstreamSymbol = "Microsoft.Teams.Apps.Schema.Other", MetadataValidator.UsageStaleRule, "does not reference");
+        AssertFinding(fixture => fixture.Manifest.Usages[0].Members = ["Other"], MetadataValidator.UsageStaleRule, "member usage is missing");
+        AssertFinding(fixture => fixture.Manifest.Usages[0].Exposure = "publicly-exposed", MetadataValidator.UsageStaleRule, "exposure in the built extension");
+        AssertFinding(fixture => fixture.Manifest.Usages[0].Files = ["../outside.cs"], MetadataValidator.UsageStaleRule, "missing or unsafe source file");
+        AssertFinding(fixture => fixture.Manifest.SourceReview = new SourceReview { Outcome = MetadataValidator.UsageReviewOutcome, Reason = "" }, MetadataValidator.UsageStaleRule, "non-empty reason");
+        AssertFinding(fixture => fixture.Capabilities.Capabilities["schema"].UpstreamNamespaces = ["Microsoft.Teams.Apps.Other"], MetadataValidator.CapabilitiesStaleRule, "No capability maps");
+    }
+
+    [Fact]
+    public void SourceReviewCannotSuppressProvableMismatch()
+    {
+        using var fixture = new MetadataFixture();
+        fixture.Manifest.DeclaredVersion = "1.0.0";
+        fixture.Manifest.SourceReview = UsageReview("The dependency version is intentionally unchanged.");
+
+        var result = fixture.Validate();
+
+        Assert.Contains(result.Findings, finding => finding.RuleId == MetadataValidator.UsageStaleRule && finding.Message.Contains("does not match", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void RelevantWorkingSourceChangeRequiresUsageReview()
+    {
+        using var fixture = new MetadataFixture(git: true);
+        fixture.AppendSource("// implementation change");
+
+        var result = fixture.Validate(fixture.BaseCommit);
+
+        Assert.Contains(result.Findings, finding => finding.RuleId == MetadataValidator.UsageReviewRule);
+    }
+
+    [Fact]
+    public void SubstantiveUsageUpdateOrFreshAcknowledgmentSatisfiesSourceReview()
+    {
+        using var substantive = new MetadataFixture(git: true);
+        substantive.AppendSource("// implementation change");
+        substantive.Manifest.Usages[0].UsageKinds.Add("updated-routing");
+        substantive.WriteManifest();
+        Assert.DoesNotContain(substantive.Validate(substantive.BaseCommit).Findings, finding => finding.RuleId == MetadataValidator.UsageReviewRule);
+
+        using var acknowledged = new MetadataFixture(git: true);
+        acknowledged.AppendSource("// implementation change");
+        acknowledged.Manifest.SourceReview = UsageReview("Only routing implementation details changed.");
+        acknowledged.WriteManifest();
+        Assert.DoesNotContain(acknowledged.Validate(acknowledged.BaseCommit).Findings, finding => finding.RuleId == MetadataValidator.UsageReviewRule);
+    }
+
+    [Fact]
+    public void BlankUnchangedAndWrongDocumentReviewsDoNotSatisfyUsageReview()
+    {
+        using var blank = new MetadataFixture(git: true);
+        blank.AppendSource("// implementation change");
+        blank.Manifest.SourceReview = UsageReview("");
+        blank.WriteManifest();
+        Assert.Contains(blank.Validate(blank.BaseCommit).Findings, finding => finding.RuleId == MetadataValidator.UsageReviewRule);
+
+        using var unchanged = new MetadataFixture();
+        unchanged.Manifest.SourceReview = UsageReview("Reviewed before this change.");
+        unchanged.WriteManifest();
+        unchanged.InitializeGit();
+        unchanged.AppendSource("// implementation change");
+        Assert.Contains(unchanged.Validate(unchanged.BaseCommit).Findings, finding => finding.RuleId == MetadataValidator.UsageReviewRule);
+
+        using var wrongDocument = new MetadataFixture(git: true);
+        wrongDocument.AppendSource("// implementation change");
+        wrongDocument.Capabilities.SourceReview = CapabilityReview("Usage metadata is unaffected.");
+        wrongDocument.WriteCapabilities();
+        Assert.Contains(wrongDocument.Validate(wrongDocument.BaseCommit).Findings, finding => finding.RuleId == MetadataValidator.UsageReviewRule);
+    }
+
+    [Theory]
+    [InlineData("staged")]
+    [InlineData("unstaged")]
+    [InlineData("untracked")]
+    [InlineData("deleted")]
+    [InlineData("committed")]
+    public void GitChangeCollectionIncludesAllRelevantStates(string state)
+    {
+        using var fixture = new MetadataFixture(git: true);
+        switch (state)
+        {
+            case "staged":
+                fixture.AppendSource("// staged");
+                fixture.Git("add", fixture.SourceRelativePath);
+                break;
+            case "unstaged":
+                fixture.AppendSource("// unstaged");
+                break;
+            case "untracked":
+                fixture.WriteSource("NewUsage.cs", "public class NewUsage { Microsoft.Teams.Apps.Schema.Used? Value { get; set; } }");
+                break;
+            case "deleted":
+                File.Delete(fixture.SourcePath);
+                break;
+            case "committed":
+                fixture.AppendSource("// committed");
+                fixture.Commit("change source");
+                break;
+        }
+
+        Assert.Contains(fixture.Validate(fixture.BaseCommit).Findings, finding => finding.RuleId == MetadataValidator.UsageReviewRule);
+    }
+
+    [Fact]
+    public void AcknowledgmentMustBeAtLeastAsRecentAsSourceChange()
+    {
+        using var fresh = new MetadataFixture(git: true);
+        fresh.AppendSource("// source first");
+        fresh.Commit("change source");
+        fresh.Manifest.SourceReview = UsageReview("No usage metadata changed.");
+        fresh.WriteManifest();
+        fresh.Commit("review usage metadata");
+        Assert.DoesNotContain(fresh.Validate(fresh.BaseCommit).Findings, finding => finding.RuleId == MetadataValidator.UsageReviewRule);
+
+        using var stale = new MetadataFixture(git: true);
+        stale.Manifest.SourceReview = UsageReview("No usage metadata changed.");
+        stale.WriteManifest();
+        stale.Commit("review usage metadata");
+        stale.AppendSource("// source after review");
+        stale.Commit("change source");
+        Assert.Contains(stale.Validate(stale.BaseCommit).Findings, finding => finding.RuleId == MetadataValidator.UsageReviewRule);
+    }
+
+    [Fact]
+    public void ChangedUsageSymbolsRequireTargetedCapabilityUpdateOrReview()
+    {
+        using var reviewed = new MetadataFixture(git: true);
+        reviewed.ChangeSymbol("Microsoft.Teams.Apps.Schema.Other");
+        reviewed.Capabilities.SourceReview = CapabilityReview("The existing schema capability still owns this symbol.");
+        reviewed.WriteCapabilities();
+        var reviewedResult = reviewed.Validate(reviewed.BaseCommit);
+        Assert.DoesNotContain(reviewedResult.Findings, finding => finding.RuleId == MetadataValidator.CapabilitiesReviewRule);
+
+        using var targeted = new MetadataFixture(git: true);
+        targeted.ChangeSymbol("Microsoft.Teams.Apps.NewArea.Other");
+        targeted.Capabilities.Capabilities["schema"].UpstreamNamespaces = ["Microsoft.Teams.Apps.NewArea"];
+        targeted.WriteCapabilities();
+        var targetedResult = targeted.Validate(targeted.BaseCommit);
+        Assert.DoesNotContain(targetedResult.Findings, finding => finding.RuleId == MetadataValidator.CapabilitiesReviewRule);
+
+        using var missing = new MetadataFixture(git: true);
+        missing.ChangeSymbol("Microsoft.Teams.Apps.Schema.Other");
+        Assert.Contains(missing.Validate(missing.BaseCommit).Findings, finding => finding.RuleId == MetadataValidator.CapabilitiesReviewRule);
+    }
+
+    [Fact]
+    public void ExplicitInvalidBaseRefIsAConfigurationError()
+    {
+        using var fixture = new MetadataFixture(git: true);
+
+        var error = Assert.Throws<InvalidOperationException>(() => fixture.Validate("missing-base-ref"));
+
+        Assert.Contains("Unable to resolve Git base ref", error.Message, StringComparison.Ordinal);
+    }
+
+    private static void AssertFinding(Action<MetadataFixture> mutate, string rule, string message)
+    {
+        using var fixture = new MetadataFixture();
+        mutate(fixture);
+        var result = fixture.Validate();
+        Assert.Contains(result.Findings, finding => finding.RuleId == rule && finding.Message.Contains(message, StringComparison.Ordinal));
+    }
+
+    private static SourceReview UsageReview(string reason) => new() { Outcome = MetadataValidator.UsageReviewOutcome, Reason = reason };
+    private static SourceReview CapabilityReview(string reason) => new() { Outcome = MetadataValidator.CapabilitiesReviewOutcome, Reason = reason };
+
+    private sealed class MetadataFixture : IDisposable
+    {
+        private const string Symbol = "Microsoft.Teams.Apps.Schema.Used";
+        private readonly string _manifestPath;
+        private readonly string _capabilitiesPath;
+
+        public MetadataFixture(bool git = false)
+        {
+            Root = Path.Combine(Path.GetTempPath(), $"teams-metadata-{Guid.NewGuid():N}");
+            SourceRelativePath = Paths.Normalize(Path.Combine(PackageConstants.SourceRoot, "TeamsUsage.cs"));
+            SourcePath = Path.Combine(Root, SourceRelativePath);
+            _manifestPath = Path.Combine(Root, "scripts", "TeamsApiDrift", "teams-api-usage.json");
+            _capabilitiesPath = Path.Combine(Root, "scripts", "TeamsApiDrift", "teams-capabilities.json");
+            Directory.CreateDirectory(Path.GetDirectoryName(SourcePath)!);
+            File.WriteAllText(SourcePath, $"public class TeamsUsage {{ {Symbol}? Value {{ get; set; }} }}{Environment.NewLine}");
+            Manifest = new UsageManifest
+            {
+                DeclaredVersion = "2.1.0",
+                Usages =
+                [
+                    new UsageEntry
+                    {
+                        UpstreamSymbol = Symbol,
+                        Members = ["Run"],
+                        UsageKinds = ["routing"],
+                        Exposure = "internal-only",
+                        Files = [SourceRelativePath]
+                    }
+                ]
+            };
+            Capabilities = new CapabilityDocument
+            {
+                Capabilities = new Dictionary<string, Capability>
+                {
+                    ["schema"] = new()
+                    {
+                        Owners = ["agents-sdk-msteams"],
+                        UpstreamNamespaces = ["Microsoft.Teams.Apps.Schema"],
+                        AdoptionPolicy = "review-new-members"
+                    }
+                }
+            };
+            Collected = new CollectedUsage(1, PackageConstants.PackageId, "fixture.dll", [new(Symbol, ["Run"], "internal-only")]);
+            WriteManifest();
+            WriteCapabilities();
+            if (git) InitializeGit();
+        }
+
+        public string Root { get; }
+        public string SourcePath { get; }
+        public string SourceRelativePath { get; }
+        public string BaseCommit { get; private set; } = string.Empty;
+        public UsageManifest Manifest { get; }
+        public CapabilityDocument Capabilities { get; }
+        public CollectedUsage Collected { get; private set; }
+
+        public MetadataValidation Validate(string? baseRef = null)
+            => MetadataValidator.Validate(Manifest, Capabilities, Collected, "2.1.0", Root, _manifestPath, _capabilitiesPath, baseRef);
+
+        public void InitializeGit()
+        {
+            Git("init");
+            Git("config", "user.email", "teams-api-drift@example.com");
+            Git("config", "user.name", "Teams API Drift Tests");
+            Commit("initial metadata");
+            BaseCommit = Git("rev-parse", "HEAD").Trim();
+        }
+
+        public void AppendSource(string text) => File.AppendAllText(SourcePath, text + Environment.NewLine);
+
+        public void WriteSource(string name, string text)
+        {
+            var path = Path.Combine(Root, PackageConstants.SourceRoot, name);
+            File.WriteAllText(path, text + Environment.NewLine);
+        }
+
+        public void ChangeSymbol(string symbol)
+        {
+            File.WriteAllText(SourcePath, $"public class TeamsUsage {{ {symbol}? Value {{ get; set; }} }}{Environment.NewLine}");
+            Manifest.Usages[0].UpstreamSymbol = symbol;
+            Collected = new CollectedUsage(1, PackageConstants.PackageId, "fixture.dll", [new(symbol, ["Run"], "internal-only")]);
+            WriteManifest();
+        }
+
+        public void WriteManifest() => ToolJson.Write(_manifestPath, Manifest);
+        public void WriteCapabilities() => ToolJson.Write(_capabilitiesPath, Capabilities);
+
+        public void Commit(string message)
+        {
+            Git("add", ".");
+            Git("commit", "-m", message);
+        }
+
+        public string Git(params string[] arguments)
+        {
+            var info = new ProcessStartInfo("git")
+            {
+                WorkingDirectory = Root,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+            foreach (var argument in arguments) info.ArgumentList.Add(argument);
+            using var process = Process.Start(info) ?? throw new InvalidOperationException("Unable to start Git.");
+            var output = process.StandardOutput.ReadToEnd();
+            var error = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+            if (process.ExitCode != 0) throw new InvalidOperationException($"git {string.Join(' ', arguments)} failed: {error}");
+            return output;
+        }
+
+        public void Dispose()
+        {
+            foreach (var file in Directory.EnumerateFiles(Root, "*", SearchOption.AllDirectories))
+            {
+                File.SetAttributes(file, FileAttributes.Normal);
+            }
+            Directory.Delete(Root, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
Addresses #984

## Description
This pull request introduces a new repository metadata validation step for Teams API drift detection, enhances the contracts and documentation for source-review acknowledgments, and updates the CI workflow to enforce these checks. The main goal is to ensure that any relevant source changes in MSTeams are properly reflected in the metadata manifests or explicitly reviewed, improving the reliability and auditability of API usage and capability tracking.

**Key changes:**

### Repository Metadata Validation

* Added a new `validate-metadata` command to the drift tool (`Program.cs`) that validates the checked-in usage and capability manifests against the built MSTeams assemblies, the centrally managed dependency version, and the current repository state. This command supports Git-based source-review validation and is now documented and integrated into the CLI. [[1]](diffhunk://#diff-58c3a015cd6e1d3b77b800acd844f0cdca702299347df56d58f8551dade8a030R22) [[2]](diffhunk://#diff-58c3a015cd6e1d3b77b800acd844f0cdca702299347df56d58f8551dade8a030R98-R119) [[3]](diffhunk://#diff-58c3a015cd6e1d3b77b800acd844f0cdca702299347df56d58f8551dade8a030L155-R183) [[4]](diffhunk://#diff-5eef37a2f8dc26e1c62dc82b63cf440f6692d1a9a9a7ecce92549db3f340994dR83-R95)
* Updated the CI workflow (`.github/workflows/ci.yml`) to run the new metadata validation step after building the solution, failing early if the manifests are stale or lack required review. The workflow passes the pull-request base SHA to enable change-detection logic. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR38-R62) [[2]](diffhunk://#diff-5eef37a2f8dc26e1c62dc82b63cf440f6692d1a9a9a7ecce92549db3f340994dR235-R238)

### Source-Review Acknowledgments

* Extended the manifest contracts (`Contracts.cs`) to include an optional `sourceReview` property in both `UsageManifest` and `CapabilityDocument`, and defined a new `SourceReview` class for structured review outcomes and reasons. [[1]](diffhunk://#diff-a284c3a718d3b93d7434fb9b5518e40a647ac7eee0b70bf0c80ef7d31a0fdeefR60) [[2]](diffhunk://#diff-a284c3a718d3b93d7434fb9b5518e40a647ac7eee0b70bf0c80ef7d31a0fdeefR77-R83)
* Updated the documentation (`technicalDescription.md`) to describe when and how to add source-review acknowledgments to metadata files, including requirements for non-empty, document-specific reasons and the distinction between usage and capability reviews.

### Validation Contracts and Utilities

* Added new record types (`MetadataValidation`, `MetadataFinding`) to support detailed reporting of validation findings.
* Refactored utility methods for collecting usage evidence, making them reusable for metadata validation and improving code organization. [[1]](diffhunk://#diff-58c3a015cd6e1d3b77b800acd844f0cdca702299347df56d58f8551dade8a030R67-R73) [[2]](diffhunk://#diff-58c3a015cd6e1d3b77b800acd844f0cdca702299347df56d58f8551dade8a030L76-R84)
* Made `MatchCapability` internal for improved testability and encapsulation.

### Documentation and Test Coverage

* Updated the technical description to document the new validation layer, workflow integration, and test coverage for repository metadata validation. [[1]](diffhunk://#diff-5eef37a2f8dc26e1c62dc82b63cf440f6692d1a9a9a7ecce92549db3f340994dR18-R26) [[2]](diffhunk://#diff-5eef37a2f8dc26e1c62dc82b63cf440f6692d1a9a9a7ecce92549db3f340994dL216-R272)
* Added a new file entry for `MetadataValidation.cs` in the documentation, describing its purpose and integration.

### Miscellaneous

* Improved PDB reading logic to ensure only Portable PDBs are processed during source file extraction.

These changes collectively strengthen the Teams API drift detection process by ensuring that all relevant source changes are accounted for in metadata, with explicit, auditable reviews when no manifest update is needed.

## Testing
These images show the CI workflow failing on stale metadata finding and then passing after updating the metadata files.
<img width="1698" height="1263" alt="image" src="https://github.com/user-attachments/assets/b4631194-77cb-4a9c-bf31-e2d2a03c24c1" />
