### PR TITLE
Add Agent Card HTTP caching metadata

### DIFF
--- a/src/libraries/Extensions/Microsoft.Agents.Extensions.A2A/A2AAdapter.cs
+++ b/src/libraries/Extensions/Microsoft.Agents.Extensions.A2A/A2AAdapter.cs
@@ -12,13 +12,16 @@ using Microsoft.Agents.Core.Validation;
 using Microsoft.Agents.Hosting.AspNetCore;
 using Microsoft.Agents.Storage;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using System.Security.Claims;
+using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -44,19 +47,45 @@ public class A2AAdapter : ChannelAdapter, IA2AHttpAdapter
     private static readonly string _assemblyVersion = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "1.0.0";
     private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger<A2AServer> _a2aServerLogger;
+    private readonly string _agentCardLastModified = DateTimeOffset.UtcNow.ToString("R", CultureInfo.InvariantCulture);
+    private readonly string _agentCardCacheControl;
 
-    public A2AAdapter(IStorage storage, ILoggerFactory loggerFactory, ChannelEventNotifier a2aNotifier = null) : this(new InMemoryTaskStore(), loggerFactory, a2aNotifier)
+    public A2AAdapter(
+        IStorage storage,
+        ILoggerFactory loggerFactory,
+        ChannelEventNotifier a2aNotifier = null,
+        A2AAdapterOptions options = null,
+        IConfiguration configuration = null)
+        : this(new InMemoryTaskStore(), loggerFactory, a2aNotifier, options, configuration)
     {
     }
 
-    public A2AAdapter(ITaskStore taskStore, ILoggerFactory loggerFactory, ChannelEventNotifier a2aNotifier = null) : base(loggerFactory.CreateLogger<A2AAdapter>())
+    public A2AAdapter(
+        ITaskStore taskStore,
+        ILoggerFactory loggerFactory,
+        ChannelEventNotifier a2aNotifier = null,
+        A2AAdapterOptions options = null,
+        IConfiguration configuration = null)
+        : base(loggerFactory.CreateLogger<A2AAdapter>())
     {
         AssertionHelpers.ThrowIfNull(taskStore, nameof(taskStore));
+
+        var adapterOptions = options
+            ?? configuration?.GetSection(nameof(A2AAdapterOptions)).Get<A2AAdapterOptions>()
+            ?? new A2AAdapterOptions();
+        if (adapterOptions.AgentCardCacheMaxAge < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(options),
+                adapterOptions.AgentCardCacheMaxAge,
+                "Agent Card cache max-age cannot be negative.");
+        }
 
         _loggerFactory = loggerFactory;
         _taskStore = taskStore;
         _a2aNotifier = a2aNotifier ?? new ChannelEventNotifier();
         _a2aServerLogger = loggerFactory.CreateLogger<A2AServer>();
+        _agentCardCacheControl = $"public, max-age={(long)Math.Ceiling(adapterOptions.AgentCardCacheMaxAge.TotalSeconds)}";
 
         OnTurnError = (turnContext, exception) =>
         {
@@ -186,8 +215,13 @@ public class A2AAdapter : ChannelAdapter, IA2AHttpAdapter
             Logger.LogDebug("AgentCard: {AgentCard}", json);
         }
 
+        var jsonBytes = Encoding.UTF8.GetBytes(json);
+
         httpResponse.ContentType = "application/json";
-        await httpResponse.Body.WriteAsync(Encoding.UTF8.GetBytes(json), cancellationToken).ConfigureAwait(false);
+        httpResponse.Headers.CacheControl = _agentCardCacheControl;
+        httpResponse.Headers.ETag = $"\"{Convert.ToHexString(SHA256.HashData(jsonBytes))}\"";
+        httpResponse.Headers.LastModified = _agentCardLastModified;
+        await httpResponse.Body.WriteAsync(jsonBytes, cancellationToken).ConfigureAwait(false);
         await httpResponse.Body.FlushAsync(cancellationToken).ConfigureAwait(false);
     }
 

--- a/src/libraries/Extensions/Microsoft.Agents.Extensions.A2A/A2AAdapter.cs
+++ b/src/libraries/Extensions/Microsoft.Agents.Extensions.A2A/A2AAdapter.cs
@@ -76,7 +76,7 @@ public class A2AAdapter : ChannelAdapter, IA2AHttpAdapter
         if (adapterOptions.AgentCardCacheMaxAge < TimeSpan.Zero)
         {
             throw new ArgumentOutOfRangeException(
-                nameof(A2AAdapterOptions.AgentCardCacheMaxAge),
+                nameof(options),
                 adapterOptions.AgentCardCacheMaxAge,
                 "Agent Card cache max-age cannot be negative.");
         }

