### PR TITLE
Add custom Teams feedback sample

### DIFF
--- a/src/samples/Teams/ConversationAgent/CustomFeedback.cs
+++ b/src/samples/Teams/ConversationAgent/CustomFeedback.cs
@@ -9,12 +9,13 @@ using Microsoft.Agents.Core.Serialization;
 using Microsoft.Agents.Extensions.MSTeams;
 using Microsoft.Agents.Extensions.MSTeams.App;
 using Microsoft.Extensions.Logging;
-using Microsoft.Teams.Apps;
 using Microsoft.Teams.Apps.Schema;
 using Microsoft.Teams.Apps.TaskModules;
 using Microsoft.Teams.Cards;
 using System;
+using System.Net;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -35,9 +36,35 @@ public partial class TeamsConversationAgent
     [InvokeRoute("message/fetchTask")]
     public static async Task OnCustomFeedbackFetchAsync(ITurnContext turnContext, ITurnState turnState, CancellationToken cancellationToken)
     {
-        var request = ProtocolJsonSerializer.ToObject<FeedbackData>(turnContext.Activity.Value);
-        var wrappedRequest = ProtocolJsonSerializer.ToObject<MessageFetchTaskInvokeValue>(turnContext.Activity.Value);
-        var reaction = request?.ActionValue?.Reaction ?? wrappedRequest?.Data?.ActionValue?.Reaction;
+        JsonObject? requestValue;
+        try
+        {
+            requestValue = ProtocolJsonSerializer.ToObject<JsonNode>(turnContext.Activity.Value) as JsonObject;
+        }
+        catch (JsonException)
+        {
+            requestValue = null;
+        }
+
+        var rootActionName = requestValue?["actionName"]?.ToString();
+        var wrappedData = requestValue?["data"] as JsonObject;
+        var wrappedActionName = wrappedData?["actionName"]?.ToString();
+        var actionName = rootActionName ?? wrappedActionName;
+        var hasConflictingActionNames = rootActionName is not null
+            && wrappedActionName is not null
+            && !string.Equals(rootActionName, wrappedActionName, StringComparison.Ordinal);
+
+        if (!string.Equals(actionName, "feedback", StringComparison.Ordinal) || hasConflictingActionNames)
+        {
+            await turnContext.SendActivityAsync(
+                Activity.CreateInvokeResponseActivity(status: (int)HttpStatusCode.BadRequest),
+                cancellationToken);
+            return;
+        }
+
+        var rootActionValue = requestValue?["actionValue"] as JsonObject;
+        var wrappedActionValue = wrappedData?["actionValue"] as JsonObject;
+        var reaction = rootActionValue?["reaction"]?.ToString() ?? wrappedActionValue?["reaction"]?.ToString();
 
         var response = TaskModuleResponse.CreateBuilder()
             .WithType(TaskModuleResponseTypes.Continue)

--- a/src/samples/Teams/ConversationAgent/CustomFeedback.cs
+++ b/src/samples/Teams/ConversationAgent/CustomFeedback.cs
@@ -1,0 +1,107 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Agents.Builder;
+using Microsoft.Agents.Builder.App;
+using Microsoft.Agents.Builder.State;
+using Microsoft.Agents.Core.Models;
+using Microsoft.Agents.Core.Serialization;
+using Microsoft.Agents.Extensions.MSTeams;
+using Microsoft.Agents.Extensions.MSTeams.App;
+using Microsoft.Extensions.Logging;
+using Microsoft.Teams.Apps;
+using Microsoft.Teams.Apps.Schema;
+using Microsoft.Teams.Apps.TaskModules;
+using Microsoft.Teams.Cards;
+using System;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ConversationAgent;
+
+public partial class TeamsConversationAgent
+{
+    [TeamsMessageRoute("customfeedback")]
+    public static async Task SendCustomFeedbackMessageAsync(ITeamsTurnContext turnContext, ITurnState turnState, CancellationToken cancellationToken)
+    {
+        var activity = Activity.CreateMessageActivity();
+        activity.Text = "Select thumbs up or thumbs down to open the custom feedback dialog.";
+        activity.TeamsEnableFeedbackLoop("custom");
+
+        await turnContext.SendActivityAsync(activity, cancellationToken);
+    }
+
+    [InvokeRoute("message/fetchTask")]
+    public static async Task OnCustomFeedbackFetchAsync(ITurnContext turnContext, ITurnState turnState, CancellationToken cancellationToken)
+    {
+        var request = ProtocolJsonSerializer.ToObject<FeedbackData>(turnContext.Activity.Value);
+        var wrappedRequest = ProtocolJsonSerializer.ToObject<MessageFetchTaskInvokeValue>(turnContext.Activity.Value);
+        var reaction = request?.ActionValue?.Reaction ?? wrappedRequest?.Data?.ActionValue?.Reaction;
+
+        var response = TaskModuleResponse.CreateBuilder()
+            .WithType(TaskModuleResponseTypes.Continue)
+            .WithTitle("Feedback")
+            .WithHeight(TaskModuleSizes.Small)
+            .WithWidth(TaskModuleSizes.Small)
+            .WithCard(CreateFeedbackCard(reaction))
+            .Build()
+            .Body
+            ?? throw new InvalidOperationException("The feedback dialog builder returned no body.");
+
+        await turnContext.SendActivityAsync(Activity.CreateInvokeResponseActivity(response), cancellationToken);
+    }
+
+    [TeamsFeedbackLoopRoute]
+    public Task OnCustomFeedbackSubmitAsync(ITeamsTurnContext turnContext, ITurnState turnState, FeedbackData feedbackData, CancellationToken cancellationToken)
+    {
+        var feedbackText = ReadFeedbackText(feedbackData.ActionValue?.Feedback);
+        _logger.LogInformation(
+            "Feedback received for activity {ReplyToId}: reaction={Reaction}, feedbackLength={FeedbackLength}",
+            feedbackData.ReplyToId,
+            feedbackData.ActionValue?.Reaction,
+            feedbackText?.Length ?? 0);
+
+        return Task.CompletedTask;
+    }
+
+    private static TeamsAttachment CreateFeedbackCard(string? reaction)
+    {
+        var prompt = reaction is null
+            ? "Tell us more about your experience."
+            : $"You selected {reaction}. Tell us more about your experience.";
+
+        var card = new AdaptiveCard([
+            new TextBlock(prompt).WithWrap(true),
+            new TextInput()
+                .WithId("feedbackText")
+                .WithPlaceholder("Enter your feedback here...")
+                .WithIsMultiline(true)
+        ]).WithActions(new SubmitAction().WithTitle("Submit"));
+
+        return TeamsAttachment.CreateBuilder()
+            .WithAdaptiveCard(card)
+            .Build();
+    }
+
+    private static string? ReadFeedbackText(string? feedback)
+    {
+        if (string.IsNullOrWhiteSpace(feedback))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(feedback);
+            return document.RootElement.ValueKind == JsonValueKind.Object
+                && document.RootElement.TryGetProperty("feedbackText", out var value)
+                ? value.ToString()
+                : feedback;
+        }
+        catch (JsonException)
+        {
+            return feedback;
+        }
+    }
+}