--- a/src/libraries/Extensions/Microsoft.Agents.Extensions.A2A/A2AAdapter.cs
+++ b/src/libraries/Extensions/Microsoft.Agents.Extensions.A2A/A2AAdapter.cs
@@ -76,7 +76,7 @@ public class A2AAdapter : ChannelAdapter, IA2AHttpAdapter
         if (adapterOptions.AgentCardCacheMaxAge < TimeSpan.Zero)
         {
             throw new ArgumentOutOfRangeException(
-                nameof(options),
+                nameof(A2AAdapterOptions.AgentCardCacheMaxAge),
                 adapterOptions.AgentCardCacheMaxAge,
                 "Agent Card cache max-age cannot be negative.");
         }

--- a/src/libraries/Extensions/Microsoft.Agents.Extensions.A2A/A2AAdapterOptions.cs
+++ b/src/libraries/Extensions/Microsoft.Agents.Extensions.A2A/A2AAdapterOptions.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Microsoft.Agents.Extensions.A2A;
+
+/// <summary>
+/// Configuration options for <see cref="A2AAdapter"/> runtime behavior.
+/// </summary>
+public sealed class A2AAdapterOptions
+{
+    /// <summary>
+    /// Gets or sets how long clients and shared caches may reuse the Agent Card.
+    /// </summary>
+    public TimeSpan AgentCardCacheMaxAge { get; set; } = TimeSpan.FromHours(1);
+}

--- a/src/tests/Microsoft.Agents.Extensions.A2A.Tests/A2AAdapterTests.cs
+++ b/src/tests/Microsoft.Agents.Extensions.A2A.Tests/A2AAdapterTests.cs
@@ -9,11 +9,15 @@ using Microsoft.Agents.Core.Models;
 using Microsoft.Agents.Core.Serialization;
 using Microsoft.Agents.Storage;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using System;
+using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
@@ -87,6 +91,115 @@ public class A2AAdapterTests
         var agentCard = await JsonSerializer.DeserializeAsync<AgentCard>(
             mockHttpResponse.Object.Body, A2AJsonUtilities.DefaultOptions);
         Assert.False(agentCard!.Capabilities.ExtendedAgentCard);
+    }
+
+    [Fact]
+    public async Task ProcessAgentCardAsync_ShouldIncludeCacheControlMaxAge()
+    {
+        // Arrange
+        var adapter = new A2AAdapter(_mockTaskStore.Object, _mockLogger);
+        var mockHttpRequest = CreateMockHttpRequest("https", "localhost:3978");
+        var mockHttpResponse = CreateMockHttpResponse();
+        var mockAgent = new Mock<IAgent>();
+
+        // Act
+        await adapter.ProcessAgentCardAsync(mockHttpRequest.Object, mockHttpResponse.Object, mockAgent.Object, "/a2a", CancellationToken.None);
+
+        // Assert
+        Assert.Equal("public, max-age=3600", mockHttpResponse.Object.Headers.CacheControl);
+    }
+
+    [Fact]
+    public async Task ProcessAgentCardAsync_WithOptions_ShouldUseConfiguredCacheMaxAge()
+    {
+        // Arrange
+        var adapter = new A2AAdapter(
+            _mockTaskStore.Object,
+            _mockLogger,
+            options: new A2AAdapterOptions { AgentCardCacheMaxAge = TimeSpan.FromMinutes(15) });
+        var mockHttpRequest = CreateMockHttpRequest("https", "localhost:3978");
+        var mockHttpResponse = CreateMockHttpResponse();
+
+        // Act
+        await adapter.ProcessAgentCardAsync(mockHttpRequest.Object, mockHttpResponse.Object, new Mock<IAgent>().Object, "/a2a", CancellationToken.None);
+
+        // Assert
+        Assert.Equal("public, max-age=900", mockHttpResponse.Object.Headers.CacheControl);
+    }
+
+    [Fact]
+    public async Task ProcessAgentCardAsync_WithConfiguration_ShouldUseConfiguredCacheMaxAge()
+    {
+        // Arrange
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["A2AAdapterOptions:AgentCardCacheMaxAge"] = "00:10:00",
+            })
+            .Build();
+        var adapter = new A2AAdapter(_mockTaskStore.Object, _mockLogger, configuration: configuration);
+        var mockHttpRequest = CreateMockHttpRequest("https", "localhost:3978");
+        var mockHttpResponse = CreateMockHttpResponse();
+
+        // Act
+        await adapter.ProcessAgentCardAsync(mockHttpRequest.Object, mockHttpResponse.Object, new Mock<IAgent>().Object, "/a2a", CancellationToken.None);
+
+        // Assert
+        Assert.Equal("public, max-age=600", mockHttpResponse.Object.Headers.CacheControl);
+    }
+
+    [Fact]
+    public void Constructor_WithNegativeAgentCardCacheMaxAge_ShouldThrow()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new A2AAdapter(
+            _mockTaskStore.Object,
+            _mockLogger,
+            options: new A2AAdapterOptions { AgentCardCacheMaxAge = TimeSpan.FromSeconds(-1) }));
+    }
+
+    [Fact]
+    public async Task ProcessAgentCardAsync_ShouldIncludeBodyDerivedETag()
+    {
+        // Arrange
+        var adapter = new A2AAdapter(_mockTaskStore.Object, _mockLogger);
+        var mockHttpRequest = CreateMockHttpRequest("https", "localhost:3978");
+        var defaultResponse = CreateMockHttpResponse();
+        var attributedResponse = CreateMockHttpResponse();
+
+        // Act
+        await adapter.ProcessAgentCardAsync(mockHttpRequest.Object, defaultResponse.Object, new Mock<IAgent>().Object, "/a2a", CancellationToken.None);
+        await adapter.ProcessAgentCardAsync(mockHttpRequest.Object, attributedResponse.Object, new TestAgentWithAttributes(), "/a2a", CancellationToken.None);
+
+        // Assert
+        Assert.False(string.IsNullOrEmpty(defaultResponse.Object.Headers.ETag));
+        Assert.NotEqual(defaultResponse.Object.Headers.ETag, attributedResponse.Object.Headers.ETag);
+        Assert.Equal(
+            $"\"{Convert.ToHexString(SHA256.HashData(((MemoryStream)defaultResponse.Object.Body).ToArray()))}\"",
+            defaultResponse.Object.Headers.ETag);
+    }
+
+    [Fact]
+    public async Task ProcessAgentCardAsync_ShouldIncludeStableLastModified()
+    {
+        // Arrange
+        var adapter = new A2AAdapter(_mockTaskStore.Object, _mockLogger);
+        var mockHttpRequest = CreateMockHttpRequest("https", "localhost:3978");
+        var firstResponse = CreateMockHttpResponse();
+        var secondResponse = CreateMockHttpResponse();
+        var mockAgent = new Mock<IAgent>();
+
+        // Act
+        await adapter.ProcessAgentCardAsync(mockHttpRequest.Object, firstResponse.Object, mockAgent.Object, "/a2a", CancellationToken.None);
+        await adapter.ProcessAgentCardAsync(mockHttpRequest.Object, secondResponse.Object, mockAgent.Object, "/a2a", CancellationToken.None);
+
+        // Assert
+        Assert.Equal(firstResponse.Object.Headers.LastModified, secondResponse.Object.Headers.LastModified);
+        Assert.True(DateTimeOffset.TryParseExact(
+            firstResponse.Object.Headers.LastModified,
+            "R",
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal,
+            out _));
     }
 
     [Fact]
@@ -298,6 +411,7 @@ public class A2AAdapterTests
         var mockResponse = new Mock<HttpResponse>();
         var memoryStream = new MemoryStream();
         mockResponse.SetupProperty(r => r.ContentType);
+        mockResponse.Setup(r => r.Headers).Returns(new HeaderDictionary());
         mockResponse.Setup(r => r.Body).Returns(memoryStream);
         return mockResponse;
     }

--- a/src/tests/Microsoft.Agents.Extensions.A2A.Tests/A2AAdapterTests.cs
+++ b/src/tests/Microsoft.Agents.Extensions.A2A.Tests/A2AAdapterTests.cs
@@ -151,10 +151,12 @@ public class A2AAdapterTests
     [Fact]
     public void Constructor_WithNegativeAgentCardCacheMaxAge_ShouldThrow()
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() => new A2AAdapter(
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => new A2AAdapter(
             _mockTaskStore.Object,
             _mockLogger,
             options: new A2AAdapterOptions { AgentCardCacheMaxAge = TimeSpan.FromSeconds(-1) }));
+
+        Assert.Equal("options", exception.ParamName);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- add configurable Agent Card cache duration through `A2AAdapterOptions`
- emit `Cache-Control`, content-derived `ETag`, and stable `Last-Modified` headers
- serialize once so the ETag is calculated from the exact response bytes
- cover default, configured, and explicitly supplied cache durations

## TCK failures

`tests/compatibility/agent_card/test_agent_card_caching.py::TestAgentCardCacheControl::test_cache_control_present`

```text
CARD-CACHE-001 [Agent Card endpoint includes Cache-Control header]: Agent Card response should include a Cache-Control header
```

`tests/compatibility/agent_card/test_agent_card_caching.py::TestAgentCardCacheControl::test_cache_control_has_max_age`

```text
CARD-CACHE-001 [Agent Card endpoint includes Cache-Control header]: Cache-Control should include max-age directive
```

`tests/compatibility/agent_card/test_agent_card_caching.py::TestAgentCardETag::test_etag_present`

```text
CARD-CACHE-002 [Agent Card endpoint includes ETag header]: Agent Card response should include an ETag header
```

`tests/compatibility/agent_card/test_agent_card_caching.py::TestAgentCardLastModified::test_last_modified_present`

```text
CARD-CACHE-003 [Agent Card endpoint may include Last-Modified header]: Agent Card response may include a Last-Modified header
```

The Agents SDK serves Agent Cards through its own adapter response path, so these headers must be applied independently of the a2a-dotnet ASP.NET Core endpoint implementation.

## Tests

- `dotnet test src\tests\Microsoft.Agents.Extensions.A2A.Tests\Microsoft.Agents.Extensions.A2A.Tests.csproj --no-restore --nologo` (108 passed)