--- a/src/samples/Teams/ConversationAgent/README.md
+++ b/src/samples/Teams/ConversationAgent/README.md
@@ -86,6 +86,17 @@ You can interact with this bot in Teams by sending it a message, or selecting a 
    - **Result:** The bot sends a targeted response containing Prompt Preview metadata for the incoming targeted slash command.
    - **Valid Scopes:** group chat, team chat
    - **Usage:** Select `promptpreview` from the Teams slash-command picker. This requires the dev-preview manifest included with the sample.
+6. **CustomFeedback**
+   - **Result:** The agent sends a response with thumbs-up and thumbs-down buttons. Selecting either button opens a custom feedback dialog.
+   - **Valid Scopes:** personal, group chat, team chat
+
+### Custom feedback flow
+
+The `customfeedback` response calls `TeamsEnableFeedbackLoop("custom")`, which sets `channelData.feedbackLoop.type` to `custom`. This tells Teams to request a custom dialog instead of showing the default feedback form.
+
+When the user selects thumbs up or thumbs down, Teams sends a `message/fetchTask` invoke activity. `OnCustomFeedbackFetchAsync` responds with a small dialog containing an Adaptive Card text input. When the user submits the dialog, Teams sends a `message/submitAction` invoke with `actionName` set to `feedback`. The `[TeamsFeedbackLoopRoute]` handler receives the reaction and the form data. This sample logs the reaction and whether additional feedback was entered, without logging the feedback text; a production application should validate and persist the feedback in its own data store.
+
+Teams does not store custom feedback for the application. For protocol details, see [Bot messages with AI-generated content](https://learn.microsoft.com/microsoftteams/platform/bots/how-to/bot-messages-ai-generated-content#feedback-buttons).
 
 You can select an option from the command list by typing ```@TeamsConversationBot``` into the compose message area and ```What can I do?``` text above the compose area.
 

--- a/src/samples/Teams/ConversationAgent/TeamsConversationAgent.cs
+++ b/src/samples/Teams/ConversationAgent/TeamsConversationAgent.cs
@@ -12,6 +12,7 @@ using Microsoft.Agents.Extensions.MSTeams;
 using Microsoft.Agents.Extensions.MSTeams.App;
 using Microsoft.Agents.Extensions.MSTeams.Channels;
 using Microsoft.Agents.Extensions.MSTeams.Teams;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -21,8 +22,10 @@ using System.Linq;
 namespace ConversationAgent;
 
 [TeamsExtension]
-public partial class TeamsConversationAgent(AgentApplicationOptions options) : AgentApplication(options)
+public partial class TeamsConversationAgent(AgentApplicationOptions options, ILogger<TeamsConversationAgent> logger) : AgentApplication(options)
 {
+    private readonly ILogger<TeamsConversationAgent> _logger = logger;
+
     [TeamsActivityRoute(ActivityTypes.InstallationUpdate)]
     public async Task OnInstallationUpdateActivityAsync(ITeamsTurnContext turnContext, ITurnState turnState, CancellationToken cancellationToken)
     {
@@ -104,7 +107,8 @@ public partial class TeamsConversationAgent(AgentApplicationOptions options) : A
             new CardAction(type: ActionTypes.MessageBack, title: "Mention Me", text: "mentionme"),
             new CardAction(type: ActionTypes.MessageBack, title: "Delete Card", text: "delete"),
             new CardAction(type: ActionTypes.MessageBack, title: "Send Targeted", text: "targeted"),
-            new CardAction(type: ActionTypes.MessageBack, title: "Quoted Reply", text: "quotedreply")
+            new CardAction(type: ActionTypes.MessageBack, title: "Quoted Reply", text: "quotedreply"),
+            new CardAction(type: ActionTypes.MessageBack, title: "Custom Feedback", text: "customfeedback")
         ]
     };
 

--- a/src/samples/Teams/ConversationAgent/TeamsConversationAgent.cs
+++ b/src/samples/Teams/ConversationAgent/TeamsConversationAgent.cs
@@ -24,7 +24,7 @@ namespace ConversationAgent;
 [TeamsExtension]
 public partial class TeamsConversationAgent(AgentApplicationOptions options, ILogger<TeamsConversationAgent> logger) : AgentApplication(options)
 {
-    private readonly ILogger<TeamsConversationAgent> _logger = logger;
+    private readonly ILogger<TeamsConversationAgent> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
     [TeamsActivityRoute(ActivityTypes.InstallationUpdate)]
     public async Task OnInstallationUpdateActivityAsync(ITeamsTurnContext turnContext, ITurnState turnState, CancellationToken cancellationToken)

--- a/src/samples/Teams/ConversationAgent/appManifest/manifest.json
+++ b/src/samples/Teams/ConversationAgent/appManifest/manifest.json
@@ -61,6 +61,10 @@
             {
               "title": "quotedreply",
               "description": "Reply with a quote of the incoming message"
+            },
+            {
+              "title": "customfeedback",
+              "description": "Open a custom feedback dialog from response feedback buttons"
             }
           ]
         },


### PR DESCRIPTION
## Summary

- add a customfeedback command to the Teams ConversationAgent sample
- enable the custom Teams feedback loop and return an Adaptive Card task-module dialog
- handle feedback submissions without logging user-entered feedback text
- document the custom feedback flow and expose the command in the Teams manifest

The fetch handler accepts both the documented root-level feedback payload and the wrapped payload represented by the current Teams SDK model.

## Validation

- dotnet build src/samples/Teams/ConversationAgent/ConversationAgent.csproj (0 warnings, 0 errors)
- dotnet test src/tests/Microsoft.Agents.Extensions.MSTeams.Tests/Microsoft.Agents.Extensions.MSTeams.Tests.csproj (318 tests passed on .NET 8 and 318 on .NET 10)
- manifest JSON parsing
- git diff --check

A live Teams client end-to-end run was not performed.

Fixes #969